### PR TITLE
De-C-ify several .h headers

### DIFF
--- a/daemon/rcutil.cpp
+++ b/daemon/rcutil.cpp
@@ -4,7 +4,7 @@
 #include "logger.hpp"
 
 #include <llarp/router_contact.hpp>
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 
 #include <fstream>
 #include "buffer.hpp"
@@ -14,9 +14,6 @@
 #include "router.hpp"
 
 #include <llarp/messages/dht.hpp>
-//#include <llarp/dht/messages/findintro.hpp>
-//#include <llarp/routing_endpoint.hpp>
-//#include <llarp/crypt.hpp>  // for llarp::pubkey
 
 struct llarp_main *ctx = 0;
 
@@ -391,7 +388,7 @@ main(int argc, char *argv[])
     printf("Creating [%s]\n", rcfname);
     // if we zero it out then
     // set updated timestamp
-    rc.last_updated = llarp_time_now_ms();
+    rc.last_updated = llarp::time_now_ms();
     // load longterm identity
     llarp_crypto crypt;
     llarp_crypto_init(&crypt);
@@ -440,7 +437,7 @@ main(int argc, char *argv[])
     // llarp_rc_read(rcfname, &rc);
 
     // set updated timestamp
-    rc.last_updated = llarp_time_now_ms();
+    rc.last_updated = llarp::time_now_ms();
     // load longterm identity
     llarp_crypto crypt;
 

--- a/include/llarp/codel.hpp
+++ b/include/llarp/codel.hpp
@@ -1,6 +1,6 @@
 #ifndef LLARP_CODEL_QUEUE_HPP
 #define LLARP_CODEL_QUEUE_HPP
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <llarp/logger.hpp>
 #include <llarp/mem.hpp>
 #include <llarp/threading.hpp>
@@ -97,7 +97,7 @@ namespace llarp
       Process(Visit visitor, Filter f)
       {
         llarp_time_t lowest = 0xFFFFFFFFFFFFFFFFUL;
-        // auto start          = llarp_time_now_ms();
+        // auto start          = time_now_ms();
         // llarp::LogInfo("CoDelQueue::Process - start at ", start);
         Lock_t lock(m_QueueMutex);
         auto start = firstPut;

--- a/include/llarp/dht/context.hpp
+++ b/include/llarp/dht/context.hpp
@@ -2,13 +2,14 @@
 #define LLARP_DHT_CONTEXT_HPP
 
 #include <llarp/dht.h>
-#include <llarp/router.h>
 #include <llarp/dht/bucket.hpp>
 #include <llarp/dht/key.hpp>
 #include <llarp/dht/message.hpp>
 #include <llarp/dht/messages/findintro.hpp>
 #include <llarp/dht/node.hpp>
+#include <llarp/router.h>
 #include <llarp/service/IntroSet.hpp>
+#include <llarp/time.hpp>
 
 #include <set>
 
@@ -302,7 +303,7 @@ namespace llarp
           if(itr == timeouts.end())
           {
             timeouts.insert(
-                std::make_pair(k, llarp_time_now_ms() + requestTimeoutMS));
+                std::make_pair(k, time_now_ms() + requestTimeoutMS));
           }
           t->Start(askpeer);
         }

