### PR TITLE
Fix compile issue in endpoint.cpp

### DIFF
--- a/include/llarp/service/endpoint.hpp
+++ b/include/llarp/service/endpoint.hpp
@@ -432,16 +432,17 @@ namespace llarp
       std::string m_Name;
       std::string m_NetNS;
 
-      std::unordered_map< Address, PendingBufferQueue, Address::Hash >
-          m_PendingTraffic;
+      using PendingTraffic =
+          std::unordered_map< Address, PendingBufferQueue, Address::Hash >;
 
-      std::unordered_multimap< Address, std::unique_ptr< OutboundContext >,
-                               Address::Hash >
-          m_RemoteSessions;
+      PendingTraffic m_PendingTraffic;
 
-      std::unordered_multimap< Address, std::unique_ptr< OutboundContext >,
-                               Address::Hash >
-          m_DeadSessions;
+      using Sessions =
+          std::unordered_multimap< Address, std::unique_ptr< OutboundContext >,
+                                   Address::Hash >;
+      Sessions m_RemoteSessions;
+
+      Sessions m_DeadSessions;
 
       std::unordered_map< Address, ServiceInfo, Address::Hash >
           m_AddressToService;

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -280,11 +280,11 @@ namespace llarp
     bool
     Endpoint::HasPathToService(const Address& addr) const
     {
-      auto range = m_RemoteSessions.equal_range(addr);
-      auto itr   = range.first;
+      auto range                   = m_RemoteSessions.equal_range(addr);
+      Sessions::const_iterator itr = range.first;
       while(itr != range.second)
       {
-        if(itr->ReadyToSend())
+        if(itr->second->ReadyToSend())
           return true;
         ++itr;
       }


### PR DESCRIPTION
swap `endpoint.hpp` to modern `using` declarations for types (and remove duplicated type instance), then fix broken build.