### PR TITLE
fix router configuration bug

### DIFF
--- a/include/llarp/net.hpp
+++ b/include/llarp/net.hpp
@@ -383,7 +383,7 @@ namespace llarp
           out << "]";
       }
 
-      return out << ":" << a.port();
+      return out << ":" << ntohs(a.port());
     }
 
     operator const sockaddr*() const

--- a/include/llarp/net.hpp
+++ b/include/llarp/net.hpp
@@ -211,7 +211,7 @@ namespace llarp
 
       _addr.sin6_family = res->ai_family;
       _addr4.sin_family = res->ai_family;
-      _addr4.sin_port   = htons(0);
+      _addr4.sin_port   = 0; // save a call, 0 is 0 no matter how u arrange it
 #if((__APPLE__ && __MACH__) || __FreeBSD__)
       _addr4.sin_len = sizeof(in_addr);
 #endif
@@ -240,7 +240,7 @@ namespace llarp
 
       _addr.sin6_family = AF_INET;  // set ipv4 mode
       _addr4.sin_family = AF_INET;
-      _addr4.sin_port   = htons(0);
+      _addr4.sin_port   = 0;
 
 #if((__APPLE__ && __MACH__) || __FreeBSD__)
       _addr4.sin_len = sizeof(in_addr);
@@ -382,8 +382,7 @@ namespace llarp
         if(a.af() == AF_INET6)
           out << "]";
       }
-
-      return out << ":" << ntohs(a.port());
+      return out << ":" << a.port();
     }
 
     operator const sockaddr*() const

--- a/llarp/ev_win32.hpp
+++ b/llarp/ev_win32.hpp
@@ -415,7 +415,7 @@ struct llarp_win32_loop : public llarp_ev_loop
       while(itr != udp_listeners.end())
       {
         if((*itr) == l)
-          itr = udp_listeners.remove(itr);
+          itr = udp_listeners.erase(itr);
         else
           ++itr;
       }

--- a/llarp/ev_win32.hpp
+++ b/llarp/ev_win32.hpp
@@ -231,8 +231,8 @@ struct llarp_win32_loop : public llarp_ev_loop
       return -1;
     else
     {
-      tick_listeners();
       result = idx;
+      tick_listeners();
     }
 
     return result;

--- a/llarp/link/utp.cpp
+++ b/llarp/link/utp.cpp
@@ -344,12 +344,12 @@ namespace llarp
       static uint64
       SendTo(utp_callback_arguments* arg)
       {
+      	Addr a = Addr(*arg->address);
         LinkLayer* l =
             static_cast< LinkLayer* >(utp_context_get_userdata(arg->context));
-        llarp::LogDebug("utp_sendto ", Addr(*arg->address), " ", arg->len,
+        llarp::LogDebug("utp_sendto ", a, " ", arg->len,
                         " bytes");
-        if(::sendto(l->m_udp.fd, (char*)arg->buf, arg->len, arg->flags,
-                    arg->address, arg->address_len)
+        if(::sendto(l->m_udp.fd, (char*)arg->buf, arg->len, arg->flags, (const sockaddr*)a, a.SockLen())
                == -1
            && errno)
         {

--- a/llarp/link/utp.cpp
+++ b/llarp/link/utp.cpp
@@ -344,12 +344,12 @@ namespace llarp
       static uint64
       SendTo(utp_callback_arguments* arg)
       {
-      	Addr a = Addr(*arg->address);
         LinkLayer* l =
             static_cast< LinkLayer* >(utp_context_get_userdata(arg->context));
-        llarp::LogDebug("utp_sendto ", a, " ", arg->len,
+        llarp::LogDebug("utp_sendto ", Addr(*arg->address), " ", arg->len,
                         " bytes");
-        if(::sendto(l->m_udp.fd, (char*)arg->buf, arg->len, arg->flags, (const sockaddr*)a, a.SockLen())
+        if(::sendto(l->m_udp.fd, (char*)arg->buf, arg->len, arg->flags,
+                    arg->address, arg->address_len)
                == -1
            && errno)
         {

--- a/llarp/router.cpp
+++ b/llarp/router.cpp
@@ -1247,8 +1247,9 @@ namespace llarp
       {
         llarp::LogInfo("Setting public port ", val);
         int p = atoi(val);
-        self->ip4addr.sin_port = htons(p);
-        self->addrInfo.port    = htons(p);
+        // Not needed to flip upside-down - this is done in llarp::Addr(const AddressInfo&)
+        self->ip4addr.sin_port = p;
+        self->addrInfo.port    = p;
         self->publicOverride   = true;
       }
     }

--- a/llarp/router.cpp
+++ b/llarp/router.cpp
@@ -12,6 +12,7 @@
 #include "str.hpp"
 
 #include <fstream>
+#include <cstdlib>
 
 namespace llarp
 {
@@ -666,8 +667,8 @@ llarp_router::Run()
 
   routerProfiling.Load(routerProfilesFile.c_str());
   // zero out router contact
-  sockaddr *dest = (sockaddr *)&this->ip4addr;
-  llarp::Addr publicAddr(*dest);
+  //sockaddr *dest = (sockaddr *)&this->ip4addr;
+  llarp::Addr publicAddr(this->addrInfo);
 
   if(this->publicOverride)
   {
@@ -1245,8 +1246,9 @@ namespace llarp
       if(StrEq(key, "public-port"))
       {
         llarp::LogInfo("Setting public port ", val);
-        self->ip4addr.sin_port = htons(atoi(val));
-        self->addrInfo.port    = htons(atoi(val));
+        int p = atoi(val);
+        self->ip4addr.sin_port = htons(p);
+        self->addrInfo.port    = htons(p);
         self->publicOverride   = true;
       }
     }


### PR DESCRIPTION
`this->ip4addr` was no longer written to after the switch to `llarp::Addr`, which left it pointing to zeros or a system-specific test pattern (on Windows: `BA AD F0 0D`) which was later written verbatim to the RC file