--- a/include/llarp/ev.h
+++ b/include/llarp/ev.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <tuntap.h>
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 
 /**
  * ev.h

--- a/include/llarp/exit/endpoint.hpp
+++ b/include/llarp/exit/endpoint.hpp
@@ -1,6 +1,6 @@
 #ifndef LLARP_EXIT_ENDPOINT_HPP
 #define LLARP_EXIT_ENDPOINT_HPP
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <llarp/crypto.hpp>
 #include <llarp/router.h>
 #include <llarp/path.hpp>

--- a/include/llarp/ip.hpp
+++ b/include/llarp/ip.hpp
@@ -1,7 +1,7 @@
 #ifndef LLARP_IP_HPP
 #define LLARP_IP_HPP
 #include <llarp/buffer.h>
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <llarp/net.hpp>
 #include <llarp/ev.h>
 

--- a/include/llarp/link/server.hpp
+++ b/include/llarp/link/server.hpp
@@ -8,7 +8,6 @@
 #include <llarp/ev.h>
 #include <llarp/link/session.hpp>
 #include <llarp/logic.h>
-#include <llarp/time.h>
 #include <list>
 
 struct llarp_router;

--- a/include/llarp/link/session.hpp
+++ b/include/llarp/link/session.hpp
@@ -4,7 +4,7 @@
 #include <llarp/crypto.hpp>
 #include <llarp/net.hpp>
 #include <llarp/router_contact.hpp>
-#include <llarp/types.h>
+#include <llarp/types.hpp>
 #include <functional>
 
 namespace llarp

--- a/include/llarp/logger.hpp
+++ b/include/llarp/logger.hpp
@@ -16,7 +16,6 @@
 #endif
 #ifdef RPI
 #include <cstdio>
-#include <llarp/time.h>
 #endif
 
 namespace llarp

--- a/include/llarp/logic.h
+++ b/include/llarp/logic.h
@@ -2,7 +2,7 @@
 #define LLARP_LOGIC_H
 #include <llarp/mem.h>
 #include <llarp/threadpool.h>
-#include <llarp/timer.h>
+#include <llarp/timer.hpp>
 
 struct llarp_logic
 {

--- a/include/llarp/path.hpp
+++ b/include/llarp/path.hpp
@@ -1,7 +1,7 @@
 #ifndef LLARP_PATH_HPP
 #define LLARP_PATH_HPP
 #include <llarp/router.h>
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <llarp/aligned.hpp>
 #include <llarp/crypto.hpp>
 #include <llarp/dht.hpp>

--- a/include/llarp/pathset.hpp
+++ b/include/llarp/pathset.hpp
@@ -1,6 +1,6 @@
 #ifndef LLARP_PATHSET_HPP
 #define LLARP_PATHSET_HPP
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <functional>
 #include <list>
 #include <llarp/path_types.hpp>

--- a/include/llarp/rpc.hpp
+++ b/include/llarp/rpc.hpp
@@ -1,6 +1,6 @@
 #ifndef LLARP_RPC_HPP
 #define LLARP_RPC_HPP
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <llarp/ev.h>
 #include <string>
 #include <functional>

--- a/include/llarp/service/IntroSet.hpp
+++ b/include/llarp/service/IntroSet.hpp
@@ -1,6 +1,6 @@
 #ifndef LLARP_SERVICE_INTROSET_HPP
 #define LLARP_SERVICE_INTROSET_HPP
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <iostream>
 #include <llarp/bencode.hpp>
 #include <llarp/crypto.hpp>

--- a/include/llarp/service/protocol.hpp
+++ b/include/llarp/service/protocol.hpp
@@ -1,6 +1,6 @@
 #ifndef LLARP_SERVICE_PROTOCOL_HPP
 #define LLARP_SERVICE_PROTOCOL_HPP
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <llarp/bencode.hpp>
 #include <llarp/crypto.hpp>
 #include <llarp/encrypted.hpp>

--- a/include/llarp/time.h
+++ b/include/llarp/time.h
@@ -1,8 +1,0 @@
-#ifndef LLARP_TIME_H
-#define LLARP_TIME_H
-#include <llarp/types.h>
-
-llarp_time_t
-llarp_time_now_ms();
-
-#endif

--- a/include/llarp/time.hpp
+++ b/include/llarp/time.hpp
@@ -1,11 +1,16 @@
 #ifndef LLARP_TIME_HPP
 #define LLARP_TIME_HPP
 
+#include <llarp/types.hpp>
+
 #include <chrono>
 
 namespace llarp
 {
-  typedef std::chrono::system_clock Clock_t;
-}
+  using Clock_t = std::chrono::system_clock;
+
+  llarp_time_t
+  time_now_ms();
+}  // namespace llarp
 
 #endif

--- a/include/llarp/timer.hpp
+++ b/include/llarp/timer.hpp
@@ -1,8 +1,9 @@
-#ifndef LLARP_TIMER_H
-#define LLARP_TIMER_H
+#ifndef LLARP_TIMER_HPP
+#define LLARP_TIMER_HPP
+
 #include <llarp/common.h>
 #include <llarp/threadpool.h>
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 
 /** called with userptr, original timeout, left */
 typedef void (*llarp_timer_handler_func)(void *, uint64_t, uint64_t);

--- a/include/llarp/types.h
+++ b/include/llarp/types.h
@@ -1,9 +1,0 @@
-#ifndef LLARP_TYPES_H
-#define LLARP_TYPES_H
-#include <stdint.h>
-
-typedef uint8_t llarp_proto_version_t;
-typedef uint64_t llarp_time_t;
-typedef uint64_t llarp_seconds_t;
-
-#endif

