### PR TITLE
better config settings for defaults

### DIFF
--- a/include/llarp/service/context.hpp
+++ b/include/llarp/service/context.hpp
@@ -72,9 +72,8 @@ namespace llarp
                     llarp::Addr &localPrivateIpAddr);
 
       bool
-      AddDefaultEndpoint(const std::string &ifaddr, const std::string &ifname,
-                         const std::string &remoteResovler,
-                         const std::string &localResolver);
+      AddDefaultEndpoint(
+          const std::unordered_multimap< std::string, std::string > &opts);
 
       bool
       AddEndpoint(const Config::section_t &conf, bool autostart = false);

--- a/llarp/router.hpp
+++ b/llarp/router.hpp
@@ -100,26 +100,23 @@ struct llarp_router
 
   llarp::service::Context hiddenServiceContext;
 
-  std::string defaultIfAddr = "auto";
-  std::string defaultIfName = "auto";
+  using NetConfig_t = std::unordered_multimap< std::string, std::string >;
 
-  /// default exit config
-  llarp::exit::Context::Config_t exitConf;
+  /// default network config for default network interface
+  NetConfig_t netConfig;
 
   bool
   ExitEnabled() const
   {
-    auto itr = exitConf.find("exit");
-    if(itr == exitConf.end())
+    // TODO: use equal_range ?
+    auto itr = netConfig.find("exit");
+    if(itr == netConfig.end())
       return false;
     return llarp::IsTrueValue(itr->second.c_str());
   }
 
   bool
   CreateDefaultHiddenService();
-
-  bool
-  ShouldCreateDefaultHiddenService();
 
   const std::string DefaultRPCBindAddr = "127.0.0.1:1190";
   bool enableRPCServer                 = true;
@@ -161,11 +158,6 @@ struct llarp_router
   // set to max value right now
   std::unordered_map< llarp::PubKey, llarp_time_t, llarp::PubKey::Hash >
       lokinetRouters;
-
-  // TODO: change me if needed
-  const std::string defaultUpstreamResolver = "1.1.1.1:53";
-  std::list< std::string > upstreamResolvers;
-  std::string resolverBindAddr = "127.0.0.1:53";
 
   llarp_router();
   ~llarp_router();
@@ -335,10 +327,8 @@ struct llarp_router
   void
   mergeHiddenServiceConfig(const Config &in, Config &out)
   {
-    for(const auto &resolver : upstreamResolvers)
-      out.push_back({"upstream-dns", resolver});
-    out.push_back({"local-dns", resolverBindAddr});
-
+    for(const auto &item : netConfig)
+      out.push_back({item.first, item.second});
     for(const auto &item : in)
       out.push_back({item.first, item.second});
   }

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -207,18 +207,20 @@ namespace llarp
     }
 
     bool
-    Context::AddDefaultEndpoint(const std::string &ifaddr,
-                                const std::string &ifname,
-                                const std::string &remoteResolver,
-                                const std::string &localResolver)
+    Context::AddDefaultEndpoint(
+        const std::unordered_multimap< std::string, std::string > &opts)
     {
-      return AddEndpoint({"default",
-                          {{"type", "tun"},
-                           {"ifaddr", ifaddr},
-                           {"ifname", ifname},
-                           {"local-dns", localResolver},
-                           {"upstream-dns", remoteResolver}}},
-                         true);
+      Config::section_values_t configOpts;
+      configOpts.push_back({"type", "tun"});
+      {
+        auto itr = opts.begin();
+        while(itr != opts.end())
+        {
+          configOpts.push_back({itr->first, itr->second});
+          ++itr;
+        }
+      }
+      return AddEndpoint({"default", configOpts});
     }
 
     bool


### PR DESCRIPTION
this allows the default network interface options to be specified in the `[network]` section in `lokinet.ini` instead of just via a seperate file via the `[services]` section