### PR TITLE
tun+ip: lots of NAT and checksum (re)calculation improvements

### DIFF
--- a/include/llarp/ip.hpp
+++ b/include/llarp/ip.hpp
@@ -153,9 +153,13 @@ namespace llarp
         Header()->daddr = htonl(ip);
       }
 
-      // update ip packet checksum
+      // update ip packet checksum (after packet gets out of network)
       void
-      UpdateChecksum();
+      UpdateChecksumsOnDst();
+
+      // update ip packet checksum (before packet gets inserted into network)
+      void
+      UpdateChecksumsOnSrc();
     };
 
   }  // namespace net

--- a/include/llarp/logger.hpp
+++ b/include/llarp/logger.hpp
@@ -82,14 +82,14 @@ namespace llarp
   struct log_timestamp
   {
     std::string format = "%c %Z";
-    friend
-    std::ostream & operator << (std::ostream & out, const log_timestamp & ts)
+    friend std::ostream&
+    operator<<(std::ostream& out, const log_timestamp& ts)
     {
       auto now = llarp::Clock_t::to_time_t(llarp::Clock_t::now());
       return out << std::put_time(std::localtime(&now), ts.format.c_str());
     }
   };
-  
+
   /** internal */
   template < typename... TArgs >
   void

--- a/include/llarp/path.hpp
+++ b/include/llarp/path.hpp
@@ -410,8 +410,8 @@ namespace llarp
       GetByUpstream(const RouterID& id, const PathID_t& path);
 
       IHopHandler*
-      GetPathForTransfer(const PathID_t & topath);
-      
+      GetPathForTransfer(const PathID_t& topath);
+
       IHopHandler*
       GetByDownstream(const RouterID& id, const PathID_t& path);
 

--- a/include/llarp/time.hpp
+++ b/include/llarp/time.hpp
@@ -8,5 +8,4 @@ namespace llarp
   typedef std::chrono::system_clock Clock_t;
 }
 
-
 #endif

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -441,7 +441,7 @@ namespace llarp
       TunEndpoint *self = static_cast< TunEndpoint * >(tun->user);
       self->m_NetworkToUserPktQueue.Process([self, tun](net::IPv4Packet &pkt) {
         // prepare packet for insertion into network
-        pkg.UpdateChecksumsOnSrc();
+        pkt.UpdateChecksumsOnSrc();
         // clear addresses
         pkt.src(0);
         pkt.dst(0);

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -329,7 +329,7 @@ namespace llarp
                memcpy(pkt.buf, buf.base, pkt.sz);
                pkt.src(themIP);
                pkt.dst(usIP);
-               pkt.UpdateChecksum();
+               pkt.UpdateChecksumsOnDst();
                return true;
              }))
 
@@ -440,11 +440,12 @@ namespace llarp
       // called in the isolated network thread
       TunEndpoint *self = static_cast< TunEndpoint * >(tun->user);
       self->m_NetworkToUserPktQueue.Process([self, tun](net::IPv4Packet &pkt) {
+        // prepare packet for insertion into network
+        pkg.UpdateChecksumsOnSrc();
         // clear addresses
         pkt.src(0);
         pkt.dst(0);
-        // clear checksum
-        pkt.Header()->check = 0;
+
         if(!llarp_ev_tun_async_write(tun, pkt.buf, pkt.sz))
           llarp::LogWarn("packet dropped");
       });

--- a/llarp/ip.cpp
+++ b/llarp/ip.cpp
@@ -60,15 +60,21 @@ namespace llarp
     deltachksum(uint16_t old_sum, uint32_t old_src_ip_n, uint32_t old_dst_ip_n,
                 uint32_t new_src_ip_n, uint32_t new_dst_ip_n)
     {
-#define ADDIPCS(x) ((uint32_t)(x & 0xFFFF) + (uint32_t)(x >> 16))
-#define SUBIPCS(x) ((uint32_t)((~x) & 0xFFFF) + (uint32_t)((~x) >> 16))
-      uint32_t sum = ~old_sum + ADDIPCS(new_src_ip_n) + ADDIPCS(new_dst_ip_n)
-          + SUBIPCS(old_src_ip_n) + SUBIPCS(old_dst_ip_n);
+#define ADDIPCS(x) ((uint32_t)ntohs(x & 0xFFFF) + (uint32_t)ntohs(x >> 16))
+#define SUBIPCS(x) \
+  ((uint32_t)ntohs((~x) & 0xFFFF) + (uint32_t)ntohs((~x) >> 16))
+
+      uint32_t sum = ntohs(old_sum) + ADDIPCS(old_src_ip_n)
+          + ADDIPCS(old_dst_ip_n) + SUBIPCS(new_src_ip_n)
+          + SUBIPCS(new_dst_ip_n);
+
 #undef ADDIPCS
 #undef SUBIPCS
+
       while(sum >> 16)
         sum = (sum & 0xffff) + (sum >> 16);
-      return ~sum;
+
+      return htons(sum);
     }
 
     static std::map<

