### PR TITLE
fix lokinet bootstrap script

### DIFF
--- a/lokinet-bootstrap
+++ b/lokinet-bootstrap
@@ -2,9 +2,18 @@
 # this shell script will be replaced by a proper program in the future (probably)
 #
 
-if [ "X$1" = "X" ] ; then url="https://i2p.rocks/i2procks.signed" ; else url="$1" ; fi
+if [ -z "$1" ]
+then
+  url="https://i2p.rocks/i2procks.signed"
+else
+  url="$1"
+fi
+
 echo "downloading $url"
-if [ ! -d $HOME/.lokinet/]; then
+
+if [ ! -d "$HOME/.lokinet" ]
+then
   mkdir $HOME/.lokinet
 fi
+
 wget -O $HOME/.lokinet/bootstrap.signed "$url" || echo "failed to download bootstrap from $url"


### PR DESCRIPTION
Fixes simple errors in bootstrap script causing it to not work on macOS