### PR TITLE
Add ios cmake toolchain file repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "darwin/ios-cmake"]
+	path = darwin/ios-cmake
+	url = https://github.com/leetal/ios-cmake.git


### PR DESCRIPTION
This commit adds the github.com/leetal/ios-cmake repo as a submodule in
the darwin/ subfolder, which provides a cmake toolchain file to enable
iOS builds.