--- a/include/llarp/types.hpp
+++ b/include/llarp/types.hpp
@@ -1,0 +1,9 @@
+#ifndef LLARP_TYPES_H
+#define LLARP_TYPES_H
+#include <cstdint>
+
+using llarp_proto_version_t = std::uint8_t;
+using llarp_time_t = std::uint64_t;
+using llarp_seconds_t = std::uint64_t;
+
+#endif

--- a/libabyss/include/abyss/server.hpp
+++ b/libabyss/include/abyss/server.hpp
@@ -3,11 +3,11 @@
 
 #include <llarp/ev.h>
 #include <llarp/logic.h>
-#include <llarp/time.h>
+#include <llarp/string_view.hpp>
+#include <llarp/time.hpp>
 #include <list>
 #include <memory>
 #include <string>
-#include <llarp/string_view.hpp>
 #include <abyss/json.hpp>
 #include <unordered_map>
 

--- a/libabyss/src/server.cpp
+++ b/libabyss/src/server.cpp
@@ -1,6 +1,6 @@
 #include <abyss/server.hpp>
 #include <abyss/http.hpp>
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <sstream>
 #include <unordered_map>
 #include <string>

--- a/llarp/ev.cpp
+++ b/llarp/ev.cpp
@@ -34,7 +34,7 @@ llarp_ev_loop_alloc(struct llarp_ev_loop **ev)
 #error no event loop subclass
 #endif
   (*ev)->init();
-  (*ev)->_now = llarp_time_now_ms();
+  (*ev)->_now = llarp::time_now_ms();
 }
 
 void
