### PR TITLE
This completes the Windows NT Server port of the LokiNetwork components.

### DIFF
--- a/llarp/ev.hpp
+++ b/llarp/ev.hpp
@@ -23,6 +23,7 @@ namespace llarp
 
     virtual int
     sendto(const sockaddr* dst, const void* data, size_t sz) = 0;
+
     virtual ~ev_io()
     {
 #ifndef _WIN32

--- a/llarp/ev_epoll.hpp
+++ b/llarp/ev_epoll.hpp
@@ -145,7 +145,7 @@ struct llarp_epoll_loop : public llarp_ev_loop
     byte_t readbuf[2048];
     do
     {
-      result = epoll_wait(epollfd, events, 1024, 100);
+      result = epoll_wait(epollfd, events, 1024, 10);
       if(result > 0)
       {
         int idx = 0;

--- a/llarp/router.cpp
+++ b/llarp/router.cpp
@@ -239,11 +239,11 @@ llarp_router::SaveRC()
     if(f.is_open())
     {
       f.write((char *)buf.base, buf.cur - buf.base);
-      llarp::LogInfo("our RC saved to ", our_rc_file.c_str());
+      llarp::LogInfo("our RC saved to ", our_rc_file.string().c_str());
       return true;
     }
   }
-  llarp::LogError("did not save RC to ", our_rc_file.c_str());
+  llarp::LogError("did not save RC to ", our_rc_file.string().c_str());
   return false;
 }
 

--- a/llarp/win32_intrnl.c
+++ b/llarp/win32_intrnl.c
@@ -8,6 +8,12 @@
 #include <assert.h>
 #include <stdio.h>
 
+// apparently mingw-w64 loses its shit over this
+// but only for 32-bit builds, naturally
+#ifdef WIN32_LEAN_AND_MEAN
+#undef WIN32_LEAN_AND_MEAN
+#endif
+
 #include <windows.h>
 #include <winternl.h>
 #include <tdi.h>


### PR DESCRIPTION
Also changed the epoll_wait timeout to 10ms in llarp_epoll_loop::run() to match the other platforms.
***it's finally here***
~~but Bencode is seriously broken on Windows~~

-despair86