### PR TITLE
codebase cleanups and some fixes

### DIFF
--- a/include/llarp.h
+++ b/include/llarp.h
@@ -108,7 +108,7 @@ extern "C"
   llarp_tun_io *
   main_router_getRange(struct llarp_main *ptr);
 
-  /// map an ip to a hidden service address
+  /// map an (host byte order) ip to a hidden service address
   bool
   main_router_mapAddress(struct llarp_main *ptr,
                          const llarp::service::Address &addr, uint32_t ip);

--- a/include/llarp/handlers/tun.hpp
+++ b/include/llarp/handlers/tun.hpp
@@ -33,7 +33,7 @@ namespace llarp
       TickTun(llarp_time_t now);
 
       bool
-      MapAddress(const service::Address& remote, uint32_t ip);
+      MapAddress(const service::Address& remote, huint32_t ip);
 
       bool
       Start();
@@ -91,18 +91,18 @@ namespace llarp
       PacketQueue_t m_NetworkToUserPktQueue;
       /// return true if we have a remote loki address for this ip address
       bool
-      HasRemoteForIP(const uint32_t& ipv4) const;
+      HasRemoteForIP(huint32_t ipv4) const;
       /// get ip address for service address unconditionally
-      uint32_t
+      huint32_t
       ObtainIPForAddr(const service::Address& addr);
 
       /// mark this address as active
       void
-      MarkIPActive(uint32_t ip);
+      MarkIPActive(huint32_t ip);
 
       /// mark this address as active forever
       void
-      MarkIPActiveForever(uint32_t ip);
+      MarkIPActiveForever(huint32_t ip);
 
       void
       FlushSend();
@@ -120,18 +120,18 @@ namespace llarp
       struct dotLokiLookup dll;
 
       /// maps ip to service address (host byte order)
-      std::unordered_map< uint32_t, service::Address > m_IPToAddr;
+      std::unordered_map< huint32_t, service::Address > m_IPToAddr;
       /// maps service address to ip (host byte order)
-      std::unordered_map< service::Address, uint32_t, service::Address::Hash >
+      std::unordered_map< service::Address, huint32_t, service::Address::Hash >
           m_AddrToIP;
       /// maps ip address to timestamp last active
-      std::unordered_map< uint32_t, llarp_time_t > m_IPActivity;
+      std::unordered_map< huint32_t, llarp_time_t > m_IPActivity;
       /// our ip address (host byte order)
-      uint32_t m_OurIP;
+      huint32_t m_OurIP;
       /// next ip address to allocate (host byte order)
-      uint32_t m_NextIP;
-      /// highest ip address to allocate
-      uint32_t m_MaxIP;
+      huint32_t m_NextIP;
+      /// highest ip address to allocate (host byte order)
+      huint32_t m_MaxIP;
     };
   }  // namespace handlers
 }  // namespace llarp

--- a/include/llarp/handlers/tun.hpp
+++ b/include/llarp/handlers/tun.hpp
@@ -120,12 +120,14 @@ namespace llarp
       struct dotLokiLookup dll;
 
       /// maps ip to service address (host byte order)
-      std::unordered_map< huint32_t, service::Address > m_IPToAddr;
+      std::unordered_map< huint32_t, service::Address, huint32_t::Hash >
+          m_IPToAddr;
       /// maps service address to ip (host byte order)
       std::unordered_map< service::Address, huint32_t, service::Address::Hash >
           m_AddrToIP;
       /// maps ip address to timestamp last active
-      std::unordered_map< huint32_t, llarp_time_t > m_IPActivity;
+      std::unordered_map< huint32_t, llarp_time_t, huint32_t::Hash >
+          m_IPActivity;
       /// our ip address (host byte order)
       huint32_t m_OurIP;
       /// next ip address to allocate (host byte order)

--- a/include/llarp/ip.hpp
+++ b/include/llarp/ip.hpp
@@ -129,28 +129,28 @@ namespace llarp
         return (ip_header*)&buf[0];
       }
 
-      inline uint32_t
+      inline huint32_t
       src()
       {
-        return ntohl(Header()->saddr);
+        return huint32_t{ntohl(Header()->saddr)};
       }
 
-      inline uint32_t
+      inline huint32_t
       dst()
       {
-        return ntohl(Header()->daddr);
+        return huint32_t{ntohl(Header()->daddr)};
       }
 
       inline void
-      src(uint32_t ip)
+      src(huint32_t ip)
       {
-        Header()->saddr = htonl(ip);
+        Header()->saddr = htonl(ip.h);
       }
 
       inline void