@@ -49,7 +49,7 @@ llarp_ev_loop_run(struct llarp_ev_loop *ev, struct llarp_logic *logic)
 {
   while(ev->running())
   {
-    ev->_now = llarp_time_now_ms();
+    ev->_now = llarp::time_now_ms();
     ev->tick(EV_TICK_INTERVAL);
     if(ev->running())
       llarp_logic_tick(logic, ev->_now);
@@ -64,7 +64,7 @@ llarp_ev_loop_run_single_process(struct llarp_ev_loop *ev,
 {
   while(ev->running())
   {
-    ev->_now = llarp_time_now_ms();
+    ev->_now = llarp::time_now_ms();
     ev->tick(EV_TICK_INTERVAL);
     if(ev->running())
     {

--- a/llarp/ev_kqueue.hpp
+++ b/llarp/ev_kqueue.hpp
@@ -8,7 +8,6 @@
 #if __FreeBSD__ || __OpenBSD__ || __NetBSD__ || (__APPLE__ && __MACH__)
 // kqueue / kevent
 #include <sys/event.h>
-#include <sys/time.h>
 #include <fcntl.h>
 #endif
 

--- a/llarp/proofofwork.cpp
+++ b/llarp/proofofwork.cpp
@@ -1,4 +1,3 @@
-#include <llarp/time.h>
 #include <cmath>
 #include <llarp/pow.hpp>
 #include "buffer.hpp"

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -1,9 +1,9 @@
 #include <llarp/bencode.hpp>
-#include <llarp/router_contact.hpp>
-#include <llarp/version.h>
 #include <llarp/crypto.hpp>
-#include <llarp/time.h>
 #include <llarp/net.hpp>
+#include <llarp/router_contact.hpp>
+#include <llarp/time.hpp>
+#include <llarp/version.h>
 #include "buffer.hpp"
 #include "logger.hpp"
 #include "mem.hpp"
@@ -156,7 +156,7 @@ namespace llarp
     byte_t tmp[MAX_RC_SIZE] = {0};
     auto buf                = llarp::StackBuffer< decltype(tmp) >(tmp);
     signature.Zero();
-    last_updated = llarp_time_now_ms();
+    last_updated = time_now_ms();
     if(!BEncode(&buf))
       return false;
     buf.sz  = buf.cur - buf.base;

--- a/llarp/routing/path_confirm.cpp
+++ b/llarp/routing/path_confirm.cpp
@@ -1,6 +1,7 @@
-#include <llarp/time.h>
-#include <llarp/bencode.hpp>
 #include <llarp/messages/path_confirm.hpp>
+
+#include <llarp/time.hpp>
+#include <llarp/bencode.hpp>
 #include <llarp/routing/handler.hpp>
 
 namespace llarp
@@ -12,7 +13,7 @@ namespace llarp
     }
 
     PathConfirmMessage::PathConfirmMessage(uint64_t lifetime)
-        : pathLifetime(lifetime), pathCreated(llarp_time_now_ms())
+        : pathLifetime(lifetime), pathCreated(time_now_ms())
     {
     }
 

--- a/llarp/service/lookup.cpp
+++ b/llarp/service/lookup.cpp
@@ -1,6 +1,7 @@
 #include <llarp/path.hpp>
 #include <llarp/service/endpoint.hpp>
 #include <llarp/service/lookup.hpp>
+#include <llarp/time.hpp>
 
 namespace llarp
 {
@@ -10,7 +11,7 @@ namespace llarp
                                    const std::string &n)
         : parent(p), txid(tx), name(n)
     {
-      m_created = llarp_time_now_ms();
+      m_created = time_now_ms();
       p->PutLookup(this, tx);
     }
 

--- a/llarp/threadpool.cpp
+++ b/llarp/threadpool.cpp
@@ -2,7 +2,7 @@
 #include <pthread.h>
 #include <cstring>
 
-#include <llarp/time.h>
+#include <llarp/time.hpp>
 #include <functional>
 #include <queue>
 

--- a/llarp/time.cpp
+++ b/llarp/time.cpp
@@ -1,4 +1,3 @@
-#include <llarp/time.h>
 #include <llarp/time.hpp>
 
 namespace llarp
@@ -12,14 +11,13 @@ namespace llarp
         .count();
   }
 
+  // use std::chrono because otherwise the network breaks with Daylight Savings
+  // this time, it doesn't get truncated -despair
+  // that concern is what drove me back to the POSIX C time functions
+  // in the first place
+  llarp_time_t
+  time_now_ms()
+  {
+    return llarp::time_since_epoch< std::chrono::milliseconds >();
+  }
 }  // namespace llarp
-
-// use std::chrono because otherwise the network breaks with Daylight Savings
-// this time, it doesn't get truncated -despair
-// that concern is what drove me back to the POSIX C time functions
-// in the first place
-llarp_time_t
-llarp_time_now_ms()
-{
-  return llarp::time_since_epoch< std::chrono::milliseconds >();
-}

--- a/llarp/timer.cpp
+++ b/llarp/timer.cpp
@@ -1,5 +1,5 @@
-#include <llarp/time.h>
-#include <llarp/timer.h>
+#include <llarp/time.hpp>
+#include <llarp/timer.hpp>
 #include <atomic>
 #include <condition_variable>
 #include <list>
@@ -66,7 +66,7 @@ struct llarp_timer_context
 
   llarp_timer_context()
   {
-    m_Now = llarp_time_now_ms();
+    m_Now = llarp::time_now_ms();
   }
 
   uint32_t ids = 0;
@@ -193,7 +193,7 @@ void
 llarp_timer_set_time(struct llarp_timer_context* t, llarp_time_t now)
 {
   if(now == 0)
-    now = llarp_time_now_ms();
+    now = llarp::time_now_ms();
   t->m_Now = now;
 }
 
@@ -261,7 +261,7 @@ llarp_timer_run(struct llarp_timer_context* t, struct llarp_threadpool* pool)
     {
       llarp::util::Lock lock(t->timersMutex);
       // we woke up
-      llarp_timer_tick_all_async(t, pool, llarp_time_now_ms());
+      llarp_timer_tick_all_async(t, pool, llarp::time_now_ms());
     }
   }
 }

--- a/test/hiddenservice_unittest.cpp
+++ b/test/hiddenservice_unittest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
+
 #include <llarp/service.hpp>
+#include <llarp/time.hpp>
 
 struct HiddenServiceTest : public ::testing::Test
 {
@@ -31,7 +33,7 @@ TEST_F(HiddenServiceTest, TestGenerateIntroSet)
   llarp::service::Address addr;
   ASSERT_TRUE(ident.pub.CalculateAddress(addr.data()));
   llarp::service::IntroSet I;
-  auto now = llarp_time_now_ms();
+  auto now = llarp::time_now_ms();
   I.T      = now;
   while(I.I.size() < 10)
   {


### PR DESCRIPTION
This commit does a few related things:

- Merge `time.h` into `time.hpp`
- Rename `types.h` to `types.hpp`
- Rename `timer.h` to `timer.hpp`

This is part of an effort to allow for C++ types in the event loop proper