--- a/llarp/ip.cpp
+++ b/llarp/ip.cpp
@@ -95,9 +95,6 @@ namespace llarp
              6,
              [](const ip_header *hdr, byte_t *pkt, size_t sz) {
                auto hlen = size_t(hdr->ihl * 4);
-               if(hlen + 16 + 2 > sz)
-                 return;
-
                uint16_t *check = (uint16_t *)(pkt + hlen + 16);
                *check = deltachksum(*check, 0, 0, hdr->saddr, hdr->daddr);
              }},
@@ -110,8 +107,7 @@ namespace llarp
       // IPv4 checksum
       auto hlen  = size_t(hdr->ihl * 4);
       hdr->check = 0;
-      if(hlen <= sz)
-        hdr->check = ipchksum(buf, hlen);
+      hdr->check = ipchksum(buf, hlen);
 
       // L4 checksum
       auto proto = hdr->protocol;
@@ -129,9 +125,6 @@ namespace llarp
              6,
              [](const ip_header *hdr, byte_t *pkt, size_t sz) {
                auto hlen = size_t(hdr->ihl * 4);
-               if(hlen + 16 + 2 > sz)
-                 return;
-
                uint16_t *check = (uint16_t *)(pkt + hlen + 16);
                *check = deltachksum(*check, hdr->saddr, hdr->daddr, 0, 0);
              }},

--- a/llarp/ip.cpp
+++ b/llarp/ip.cpp
@@ -16,11 +16,7 @@ namespace llarp
     bool
     IPv4Packet::Load(llarp_buffer_t pkt)
     {
-#ifndef MIN
-#define MIN(a, b) (a < b ? a : b)
-      sz = MIN(pkt.sz, sizeof(buf));
-#undef MIN
-#endif
+      sz = std::min(pkt.sz, sizeof(buf));
       memcpy(buf, pkt.base, sz);
       return true;
     }

--- a/llarp/ip.cpp
+++ b/llarp/ip.cpp
@@ -78,18 +78,28 @@ namespace llarp
                *check = ipchksum(pktbuf, 12 + pktsz);
              }}};
     void
-    IPv4Packet::UpdateChecksum()
+    IPv4Packet::UpdateChecksumsOnDst()
     {
+      // IPv4 checksum
       auto hdr   = Header();
       hdr->check = 0;
       auto len   = hdr->ihl * 4;
       hdr->check = ipchksum(buf, len);
+
+      // L4 checksum
       auto proto = hdr->protocol;
       auto itr   = protoCheckSummer.find(proto);
       if(itr != protoCheckSummer.end())
       {
         itr->second(hdr, buf, sz);
       }
+    }
+
+    void
+    IPv4Packet::UpdateChecksumsOnSrc()
+    {
+      // IPv4
+      Header()->check = 0;
     }
   }  // namespace net
 }  // namespace llarp

--- a/llarp/path.cpp
+++ b/llarp/path.cpp
@@ -204,8 +204,8 @@ namespace llarp
       return m_Router;
     }
 
-    IHopHandler *
-    PathContext::GetPathForTransfer(const PathID_t & id)
+    IHopHandler*
+    PathContext::GetPathForTransfer(const PathID_t& id)
     {
       RouterID us(OurRouterID());
       auto& map = m_TransitPaths;
@@ -220,7 +220,7 @@ namespace llarp
       }
       return nullptr;
     }
-    
+
     void
     PathContext::PutTransitHop(TransitHop* hop)
     {


### PR DESCRIPTION
use incremental checksum calculation where we can.
support UDP checksum recalculation.
also fixes some bugs and cleans up bogus code.