-      dst(uint32_t ip)
+      dst(huint32_t ip)
       {
-        Header()->daddr = htonl(ip);
+        Header()->daddr = htonl(ip.h);
       }
 
       // update ip packet checksum (after packet gets out of network)

--- a/include/llarp/net.hpp
+++ b/include/llarp/net.hpp
@@ -51,6 +51,79 @@ llarp_getPrivateIfs();
 
 namespace llarp
 {
+  struct huint32_t;
+  struct nuint32_t;
+
+  // clang-format off
+
+  struct huint32_t
+  {
+    uint32_t h;
+
+    //inline operator nuint32_t() const { return xhtonl(*this); }
+    constexpr huint32_t operator &(huint32_t x) const { return huint32_t{h & x.h}; }
+    constexpr huint32_t operator |(huint32_t x) const { return huint32_t{h | x.h}; }
+    constexpr huint32_t operator ~() const { return huint32_t{~h}; }
+    inline huint32_t operator ++() { ++h; return *this; }
+    inline huint32_t operator --() { --h; return *this; }
+    constexpr bool operator <(huint32_t x) const { return h < x.h; }
+    constexpr bool operator ==(huint32_t x) const { return h == x.h; }
+  };
+
+  struct nuint32_t
+  {
+    uint32_t n;
+
+    //inline operator huint32_t() const { return xntohl(*this); }
+    constexpr nuint32_t operator &(nuint32_t x) const { return nuint32_t{n & x.n}; }
+    constexpr nuint32_t operator |(nuint32_t x) const { return nuint32_t{n | x.n}; }
+    constexpr nuint32_t operator ~() const { return nuint32_t{~n}; }
+    inline nuint32_t operator ++() { ++n; return *this; }
+    inline nuint32_t operator --() { --n; return *this; }
+    constexpr bool operator <(nuint32_t x) const { return n < x.n; }
+    constexpr bool operator ==(nuint32_t x) const { return n == x.n; }
+  };
+
+  // clang-format on
+
+  static inline huint32_t
+  xntohl(nuint32_t x)
+  {
+    return huint32_t{ntohl(x.n)};
+  }
+
+  static inline nuint32_t
+  xhtonl(huint32_t x)
+  {
+    return nuint32_t{htonl(x.h)};
+  }
+}  // namespace llarp
+
+namespace std
+{
+  template <>
+  struct hash< llarp::huint32_t >
+  {
+    inline size_t
+    operator()(llarp::huint32_t x) const
+    {
+      return hash< uint32_t >{}(x.h);
+    }
+  };
+
+  template <>
+  struct hash< llarp::nuint32_t >
+  {
+    inline size_t
+    operator()(llarp::nuint32_t x) const
+    {
+      return hash< uint32_t >{}(x.n);
+    }
+  };
+}  // namespace std
+
+namespace llarp
+{
   struct Addr
   {
     // network order
@@ -434,16 +507,28 @@ namespace llarp
       return *this;
     }
 
-    uint32_t
-    tohl()
+    inline uint32_t
+    tohl() const
     {
       return ntohl(addr4()->s_addr);
     }
 
-    uint32_t
-    ton()
+    inline huint32_t
+    xtohl() const
+    {
+      return huint32_t{ntohl(addr4()->s_addr)};
+    }
+
+    inline uint32_t
+    ton() const
     {
       return addr4()->s_addr;
+    }
+
+    inline nuint32_t
+    xtonl() const
+    {
+      return nuint32_t{addr4()->s_addr};
     }
 
     sockaddr*

--- a/include/llarp/net.hpp
+++ b/include/llarp/net.hpp
@@ -51,16 +51,12 @@ llarp_getPrivateIfs();
 
 namespace llarp
 {
-  struct huint32_t;
-  struct nuint32_t;
-
   // clang-format off
 
   struct huint32_t
   {
     uint32_t h;
 
-    //inline operator nuint32_t() const { return xhtonl(*this); }
     constexpr huint32_t operator &(huint32_t x) const { return huint32_t{h & x.h}; }
     constexpr huint32_t operator |(huint32_t x) const { return huint32_t{h | x.h}; }
     constexpr huint32_t operator ~() const { return huint32_t{~h}; }
@@ -68,13 +64,21 @@ namespace llarp
     inline huint32_t operator --() { --h; return *this; }
     constexpr bool operator <(huint32_t x) const { return h < x.h; }
     constexpr bool operator ==(huint32_t x) const { return h == x.h; }
+
+    struct Hash
+    {
+      inline size_t
+      operator()(huint32_t x) const
+      {
+        return std::hash< uint32_t >{}(x.h);
+      }
+    };
   };
 
   struct nuint32_t
   {
     uint32_t n;
 
-    //inline operator huint32_t() const { return xntohl(*this); }
     constexpr nuint32_t operator &(nuint32_t x) const { return nuint32_t{n & x.n}; }
     constexpr nuint32_t operator |(nuint32_t x) const { return nuint32_t{n | x.n}; }
     constexpr nuint32_t operator ~() const { return nuint32_t{~n}; }
@@ -82,6 +86,15 @@ namespace llarp
     inline nuint32_t operator --() { --n; return *this; }
     constexpr bool operator <(nuint32_t x) const { return n < x.n; }
     constexpr bool operator ==(nuint32_t x) const { return n == x.n; }
+
+    struct Hash
+    {
+      inline size_t
+      operator()(nuint32_t x) const
+      {
+        return std::hash< uint32_t >{}(x.n);
+      }
+    };
   };
 
   // clang-format on
@@ -97,33 +110,7 @@ namespace llarp
   {
     return nuint32_t{htonl(x.h)};
   }
-}  // namespace llarp
 
-namespace std
-{
-  template <>
-  struct hash< llarp::huint32_t >
-  {
-    inline size_t
-    operator()(llarp::huint32_t x) const
-    {
-      return hash< uint32_t >{}(x.h);
-    }
-  };
-
-  template <>
-  struct hash< llarp::nuint32_t >
-  {
-    inline size_t
-    operator()(llarp::nuint32_t x) const
-    {
-      return hash< uint32_t >{}(x.n);
-    }
-  };
-}  // namespace std
-
-namespace llarp
-{
   struct Addr
   {
     // network order

--- a/include/llarp/service/context.hpp
+++ b/include/llarp/service/context.hpp
@@ -1,6 +1,7 @@
 #ifndef LLARP_SERVICE_CONTEXT_HPP
 #define LLARP_SERVICE_CONTEXT_HPP
 #include <llarp/router.h>
+#include <llarp/net.hpp>
 #include <llarp/service/config.hpp>
 #include <llarp/service/endpoint.hpp>
 #include <unordered_map>
@@ -58,7 +59,7 @@ namespace llarp
       /// punch a hole open for DNS to add mappings
       /// ip is in network order
       bool
-      MapAddress(const llarp::service::Address &addr, uint32_t ip);
+      MapAddress(const llarp::service::Address &addr, huint32_t ip);
 
       bool
       MapAddressAll(const llarp::service::Address &addr,

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -461,7 +461,7 @@ extern "C"
                          const llarp::service::Address &addr, uint32_t ip)
   {
     auto *endpoint = &ptr->ctx->router->hiddenServiceContext;
-    return endpoint->MapAddress(addr, ip);
+    return endpoint->MapAddress(addr, llarp::huint32_t{ip});
   }
 
   bool

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -474,17 +474,8 @@ namespace llarp
       llarp::LogDebug("got pkt ", sz, " bytes");
       if(!self->m_UserToNetworkPktQueue.EmplaceIf(
              [self, buf, sz](net::IPv4Packet &pkt) -> bool {
-               if(pkt.Load(llarp::InitBuffer(buf, sz))
-                  && pkt.Header()->version == 4)
-               {
-                 // clear addresses
-                 pkt.src(0);
-                 pkt.dst(0);
-                 // clear checksum
-                 pkt.Header()->check = 0;
-                 return true;
-               }
-               return false;
+               return pkt.Load(llarp::InitBuffer(buf, sz))
+                   && pkt.Header()->version == 4;
              }))
       {
         llarp::LogInfo("Failed to parse ipv4 packet");

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -115,7 +115,7 @@ namespace llarp
     }
 
     bool
-    Context::MapAddress(const llarp::service::Address &addr, uint32_t ip)
+    Context::MapAddress(const llarp::service::Address &addr, huint32_t ip)
     {
       if(!m_Endpoints.size())
       {
@@ -148,7 +148,7 @@ namespace llarp
         return false;
       }
       return tunEndpoint->MapAddress(context->serviceAddr,
-                                     context->localPrivateIpAddr.tohl());
+                                     context->localPrivateIpAddr.xtohl());
     }
 
     bool


### PR DESCRIPTION
introduces byte order specific `nuint32_t` and `huint32_t` types and functions to convert these.
modifies part of codebase to use that.
fix bug probably introduced by https://github.com/loki-project/loki-network/commit/cbfc73515e093c9b443b530a972bca5e0f2f7df7 (that was fixed in my earlier PR, fucked up because merge on different base?).
plz review if I didn't do any mistakes with byte ordering.