### PR TITLE
DNS QoL improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,10 @@ if(STATIC_LINK)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc -static" )
 endif()
 
-if(DNS_PORT)
-  add_definitions(-DDNS_PORT=${DNS_PORT})
-endif()
+# This is now configurable in ini
+#if(DNS_PORT)
+#  add_definitions(-DDNS_PORT=${DNS_PORT})
+#endif()
 
 if(SHADOW)
   set(WITH_STATIC OFF)

--- a/llarp/config.cpp
+++ b/llarp/config.cpp
@@ -162,7 +162,14 @@ llarp_generic_ensure_config(std::ofstream &f, std::string basepath)
   f << "upstream=" << DEFAULT_RESOLVER_EU << std::endl;
   f << "# opennic au resolver" << std::endl;
   f << "upstream=" << DEFAULT_RESOLVER_AU << std::endl;
+
+// Make auto-config smarter
+// will this break reproducibility rules?
+#ifdef __linux__
+  f << "bind=127.3.2.1:53" << std::endl;
+#else
   f << "bind=127.0.0.1:53" << std::endl;
+#endif
   f << std::endl << std::endl;
 
   f << "# network database settings block " << std::endl;
@@ -239,6 +246,8 @@ llarp_ensure_client_config(std::ofstream &f, std::string basepath)
   f << "# network settings " << std::endl;
   f << "[network]" << std::endl;
   f << "profiles=" << basepath << "profiles.dat" << std::endl;
+
+// WHAT? Why this ifndef?
 #ifndef __linux__
   f << "# ";
 #endif

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -9,10 +9,6 @@
 #include <netdb.h>
 #endif
 
-#ifndef DNS_PORT
-#define DNS_PORT (53)
-#endif
-
 namespace llarp
 {
   namespace handlers
@@ -48,7 +44,7 @@ namespace llarp
       if(k == "local-dns")
       {
         std::string resolverAddr = v;
-        uint16_t dnsport         = DNS_PORT;
+        uint16_t dnsport         = 53;
         auto pos                 = v.find(":");
         if(pos != std::string::npos)
         {
@@ -61,7 +57,7 @@ namespace llarp
       if(k == "upstream-dns")
       {
         std::string resolverAddr = v;
-        uint16_t dnsport         = DNS_PORT;
+        uint16_t dnsport         = 53;
         auto pos                 = v.find(":");
         if(pos != std::string::npos)
         {
@@ -392,7 +388,7 @@ namespace llarp
       {
         // not found
         service::Address addr;
-        llarp::LogWarn(ip, " not found in tun map. Sending ", addr.ToString());
+        llarp::LogWarn(ip, " not found in tun map.");
         return addr;
       }
       // found


### PR DESCRIPTION
Deprecate DNS_PORT (it had a bug and is now configurable via INI anyways)
Improve linux UX: Make 127.3.2.1 the default on linux (so you don't have to fug with systemd) when writing default config

Also tone down the debug a bit on the reverse ip lookup.