### PR TITLE
Remove implicit conversions between AlignedBuffers

### DIFF
--- a/llarp/address_info.cpp
+++ b/llarp/address_info.cpp
@@ -137,7 +137,7 @@ namespace llarp
     /* encryption key */
     if(!bencode_write_bytestring(buff, "e", 1))
       return false;
-    if(!bencode_write_bytestring(buff, pubkey.as_array().data(), PUBKEYSIZE))
+    if(!bencode_write_bytestring(buff, pubkey.data(), PUBKEYSIZE))
       return false;
     /** ip */
     ipstr = inet_ntop(AF_INET6, (void *)&ip, ipbuff, sizeof(ipbuff));

--- a/llarp/address_info.cpp
+++ b/llarp/address_info.cpp
@@ -137,7 +137,7 @@ namespace llarp
     /* encryption key */
     if(!bencode_write_bytestring(buff, "e", 1))
       return false;
-    if(!bencode_write_bytestring(buff, pubkey, PUBKEYSIZE))
+    if(!bencode_write_bytestring(buff, pubkey.as_array().data(), PUBKEYSIZE))
       return false;
     /** ip */
     ipstr = inet_ntop(AF_INET6, (void *)&ip, ipbuff, sizeof(ipbuff));

--- a/llarp/aligned.hpp
+++ b/llarp/aligned.hpp
@@ -206,16 +206,6 @@ namespace llarp
       return as_array().data();
     }
 
-    operator const Data&() const
-    {
-      return as_array();
-    }
-
-    operator Data&()
-    {
-      return as_array();
-    }
-
     typename Data::iterator
     begin()
     {

--- a/llarp/aligned.hpp
+++ b/llarp/aligned.hpp
@@ -35,7 +35,7 @@ namespace llarp
       Zero();
     }
 
-    AlignedBuffer(const byte_t* data)
+    explicit AlignedBuffer(const byte_t* data)
     {
       new(&val) Data;
       auto& b = as_array();

--- a/llarp/aligned.hpp
+++ b/llarp/aligned.hpp
@@ -139,6 +139,18 @@ namespace llarp
       return *this;
     }
 
+    byte_t& operator[](size_t idx)
+    {
+      assert(idx < SIZE);
+      return as_array()[idx];
+    }
+
+    const byte_t& operator[](size_t idx) const
+    {
+      assert(idx < SIZE);
+      return as_array()[idx];
+    }
+
     static constexpr size_t
     size()
     {
@@ -184,18 +196,6 @@ namespace llarp
       randombytes(as_array().data(), SIZE);
     }
 
-    byte_t*
-    data()
-    {
-      return as_array().data();
-    }
-
-    const byte_t*
-    data() const
-    {
-      return as_array().data();
-    }
-
     operator const byte_t*() const
     {
       return as_array().data();
@@ -214,6 +214,30 @@ namespace llarp
     operator Data&()
     {
       return as_array();
+    }
+
+    typename Data::iterator
+    begin()
+    {
+      return as_array().begin();
+    }
+
+    typename Data::iterator
+    end()
+    {
+      return as_array().end();
+    }
+
+    typename Data::const_iterator
+    begin() const
+    {
+      return as_array().cbegin();
+    }
+
+    typename Data::const_iterator
+    end() const
+    {
+      return as_array().cend();
     }
 
     bool

--- a/llarp/aligned.hpp
+++ b/llarp/aligned.hpp
@@ -45,7 +45,7 @@ namespace llarp
       }
     }
 
-    AlignedBuffer(const Data& buf)
+    explicit AlignedBuffer(const Data& buf)
     {
       new(&val) Data;
       std::copy(buf.begin(), buf.end(), begin());

--- a/llarp/aligned.hpp
+++ b/llarp/aligned.hpp
@@ -201,11 +201,6 @@ namespace llarp
       return as_array().data();
     }
 
-    operator byte_t*()
-    {
-      return as_array().data();
-    }
-
     typename Data::iterator
     begin()
     {

--- a/llarp/buffer.hpp
+++ b/llarp/buffer.hpp
@@ -35,7 +35,10 @@ namespace llarp
   Buffer(T& t)
   {
     llarp_buffer_t buff;
-    buff.base = &t[0];
+    // use data over the first element to "enforce" the container used has
+    // contiguous memory. (Note this isn't required by the standard, but a
+    // reasonable test on most standard library implementations).
+    buff.base = t.data();
     buff.cur  = buff.base;
     buff.sz   = t.size();
     return buff;

--- a/llarp/crypto.cpp
+++ b/llarp/crypto.cpp
@@ -7,7 +7,7 @@ namespace llarp
   bool
   PubKey::FromString(const std::string& str)
   {
-    return HexDecode(str.c_str(), data(), size());
+    return HexDecode(str.c_str(), as_array().data(), size());
   }
 
   std::string
@@ -31,7 +31,8 @@ namespace llarp
     if(sz == size())
     {
       // is raw buffer
-      f.read((char*)data(), 64);
+      std::copy(std::istream_iterator< byte_t >(f),
+                std::istream_iterator< byte_t >(), begin());
       return true;
     }
     byte_t tmp[128];

--- a/llarp/crypto.cpp
+++ b/llarp/crypto.cpp
@@ -7,7 +7,7 @@ namespace llarp
   bool
   PubKey::FromString(const std::string& str)
   {
-    return HexDecode(str.c_str(), as_array().data(), size());
+    return HexDecode(str.c_str(), begin(), size());
   }
 
   std::string

--- a/llarp/crypto.hpp
+++ b/llarp/crypto.hpp
@@ -40,111 +40,20 @@ static constexpr uint32_t PATHIDSIZE    = 16;
 
 namespace llarp
 {
-  /// label functors
-
-  /// PKE(result, publickey, secretkey, nonce)
-  using path_dh_func = std::function< bool(byte_t *, const byte_t *,
-                                           const byte_t *, const byte_t *) >;
-
-  /// TKE(result, publickey, secretkey, nonce)
-  using transport_dh_func = std::function< bool(
-      byte_t *, const byte_t *, const byte_t *, const byte_t *) >;
-
-  /// SD/SE(buffer, key, nonce)
-  using sym_cipher_func =
-      std::function< bool(llarp_buffer_t, const byte_t *, const byte_t *) >;
-
-  /// SD/SE(dst, src, key, nonce)
-  using sym_ciper_alt_func = std::function< bool(
-      llarp_buffer_t, llarp_buffer_t, const byte_t *, const byte_t *) >;
-
-  /// H(result, body)
-  using hash_func = std::function< bool(byte_t *, llarp_buffer_t) >;
-
-  /// SH(result, body)
-  using shorthash_func = std::function< bool(byte_t *, llarp_buffer_t) >;
-
-  /// MDS(result, body, shared_secret)
-  using hmac_func =
-      std::function< bool(byte_t *, llarp_buffer_t, const byte_t *) >;
-
-  /// S(sig, secretkey, body)
-  using sign_func =
-      std::function< bool(byte_t *, const byte_t *, llarp_buffer_t) >;
-
-  /// V(pubkey, body, sig)
-  using verify_func =
-      std::function< bool(const byte_t *, llarp_buffer_t, const byte_t *) >;
-
-  /// library crypto configuration
-  struct Crypto
-  {
-    /// xchacha symettric cipher
-    sym_cipher_func xchacha20;
-    /// xchacha symettric cipher (multibuffer)
-    sym_ciper_alt_func xchacha20_alt;
-    /// path dh creator's side
-    path_dh_func dh_client;
-    /// path dh relay side
-    path_dh_func dh_server;
-    /// transport dh client side
-    transport_dh_func transport_dh_client;
-    /// transport dh server side
-    transport_dh_func transport_dh_server;
-    /// blake2b 512 bit
-    hash_func hash;
-    /// blake2b 256 bit
-    shorthash_func shorthash;
-    /// blake2s 256 bit hmac
-    hmac_func hmac;
-    /// ed25519 sign
-    sign_func sign;
-    /// ed25519 verify
-    verify_func verify;
-    /// randomize buffer
-    std::function< void(llarp_buffer_t) > randomize;
-    /// randomizer memory
-    std::function< void(void *, size_t) > randbytes;
-    /// generate signing keypair
-    std::function< void(byte_t *) > identity_keygen;
-    /// generate encryption keypair
-    std::function< void(byte_t *) > encryption_keygen;
-    /// generate post quantum encrytion key
-    std::function< void(byte_t *) > pqe_keygen;
-    /// post quantum decrypt (buffer, sharedkey_dst, sec)
-    std::function< bool(const byte_t *, byte_t *, const byte_t *) > pqe_decrypt;
-    /// post quantum encrypt (buffer, sharedkey_dst,  pub)
-    std::function< bool(byte_t *, byte_t *, const byte_t *) > pqe_encrypt;
-
-    // Give a basic type tag for the constructor to pick libsodium
-    struct sodium
-    {
-    };
-
-    Crypto(Crypto::sodium tag);
-  };
-
-  /// return random 64bit unsigned interger
-  uint64_t
-  randint();
-
-  const byte_t *
-  seckey_topublic(const byte_t *secret);
-
-  const byte_t *
-  pq_keypair_to_public(const byte_t *keypair);
-
-  const byte_t *
-  pq_keypair_to_secret(const byte_t *keypair);
-
   using SharedSecret     = AlignedBuffer< SHAREDKEYSIZE >;
   using KeyExchangeNonce = AlignedBuffer< 32 >;
 
   struct PubKey final : public AlignedBuffer< PUBKEYSIZE >
   {
-    PubKey() : AlignedBuffer< SIZE >(){}
-    PubKey(const byte_t *ptr) : AlignedBuffer< SIZE >(ptr){}
-    PubKey(const Data& data) : AlignedBuffer< SIZE >(data){}
+    PubKey() : AlignedBuffer< SIZE >()
+    {
+    }
+    PubKey(const byte_t *ptr) : AlignedBuffer< SIZE >(ptr)
+    {
+    }
+    PubKey(const Data &data) : AlignedBuffer< SIZE >(data)
+    {
+    }
 
     std::string
     ToString() const;
@@ -203,6 +112,105 @@ namespace llarp
   using PQCipherBlock = AlignedBuffer< PQ_CIPHERTEXTSIZE + 1 >;
   using PQPubKey      = AlignedBuffer< PQ_PUBKEYSIZE >;
   using PQKeyPair     = AlignedBuffer< PQ_KEYPAIRSIZE >;
+
+  /// label functors
+
+  /// PKE(result, publickey, secretkey, nonce)
+  using path_dh_func = std::function< bool(SharedSecret &, const PubKey &,
+                                           const byte_t *, const byte_t *) >;
+
+  /// TKE(result, publickey, secretkey, nonce)
+  using transport_dh_func = std::function< bool(
+      SharedSecret &, const PubKey &, const byte_t *, const byte_t *) >;
+
+  /// SD/SE(buffer, key, nonce)
+  using sym_cipher_func =
+      std::function< bool(llarp_buffer_t, const byte_t *, const byte_t *) >;
+
+  /// SD/SE(dst, src, key, nonce)
+  using sym_cipher_alt_func = std::function< bool(
+      llarp_buffer_t, llarp_buffer_t, const byte_t *, const byte_t *) >;
+
+  /// H(result, body)
+  using hash_func = std::function< bool(byte_t *, llarp_buffer_t) >;
+
+  /// SH(result, body)
+  using shorthash_func = std::function< bool(ShortHash &, llarp_buffer_t) >;
+
+  /// MDS(result, body, shared_secret)
+  using hmac_func =
+      std::function< bool(byte_t *, llarp_buffer_t, const SharedSecret &) >;
+
+  /// S(sig, secretkey, body)
+  using sign_func =
+      std::function< bool(Signature &, const SecretKey &, llarp_buffer_t) >;
+
+  /// V(pubkey, body, sig)
+  using verify_func =
+      std::function< bool(const PubKey &, llarp_buffer_t, const byte_t *) >;
+
+  /// library crypto configuration
+  struct Crypto
+  {
+    /// xchacha symmetric cipher
+    sym_cipher_func xchacha20;
+    /// xchacha symmetric cipher (multibuffer)
+    sym_cipher_alt_func xchacha20_alt;
+    /// path dh creator's side
+    path_dh_func dh_client;
+    /// path dh relay side
+    path_dh_func dh_server;
+    /// transport dh client side
+    transport_dh_func transport_dh_client;
+    /// transport dh server side
+    transport_dh_func transport_dh_server;
+    /// blake2b 512 bit
+    hash_func hash;
+    /// blake2b 256 bit
+    shorthash_func shorthash;
+    /// blake2s 256 bit hmac
+    hmac_func hmac;
+    /// ed25519 sign
+    sign_func sign;
+    /// ed25519 verify
+    verify_func verify;
+    /// randomize buffer
+    std::function< void(llarp_buffer_t) > randomize;
+    /// randomizer memory
+    std::function< void(void *, size_t) > randbytes;
+    /// generate signing keypair
+    std::function< void(SecretKey &) > identity_keygen;
+    /// generate encryption keypair
+    std::function< void(SecretKey &) > encryption_keygen;
+    /// generate post quantum encrytion key
+    std::function< void(PQKeyPair &) > pqe_keygen;
+    /// post quantum decrypt (buffer, sharedkey_dst, sec)
+    std::function< bool(const PQCipherBlock &, SharedSecret &, const byte_t *) >
+        pqe_decrypt;
+    /// post quantum encrypt (buffer, sharedkey_dst,  pub)
+    std::function< bool(PQCipherBlock &, SharedSecret &, const byte_t *) >
+        pqe_encrypt;
+
+    // Give a basic type tag for the constructor to pick libsodium
+    struct sodium
+    {
+    };
+
+    Crypto(Crypto::sodium tag);
+  };
+
+  /// return random 64bit unsigned interger
+  uint64_t
+  randint();
+
+  const byte_t *
+  seckey_topublic(const byte_t *secret);
+
+  const byte_t *
+  pq_keypair_to_public(const byte_t *keypair);
+
+  const byte_t *
+  pq_keypair_to_secret(const byte_t *keypair);
 
 }  // namespace llarp
 

--- a/llarp/crypto.hpp
+++ b/llarp/crypto.hpp
@@ -48,10 +48,17 @@ namespace llarp
     PubKey() : AlignedBuffer< SIZE >()
     {
     }
-    PubKey(const byte_t *ptr) : AlignedBuffer< SIZE >(ptr)
+
+    explicit PubKey(const byte_t *ptr) : AlignedBuffer< SIZE >(ptr)
     {
     }
-    PubKey(const Data &data) : AlignedBuffer< SIZE >(data)
+
+    explicit PubKey(const Data &data) : AlignedBuffer< SIZE >(data)
+    {
+    }
+
+    explicit PubKey(const AlignedBuffer< SIZE > &other)
+        : AlignedBuffer< SIZE >(other)
     {
     }
 
@@ -87,6 +94,12 @@ namespace llarp
     {
       // make sure we never print out secret keys
       return out << "[secretkey]";
+    }
+
+    PubKey
+    toPublic() const
+    {
+      return PubKey(data() + 32);
     }
 
     bool

--- a/llarp/crypto.hpp
+++ b/llarp/crypto.hpp
@@ -75,7 +75,7 @@ namespace llarp
     PubKey &
     operator=(const byte_t *ptr)
     {
-      std::copy(ptr, ptr + SIZE, as_array().begin());
+      std::copy(ptr, ptr + SIZE, begin());
       return *this;
     }
   };
@@ -98,7 +98,7 @@ namespace llarp
     SecretKey &
     operator=(const byte_t *ptr)
     {
-      std::copy(ptr, ptr + SIZE, as_array().begin());
+      std::copy(ptr, ptr + SIZE, begin());
       return *this;
     }
   };
@@ -116,20 +116,20 @@ namespace llarp
   /// label functors
 
   /// PKE(result, publickey, secretkey, nonce)
-  using path_dh_func = std::function< bool(SharedSecret &, const PubKey &,
-                                           const byte_t *, const byte_t *) >;
+  using path_dh_func = std::function< bool(
+      SharedSecret &, const PubKey &, const SecretKey &, const TunnelNonce &) >;
 
   /// TKE(result, publickey, secretkey, nonce)
   using transport_dh_func = std::function< bool(
-      SharedSecret &, const PubKey &, const byte_t *, const byte_t *) >;
+      SharedSecret &, const PubKey &, const SecretKey &, const TunnelNonce &) >;
 
   /// SD/SE(buffer, key, nonce)
-  using sym_cipher_func =
-      std::function< bool(llarp_buffer_t, const byte_t *, const byte_t *) >;
+  using sym_cipher_func = std::function< bool(
+      llarp_buffer_t, const SharedSecret &, const TunnelNonce &) >;
 
   /// SD/SE(dst, src, key, nonce)
   using sym_cipher_alt_func = std::function< bool(
-      llarp_buffer_t, llarp_buffer_t, const byte_t *, const byte_t *) >;
+      llarp_buffer_t, llarp_buffer_t, const SharedSecret &, const byte_t *) >;
 
   /// H(result, body)
   using hash_func = std::function< bool(byte_t *, llarp_buffer_t) >;
@@ -147,7 +147,7 @@ namespace llarp
 
   /// V(pubkey, body, sig)
   using verify_func =
-      std::function< bool(const PubKey &, llarp_buffer_t, const byte_t *) >;
+      std::function< bool(const PubKey &, llarp_buffer_t, const Signature &) >;
 
   /// library crypto configuration
   struct Crypto
@@ -188,7 +188,7 @@ namespace llarp
     std::function< bool(const PQCipherBlock &, SharedSecret &, const byte_t *) >
         pqe_decrypt;
     /// post quantum encrypt (buffer, sharedkey_dst,  pub)
-    std::function< bool(PQCipherBlock &, SharedSecret &, const byte_t *) >
+    std::function< bool(PQCipherBlock &, SharedSecret &, const PQPubKey &) >
         pqe_encrypt;
 
     // Give a basic type tag for the constructor to pick libsodium
@@ -204,13 +204,13 @@ namespace llarp
   randint();
 
   const byte_t *
-  seckey_topublic(const byte_t *secret);
+  seckey_topublic(const SecretKey &secret);
 
   const byte_t *
-  pq_keypair_to_public(const byte_t *keypair);
+  pq_keypair_to_public(const PQKeyPair &keypair);
 
   const byte_t *
-  pq_keypair_to_secret(const byte_t *keypair);
+  pq_keypair_to_secret(const PQKeyPair &keypair);
 
 }  // namespace llarp
 

--- a/llarp/crypto.hpp
+++ b/llarp/crypto.hpp
@@ -142,8 +142,9 @@ namespace llarp
 
   struct PubKey final : public AlignedBuffer< PUBKEYSIZE >
   {
-    PubKey() : AlignedBuffer< PUBKEYSIZE >(){};
-    PubKey(const byte_t *ptr) : AlignedBuffer< PUBKEYSIZE >(ptr){};
+    PubKey() : AlignedBuffer< SIZE >(){}
+    PubKey(const byte_t *ptr) : AlignedBuffer< SIZE >(ptr){}
+    PubKey(const Data& data) : AlignedBuffer< SIZE >(data){}
 
     std::string
     ToString() const;
@@ -159,13 +160,13 @@ namespace llarp
 
     operator RouterID() const
     {
-      return RouterID(data());
+      return RouterID(as_array());
     }
 
     PubKey &
     operator=(const byte_t *ptr)
     {
-      memcpy(data(), ptr, size());
+      std::copy(ptr, ptr + SIZE, as_array().begin());
       return *this;
     }
   };
@@ -188,7 +189,7 @@ namespace llarp
     SecretKey &
     operator=(const byte_t *ptr)
     {
-      memcpy(data(), ptr, size());
+      std::copy(ptr, ptr + SIZE, as_array().begin());
       return *this;
     }
   };

--- a/llarp/crypto_libsodium.cpp
+++ b/llarp/crypto_libsodium.cpp
@@ -21,8 +21,7 @@ namespace llarp
     xchacha20(llarp_buffer_t buff, const SharedSecret &k, const TunnelNonce &n)
     {
       return crypto_stream_xchacha20_xor(buff.base, buff.base, buff.sz,
-                                         n.data(),
-                                         k.data())
+                                         n.data(), k.data())
           == 0;
     }
 
@@ -32,8 +31,7 @@ namespace llarp
     {
       if(in.sz > out.sz)
         return false;
-      return crypto_stream_xchacha20_xor(out.base, in.base, in.sz, n,
-                                         k.data())
+      return crypto_stream_xchacha20_xor(out.base, in.base, in.sz, n, k.data())
           == 0;
     }
 
@@ -45,8 +43,7 @@ namespace llarp
       crypto_generichash_state h;
       const size_t outsz = SHAREDKEYSIZE;
 
-      if(crypto_scalarmult_curve25519(shared.data(),
-                                      usSec.data(), themPub))
+      if(crypto_scalarmult_curve25519(shared.data(), usSec.data(), themPub))
         return false;
       crypto_generichash_blake2b_init(&h, nullptr, 0U, outsz);
       crypto_generichash_blake2b_update(&h, client_pk.data(), 32);
@@ -62,11 +59,9 @@ namespace llarp
     {
       llarp::SharedSecret dh_result;
 
-      if(dh(dh_result, llarp::seckey_topublic(sk), pk.data(),
-            pk.data(), sk))
+      if(dh(dh_result, sk.toPublic(), pk, pk.data(), sk))
       {
-        return crypto_generichash_blake2b(shared.data(), 32,
-                                          n.data(), 32,
+        return crypto_generichash_blake2b(shared.data(), 32, n.data(), 32,
                                           dh_result.data(), 32)
             != -1;
       }
@@ -79,11 +74,9 @@ namespace llarp
               const SecretKey &sk, const TunnelNonce &n)
     {
       llarp::SharedSecret dh_result;
-      if(dh(dh_result, pk, llarp::seckey_topublic(sk), pk.data(),
-            sk))
+      if(dh(dh_result, pk, sk.toPublic(), pk.data(), sk))
       {
-        return crypto_generichash_blake2b(shared.data(), 32,
-                                          n.data(), 32,
+        return crypto_generichash_blake2b(shared.data(), 32, n.data(), 32,
                                           dh_result.data(), 32)
             != -1;
       }
@@ -102,9 +95,8 @@ namespace llarp
     static bool
     shorthash(ShortHash &result, llarp_buffer_t buff)
     {
-      return crypto_generichash_blake2b(result.data(),
-                                        ShortHash::SIZE, buff.base, buff.sz,
-                                        nullptr, 0)
+      return crypto_generichash_blake2b(result.data(), ShortHash::SIZE,
+                                        buff.base, buff.sz, nullptr, 0)
           != -1;
     }
 
@@ -119,17 +111,16 @@ namespace llarp
     static bool
     sign(Signature &result, const SecretKey &secret, llarp_buffer_t buff)
     {
-      int rc =
-          crypto_sign_detached(result.data(), nullptr, buff.base,
-                               buff.sz, secret.data());
+      int rc = crypto_sign_detached(result.data(), nullptr, buff.base, buff.sz,
+                                    secret.data());
       return rc != -1;
     }
 
     static bool
     verify(const PubKey &pub, llarp_buffer_t buff, const Signature &sig)
     {
-      int rc = crypto_sign_verify_detached(sig.data(), buff.base,
-                                           buff.sz, pub.data());
+      int rc = crypto_sign_verify_detached(sig.data(), buff.base, buff.sz,
+                                           pub.data());
       return rc != -1;
     }
 
@@ -173,17 +164,14 @@ namespace llarp
     encrypt(PQCipherBlock &ciphertext, SharedSecret &sharedkey,
             const PQPubKey &pubkey)
     {
-      return crypto_kem_enc(ciphertext.data(),
-                            sharedkey.data(),
-                            pubkey.data())
+      return crypto_kem_enc(ciphertext.data(), sharedkey.data(), pubkey.data())
           != -1;
     }
     bool
     decrypt(const PQCipherBlock &ciphertext, SharedSecret &sharedkey,
             const byte_t *secretkey)
     {
-      return crypto_kem_dec(sharedkey.data(),
-                            ciphertext.data(), secretkey)
+      return crypto_kem_dec(sharedkey.data(), ciphertext.data(), secretkey)
           != -1;
     }
 

--- a/llarp/crypto_libsodium.cpp
+++ b/llarp/crypto_libsodium.cpp
@@ -18,49 +18,56 @@ namespace llarp
   namespace sodium
   {
     static bool
-    xchacha20(llarp_buffer_t buff, const byte_t *k, const byte_t *n)
+    xchacha20(llarp_buffer_t buff, const SharedSecret &k, const TunnelNonce &n)
     {
-      return crypto_stream_xchacha20_xor(buff.base, buff.base, buff.sz, n, k)
+      return crypto_stream_xchacha20_xor(buff.base, buff.base, buff.sz,
+                                         n.data(),
+                                         k.data())
           == 0;
     }
 
     static bool
-    xchacha20_alt(llarp_buffer_t out, llarp_buffer_t in, const byte_t *k,
+    xchacha20_alt(llarp_buffer_t out, llarp_buffer_t in, const SharedSecret &k,
                   const byte_t *n)
     {
       if(in.sz > out.sz)
         return false;
-      return crypto_stream_xchacha20_xor(out.base, in.base, in.sz, n, k) == 0;
+      return crypto_stream_xchacha20_xor(out.base, in.base, in.sz, n,
+                                         k.data())
+          == 0;
     }
 
     static bool
     dh(llarp::SharedSecret &out, const PubKey &client_pk,
-       const uint8_t *server_pk, const uint8_t *themPub, const uint8_t *usSec)
+       const PubKey &server_pk, const uint8_t *themPub, const SecretKey &usSec)
     {
       llarp::SharedSecret shared;
       crypto_generichash_state h;
       const size_t outsz = SHAREDKEYSIZE;
 
-      if(crypto_scalarmult_curve25519(shared.as_array().data(), usSec, themPub))
+      if(crypto_scalarmult_curve25519(shared.data(),
+                                      usSec.data(), themPub))
         return false;
       crypto_generichash_blake2b_init(&h, nullptr, 0U, outsz);
-      crypto_generichash_blake2b_update(&h, client_pk.as_array().data(), 32);
-      crypto_generichash_blake2b_update(&h, server_pk, 32);
-      crypto_generichash_blake2b_update(&h, shared, 32);
-      crypto_generichash_blake2b_final(&h, out.as_array().data(), outsz);
+      crypto_generichash_blake2b_update(&h, client_pk.data(), 32);
+      crypto_generichash_blake2b_update(&h, server_pk.data(), 32);
+      crypto_generichash_blake2b_update(&h, shared.data(), 32);
+      crypto_generichash_blake2b_final(&h, out.data(), outsz);
       return true;
     }
 
     static bool
-    dh_client(llarp::SharedSecret &shared, const PubKey &pk, const uint8_t *sk,
-              const uint8_t *n)
+    dh_client(llarp::SharedSecret &shared, const PubKey &pk,
+              const SecretKey &sk, const TunnelNonce &n)
     {
       llarp::SharedSecret dh_result;
 
-      if(dh(dh_result, llarp::seckey_topublic(sk), pk, pk, sk))
+      if(dh(dh_result, llarp::seckey_topublic(sk), pk.data(),
+            pk.data(), sk))
       {
-        return crypto_generichash_blake2b(shared.as_array().data(), 32, n, 32,
-                                          dh_result, 32)
+        return crypto_generichash_blake2b(shared.data(), 32,
+                                          n.data(), 32,
+                                          dh_result.data(), 32)
             != -1;
       }
       llarp::LogWarn("crypto::dh_client - dh failed");
@@ -68,14 +75,16 @@ namespace llarp
     }
 
     static bool
-    dh_server(llarp::SharedSecret &shared, const uint8_t *pk, const uint8_t *sk,
-              const uint8_t *n)
+    dh_server(llarp::SharedSecret &shared, const PubKey &pk,
+              const SecretKey &sk, const TunnelNonce &n)
     {
       llarp::SharedSecret dh_result;
-      if(dh(dh_result, pk, llarp::seckey_topublic(sk), pk, sk))
+      if(dh(dh_result, pk, llarp::seckey_topublic(sk), pk.data(),
+            sk))
       {
-        return crypto_generichash_blake2b(shared.as_array().data(), 32, n, 32,
-                                          dh_result, 32)
+        return crypto_generichash_blake2b(shared.data(), 32,
+                                          n.data(), 32,
+                                          dh_result.data(), 32)
             != -1;
       }
       llarp::LogWarn("crypto::dh_server - dh failed");
@@ -93,7 +102,7 @@ namespace llarp
     static bool
     shorthash(ShortHash &result, llarp_buffer_t buff)
     {
-      return crypto_generichash_blake2b(result.as_array().data(),
+      return crypto_generichash_blake2b(result.data(),
                                         ShortHash::SIZE, buff.base, buff.sz,
                                         nullptr, 0)
           != -1;
@@ -103,24 +112,25 @@ namespace llarp
     hmac(byte_t *result, llarp_buffer_t buff, const SharedSecret &secret)
     {
       return crypto_generichash_blake2b(result, HMACSIZE, buff.base, buff.sz,
-                                        secret.as_array().data(), HMACSECSIZE)
+                                        secret.data(), HMACSECSIZE)
           != -1;
     }
 
     static bool
     sign(Signature &result, const SecretKey &secret, llarp_buffer_t buff)
     {
-      return crypto_sign_detached(result.as_array().begin(), nullptr, buff.base,
-                                  buff.sz, secret.as_array().begin())
-          != -1;
+      int rc =
+          crypto_sign_detached(result.data(), nullptr, buff.base,
+                               buff.sz, secret.data());
+      return rc != -1;
     }
 
     static bool
-    verify(const PubKey &pub, llarp_buffer_t buff, const uint8_t *sig)
+    verify(const PubKey &pub, llarp_buffer_t buff, const Signature &sig)
     {
-      return crypto_sign_verify_detached(sig, buff.base, buff.sz,
-                                         pub.as_array().data())
-          != -1;
+      int rc = crypto_sign_verify_detached(sig.data(), buff.base,
+                                           buff.sz, pub.data());
+      return rc != -1;
     }
 
     static void
@@ -138,62 +148,63 @@ namespace llarp
     static void
     sigkeygen(llarp::SecretKey &keys)
     {
-      auto d = keys.as_array().data();
+      byte_t *d = keys.data();
       crypto_sign_keypair(d + 32, d);
     }
 
     static void
     enckeygen(llarp::SecretKey &keys)
     {
-      auto d = keys.as_array().data();
+      auto d = keys.data();
       randombytes(d, 32);
       crypto_scalarmult_curve25519_base(d + 32, d);
     }
   }  // namespace sodium
 
   const byte_t *
-  seckey_topublic(const byte_t *sec)
+  seckey_topublic(const SecretKey &sec)
   {
-    return sec + 32;
+    return sec.data() + 32;
   }
 
   namespace pq
   {
     bool
     encrypt(PQCipherBlock &ciphertext, SharedSecret &sharedkey,
-            const byte_t *pubkey)
+            const PQPubKey &pubkey)
     {
-      return crypto_kem_enc(ciphertext.as_array().data(),
-                            sharedkey.as_array().data(), pubkey)
+      return crypto_kem_enc(ciphertext.data(),
+                            sharedkey.data(),
+                            pubkey.data())
           != -1;
     }
     bool
     decrypt(const PQCipherBlock &ciphertext, SharedSecret &sharedkey,
             const byte_t *secretkey)
     {
-      return crypto_kem_dec(sharedkey.as_array().data(),
-                            ciphertext.as_array().data(), secretkey)
+      return crypto_kem_dec(sharedkey.data(),
+                            ciphertext.data(), secretkey)
           != -1;
     }
 
     void
     keygen(PQKeyPair &keypair)
     {
-      auto d = keypair.as_array().data();
+      auto d = keypair.data();
       crypto_kem_keypair(d + PQ_SECRETKEYSIZE, d);
     }
   }  // namespace pq
 
   const byte_t *
-  pq_keypair_to_public(const byte_t *k)
+  pq_keypair_to_public(const PQKeyPair &k)
   {
-    return k + PQ_SECRETKEYSIZE;
+    return k.data() + PQ_SECRETKEYSIZE;
   }
 
   const byte_t *
-  pq_keypair_to_secret(const byte_t *k)
+  pq_keypair_to_secret(const PQKeyPair &k)
   {
-    return k;
+    return k.data();
   }
 
   Crypto::Crypto(Crypto::sodium tag)

--- a/llarp/crypto_libsodium.cpp
+++ b/llarp/crypto_libsodium.cpp
@@ -34,32 +34,33 @@ namespace llarp
     }
 
     static bool
-    dh(uint8_t *out, const uint8_t *client_pk, const uint8_t *server_pk,
-       const uint8_t *themPub, const uint8_t *usSec)
+    dh(llarp::SharedSecret &out, const PubKey &client_pk,
+       const uint8_t *server_pk, const uint8_t *themPub, const uint8_t *usSec)
     {
       llarp::SharedSecret shared;
       crypto_generichash_state h;
       const size_t outsz = SHAREDKEYSIZE;
 
-      if(crypto_scalarmult_curve25519(shared, usSec, themPub))
+      if(crypto_scalarmult_curve25519(shared.as_array().data(), usSec, themPub))
         return false;
       crypto_generichash_blake2b_init(&h, nullptr, 0U, outsz);
-      crypto_generichash_blake2b_update(&h, client_pk, 32);
+      crypto_generichash_blake2b_update(&h, client_pk.as_array().data(), 32);
       crypto_generichash_blake2b_update(&h, server_pk, 32);
       crypto_generichash_blake2b_update(&h, shared, 32);
-      crypto_generichash_blake2b_final(&h, out, outsz);
+      crypto_generichash_blake2b_final(&h, out.as_array().data(), outsz);
       return true;
     }
 
     static bool
-    dh_client(uint8_t *shared, const uint8_t *pk, const uint8_t *sk,
+    dh_client(llarp::SharedSecret &shared, const PubKey &pk, const uint8_t *sk,
               const uint8_t *n)
     {
       llarp::SharedSecret dh_result;
 
       if(dh(dh_result, llarp::seckey_topublic(sk), pk, pk, sk))
       {
-        return crypto_generichash_blake2b(shared, 32, n, 32, dh_result, 32)
+        return crypto_generichash_blake2b(shared.as_array().data(), 32, n, 32,
+                                          dh_result, 32)
             != -1;
       }
       llarp::LogWarn("crypto::dh_client - dh failed");
@@ -67,13 +68,14 @@ namespace llarp
     }
 
     static bool
-    dh_server(uint8_t *shared, const uint8_t *pk, const uint8_t *sk,
+    dh_server(llarp::SharedSecret &shared, const uint8_t *pk, const uint8_t *sk,
               const uint8_t *n)
     {
       llarp::SharedSecret dh_result;
       if(dh(dh_result, pk, llarp::seckey_topublic(sk), pk, sk))
       {
-        return crypto_generichash_blake2b(shared, 32, n, 32, dh_result, 32)
+        return crypto_generichash_blake2b(shared.as_array().data(), 32, n, 32,
+                                          dh_result, 32)
             != -1;
       }
       llarp::LogWarn("crypto::dh_server - dh failed");
@@ -89,32 +91,36 @@ namespace llarp
     }
 
     static bool
-    shorthash(uint8_t *result, llarp_buffer_t buff)
+    shorthash(ShortHash &result, llarp_buffer_t buff)
     {
-      return crypto_generichash_blake2b(result, SHORTHASHSIZE, buff.base,
-                                        buff.sz, nullptr, 0)
+      return crypto_generichash_blake2b(result.as_array().data(),
+                                        ShortHash::SIZE, buff.base, buff.sz,
+                                        nullptr, 0)
           != -1;
     }
 
     static bool
-    hmac(uint8_t *result, llarp_buffer_t buff, const uint8_t *secret)
+    hmac(byte_t *result, llarp_buffer_t buff, const SharedSecret &secret)
     {
       return crypto_generichash_blake2b(result, HMACSIZE, buff.base, buff.sz,
-                                        secret, HMACSECSIZE)
+                                        secret.as_array().data(), HMACSECSIZE)
           != -1;
     }
 
     static bool
-    sign(uint8_t *result, const uint8_t *secret, llarp_buffer_t buff)
+    sign(Signature &result, const SecretKey &secret, llarp_buffer_t buff)
     {
-      return crypto_sign_detached(result, nullptr, buff.base, buff.sz, secret)
+      return crypto_sign_detached(result.as_array().begin(), nullptr, buff.base,
+                                  buff.sz, secret.as_array().begin())
           != -1;
     }
 
     static bool
-    verify(const uint8_t *pub, llarp_buffer_t buff, const uint8_t *sig)
+    verify(const PubKey &pub, llarp_buffer_t buff, const uint8_t *sig)
     {
-      return crypto_sign_verify_detached(sig, buff.base, buff.sz, pub) != -1;
+      return crypto_sign_verify_detached(sig, buff.base, buff.sz,
+                                         pub.as_array().data())
+          != -1;
     }
 
     static void
@@ -130,16 +136,18 @@ namespace llarp
     }
 
     static void
-    sigkeygen(uint8_t *keys)
+    sigkeygen(llarp::SecretKey &keys)
     {
-      crypto_sign_keypair(keys + 32, keys);
+      auto d = keys.as_array().data();
+      crypto_sign_keypair(d + 32, d);
     }
 
     static void
-    enckeygen(uint8_t *keys)
+    enckeygen(llarp::SecretKey &keys)
     {
-      randombytes(keys, 32);
-      crypto_scalarmult_curve25519_base(keys + 32, keys);
+      auto d = keys.as_array().data();
+      randombytes(d, 32);
+      crypto_scalarmult_curve25519_base(d + 32, d);
     }
   }  // namespace sodium
 
@@ -152,21 +160,27 @@ namespace llarp
   namespace pq
   {
     bool
-    encrypt(byte_t *ciphertext, byte_t *sharedkey, const byte_t *pubkey)
+    encrypt(PQCipherBlock &ciphertext, SharedSecret &sharedkey,
+            const byte_t *pubkey)
     {
-      return crypto_kem_enc(ciphertext, sharedkey, pubkey) != -1;
+      return crypto_kem_enc(ciphertext.as_array().data(),
+                            sharedkey.as_array().data(), pubkey)
+          != -1;
     }
     bool
-    decrypt(const byte_t *ciphertext, byte_t *sharedkey,
+    decrypt(const PQCipherBlock &ciphertext, SharedSecret &sharedkey,
             const byte_t *secretkey)
     {
-      return crypto_kem_dec(sharedkey, ciphertext, secretkey) != -1;
+      return crypto_kem_dec(sharedkey.as_array().data(),
+                            ciphertext.as_array().data(), secretkey)
+          != -1;
     }
 
     void
-    keygen(byte_t *keypair)
+    keygen(PQKeyPair &keypair)
     {
-      crypto_kem_keypair(keypair + PQ_SECRETKEYSIZE, keypair);
+      auto d = keypair.as_array().data();
+      crypto_kem_keypair(d + PQ_SECRETKEYSIZE, d);
     }
   }  // namespace pq
 

--- a/llarp/dht.cpp
+++ b/llarp/dht.cpp
@@ -22,7 +22,7 @@ llarp_dht_context_free(struct llarp_dht_context *ctx)
 void
 __llarp_dht_remove_peer(struct llarp_dht_context *ctx, const byte_t *id)
 {
-  ctx->impl.nodes->DelNode(id);
+  ctx->impl.nodes->DelNode(llarp::dht::Key_t(id));
 }
 
 void
@@ -34,7 +34,7 @@ llarp_dht_allow_transit(llarp_dht_context *ctx)
 void
 llarp_dht_context_start(struct llarp_dht_context *ctx, const byte_t *key)
 {
-  ctx->impl.Init(key, ctx->parent, 20000);
+  ctx->impl.Init(llarp::dht::Key_t(key), ctx->parent, 20000);
 }
 
 void

--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -92,8 +92,9 @@ namespace llarp
       uint64_t txid = ++ids;
       TXOwner peer(askpeer, txid);
       TXOwner whoasked(OurKey(), txid);
-      pendingExploreLookups.NewTX(peer, whoasked, askpeer.data(),
-                                  new ExploreNetworkJob(askpeer.data(), this));
+      pendingExploreLookups.NewTX(
+          peer, whoasked, askpeer.as_array(),
+          new ExploreNetworkJob(askpeer.as_array(), this));
     }
 
     void
@@ -211,8 +212,8 @@ namespace llarp
           // is the next peer we ask closer to the target than us?
           if((next ^ target) < (ourKey ^ target))
           {
-            // yes it is closer, ask neighboor recursively
-            LookupRouterRecursive(target.data(), requester, txid, next);
+            // yes it is closer, ask neighbour recursively
+            LookupRouterRecursive(target.as_array(), requester, txid, next);
           }
           else
           {
@@ -240,7 +241,8 @@ namespace llarp
     Context::GetIntroSetByServiceAddress(
         const llarp::service::Address &addr) const
     {
-      auto itr = services->nodes.find(addr.data());
+      auto key = addr.ToKey();
+      auto itr = services->nodes.find(key);
       if(itr == services->nodes.end())
         return nullptr;
       return &itr->second.introset;
@@ -343,7 +345,7 @@ namespace llarp
       bool
       GetNextPeer(Key_t &next, const std::set< Key_t > &exclude) override
       {
-        Key_t k = target.data();
+        Key_t k = target.ToKey();
         return parent->nodes->FindCloseExcluding(k, next, exclude);
       }
 
@@ -392,8 +394,8 @@ namespace llarp
       void
       SendReply() override
       {
-        auto path =
-            parent->router->paths.GetByUpstream(parent->OurKey(), localPath);
+        auto path = parent->router->paths.GetByUpstream(
+            parent->OurKey().as_array(), localPath);
         if(!path)
         {
           llarp::LogWarn(
@@ -619,8 +621,8 @@ namespace llarp
       void
       SendReply() override
       {
-        auto path =
-            parent->router->paths.GetByUpstream(parent->OurKey(), localPath);
+        auto path = parent->router->paths.GetByUpstream(
+            parent->OurKey().as_array(), localPath);
         if(!path)
         {
           llarp::LogWarn(
@@ -657,7 +659,7 @@ namespace llarp
         std::vector< std::unique_ptr< IMessage > > &reply)
     {
       std::vector< RouterID > closer;
-      Key_t t(target.data());
+      Key_t t(target.as_array());
       std::set< Key_t > found;
       if(!nodes)
         return false;
@@ -686,7 +688,7 @@ namespace llarp
         return false;
       }
       for(const auto &f : found)
-        closer.emplace_back(f.data());
+        closer.emplace_back(f.as_array());
       reply.emplace_back(new GotRouterMessage(txid, closer, false));
       return true;
     }
@@ -762,8 +764,8 @@ namespace llarp
       void
       SendReply() override
       {
-        auto path =
-            parent->router->paths.GetByUpstream(parent->OurKey(), localPath);
+        auto path = parent->router->paths.GetByUpstream(
+            parent->OurKey().as_array(), localPath);
         if(!path)
         {
           llarp::LogWarn(

--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -57,7 +57,8 @@ namespace llarp
       void
       Start(const TXOwner &peer) override
       {
-        parent->DHTSendTo(peer.node, new FindRouterMessage(peer.txid));
+        parent->DHTSendTo(peer.node.as_array(),
+                          new FindRouterMessage(peer.txid));
       }
 
       bool
@@ -284,7 +285,7 @@ namespace llarp
     }
 
     void
-    Context::DHTSendTo(const byte_t *peer, IMessage *msg, bool keepalive)
+    Context::DHTSendTo(const RouterID &peer, IMessage *msg, bool keepalive)
     {
       llarp::DHTImmeidateMessage m;
       m.msgs.emplace_back(msg);
@@ -352,7 +353,7 @@ namespace llarp
       void
       Start(const TXOwner &peer) override
       {
-        parent->DHTSendTo(peer.node,
+        parent->DHTSendTo(peer.node.as_array(),
                           new FindIntroMessage(peer.txid, target, R));
       }
 
@@ -373,7 +374,7 @@ namespace llarp
         if(handleResult)
           handleResult(valuesFound);
 
-        parent->DHTSendTo(whoasked.node,
+        parent->DHTSendTo(whoasked.node.as_array(),
                           new GotIntroMessage(valuesFound, whoasked.txid));
       }
     };
@@ -462,7 +463,7 @@ namespace llarp
         std::vector< Key_t > exclude;
         for(const auto &router : dontTell)
           exclude.push_back(router);
-        parent->DHTSendTo(peer.node,
+        parent->DHTSendTo(peer.node.as_array(),
                           new PublishIntroMessage(I, peer.txid, S, exclude));
       }
 
@@ -552,7 +553,7 @@ namespace llarp
       void
       Start(const TXOwner &peer) override
       {
-        parent->DHTSendTo(peer.node,
+        parent->DHTSendTo(peer.node.as_array(),
                           new FindIntroMessage(target, peer.txid, R));
       }
 
@@ -589,7 +590,7 @@ namespace llarp
         {
           values.push_back(introset);
         }
-        parent->DHTSendTo(whoasked.node,
+        parent->DHTSendTo(whoasked.node.as_array(),
                           new GotIntroMessage(values, whoasked.txid));
       }
     };
@@ -730,7 +731,7 @@ namespace llarp
       void
       Start(const TXOwner &peer) override
       {
-        parent->DHTSendTo(peer.node, new FindRouterMessage(peer.txid, target));
+        parent->DHTSendTo(peer.node.as_array(), new FindRouterMessage(peer.txid, target));
       }
 
       virtual void
@@ -743,7 +744,7 @@ namespace llarp
         else
         {
           parent->DHTSendTo(
-              whoasked.node,
+              whoasked.node.as_array(),
               new GotRouterMessage({}, whoasked.txid, valuesFound, false));
         }
       }

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -205,7 +205,7 @@ namespace llarp
       /// send a dht message to peer, if keepalive is true then keep the session
       /// with that peer alive for 10 seconds
       void
-      DHTSendTo(const byte_t* peer, IMessage* msg, bool keepalive = true);
+      DHTSendTo(const RouterID& peer, IMessage* msg, bool keepalive = true);
 
       /// get routers closest to target excluding requester
       bool

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -109,7 +109,7 @@ namespace llarp
           return false;
         }
 
-        const Key_t targetKey = target.as_array();
+        const Key_t targetKey{target};
         if((prevPeer ^ targetKey) < (peer ^ targetKey))
         {
           // next peer is not closer
@@ -168,7 +168,7 @@ namespace llarp
       LookupRouter(const RouterID& target, RouterLookupHandler result)
       {
         Key_t askpeer;
-        if(!nodes->FindClosest(target.as_array(), askpeer))
+        if(!nodes->FindClosest(Key_t(target), askpeer))
           return false;
         LookupRouterRecursive(target, OurKey(), 0, askpeer, result);
         return true;

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -100,7 +100,7 @@ namespace llarp
         if(next)
         {
           // explicit next peer provided
-          peer = next->data();
+          peer = *next;
         }
         else if(!GetNextPeer(peer, peersAsked))
         {
@@ -109,7 +109,7 @@ namespace llarp
           return false;
         }
 
-        const Key_t targetKey = target.data();
+        const Key_t targetKey = target.as_array();
         if((prevPeer ^ targetKey) < (peer ^ targetKey))
         {
           // next peer is not closer
@@ -118,7 +118,9 @@ namespace llarp
           return false;
         }
         else
+        {
           peersAsked.insert(peer);
+        }
         DoNextRequest(peer);
         return true;
       }
@@ -166,7 +168,7 @@ namespace llarp
       LookupRouter(const RouterID& target, RouterLookupHandler result)
       {
         Key_t askpeer;
-        if(!nodes->FindClosest(target.data(), askpeer))
+        if(!nodes->FindClosest(target.as_array(), askpeer))
           return false;
         LookupRouterRecursive(target, OurKey(), 0, askpeer, result);
         return true;
@@ -260,7 +262,7 @@ namespace llarp
       Bucket< ISNode >* services = nullptr;
       bool allowTransit          = false;
 
-      const byte_t*
+      const Key_t&
       OurKey() const
       {
         return ourKey;

--- a/llarp/dht/dht_immediate.cpp
+++ b/llarp/dht/dht_immediate.cpp
@@ -18,7 +18,8 @@ namespace llarp
   DHTImmeidateMessage::DecodeKey(llarp_buffer_t key, llarp_buffer_t *buf)
   {
     if(llarp_buffer_eq(key, "m"))
-      return llarp::dht::DecodeMesssageList(session->GetPubKey(), buf, msgs);
+      return llarp::dht::DecodeMesssageList(session->GetPubKey().as_array(),
+                                            buf, msgs);
     if(llarp_buffer_eq(key, "v"))
     {
       if(!bencode_read_integer(buf, &version))

--- a/llarp/dht/dht_immediate.cpp
+++ b/llarp/dht/dht_immediate.cpp
@@ -18,7 +18,7 @@ namespace llarp
   DHTImmeidateMessage::DecodeKey(llarp_buffer_t key, llarp_buffer_t *buf)
   {
     if(llarp_buffer_eq(key, "m"))
-      return llarp::dht::DecodeMesssageList(session->GetPubKey().as_array(),
+      return llarp::dht::DecodeMesssageList(dht::Key_t(session->GetPubKey()),
                                             buf, msgs);
     if(llarp_buffer_eq(key, "v"))
     {

--- a/llarp/dht/find_intro.cpp
+++ b/llarp/dht/find_intro.cpp
@@ -117,7 +117,7 @@ namespace llarp
           if(R == 0)
           {
             // we don't have it
-            Key_t target = S.data();
+            Key_t target = S.ToKey();
             Key_t closer;
             // find closer peer
             if(!dht.nodes->FindClosest(target, closer))
@@ -131,7 +131,7 @@ namespace llarp
           else
           {
             Key_t us     = dht.OurKey();
-            Key_t target = S.data();
+            Key_t target = S.ToKey();
             // we are recursive
             if(dht.nodes->FindCloseExcluding(target, peer, exclude))
             {

--- a/llarp/dht/find_router.cpp
+++ b/llarp/dht/find_router.cpp
@@ -75,7 +75,7 @@ namespace llarp
       // key
       if(!bencode_write_bytestring(buf, "K", 1))
         return false;
-      if(!bencode_write_bytestring(buf, K.as_array().data(), K.size()))
+      if(!bencode_write_bytestring(buf, K.data(), K.size()))
         return false;
 
       // txid
@@ -124,7 +124,7 @@ namespace llarp
         if(strbuf.sz != K.size())
           return false;
 
-        std::copy(strbuf.base, strbuf.base + K.SIZE, K.as_array().begin());
+        std::copy(strbuf.base, strbuf.base + K.SIZE, K.begin());
         return true;
       }
       if(llarp_buffer_eq(key, "T"))

--- a/llarp/dht/find_router.cpp
+++ b/llarp/dht/find_router.cpp
@@ -16,26 +16,25 @@ namespace llarp
       auto &dht = ctx->impl;
       /// lookup for us, send an immeidate reply
       Key_t us = dht.OurKey();
+      Key_t k{K};
       if(K == us)
       {
         auto path = dht.router->paths.GetByUpstream(K, pathID);
         if(path)
         {
-          replies.emplace_back(new GotRouterMessage(K.as_array(), txid,
-                                                    {dht.router->rc()}, false));
+          replies.emplace_back(
+              new GotRouterMessage(k, txid, {dht.router->rc()}, false));
           return true;
         }
         return false;
       }
 
       Key_t peer;
-      Key_t k = K.as_array();
       // check if we know this in our nodedb first
       RouterContact found;
       if(dht.router->nodedb->Get(K, found))
       {
-        replies.emplace_back(
-            new GotRouterMessage(K.as_array(), txid, {found}, false));
+        replies.emplace_back(new GotRouterMessage(k, txid, {found}, false));
         return true;
       }
       // lookup if we don't have it in our nodedb
@@ -156,16 +155,16 @@ namespace llarp
         return false;
       }
       RouterContact found;
+      Key_t k{K};
       if(exploritory)
         return dht.HandleExploritoryRouterLookup(From, txid, K, replies);
       else if(dht.router->nodedb->Get(K, found))
       {
-        replies.emplace_back(
-            new GotRouterMessage(K.as_array(), txid, {found}, false));
+        replies.emplace_back(new GotRouterMessage(k, txid, {found}, false));
         return true;
       }
       else
-        dht.LookupRouterRelayed(From, txid, K.as_array(), !iterative, replies);
+        dht.LookupRouterRelayed(From, txid, k, !iterative, replies);
       return true;
     }
   }  // namespace dht

--- a/llarp/dht/find_router.cpp
+++ b/llarp/dht/find_router.cpp
@@ -21,21 +21,21 @@ namespace llarp
         auto path = dht.router->paths.GetByUpstream(K, pathID);
         if(path)
         {
-          replies.emplace_back(
-              new GotRouterMessage(K.data(), txid, {dht.router->rc()}, false));
+          replies.emplace_back(new GotRouterMessage(K.as_array(), txid,
+                                                    {dht.router->rc()}, false));
           return true;
         }
         return false;
       }
 
       Key_t peer;
-      Key_t k = K.data();
+      Key_t k = K.as_array();
       // check if we know this in our nodedb first
       RouterContact found;
       if(dht.router->nodedb->Get(K, found))
       {
         replies.emplace_back(
-            new GotRouterMessage(K.data(), txid, {found}, false));
+            new GotRouterMessage(K.as_array(), txid, {found}, false));
         return true;
       }
       // lookup if we don't have it in our nodedb
@@ -75,7 +75,7 @@ namespace llarp
       // key
       if(!bencode_write_bytestring(buf, "K", 1))
         return false;
-      if(!bencode_write_bytestring(buf, K.data(), K.size()))
+      if(!bencode_write_bytestring(buf, K.as_array().data(), K.size()))
         return false;
 
       // txid
@@ -124,7 +124,7 @@ namespace llarp
         if(strbuf.sz != K.size())
           return false;
 
-        memcpy(K.data(), strbuf.base, K.size());
+        std::copy(strbuf.base, strbuf.base + K.SIZE, K.as_array().begin());
         return true;
       }
       if(llarp_buffer_eq(key, "T"))
@@ -161,11 +161,11 @@ namespace llarp
       else if(dht.router->nodedb->Get(K, found))
       {
         replies.emplace_back(
-            new GotRouterMessage(K.data(), txid, {found}, false));
+            new GotRouterMessage(K.as_array(), txid, {found}, false));
         return true;
       }
       else
-        dht.LookupRouterRelayed(From, txid, K.data(), !iterative, replies);
+        dht.LookupRouterRelayed(From, txid, K.as_array(), !iterative, replies);
       return true;
     }
   }  // namespace dht

--- a/llarp/dht/got_router.cpp
+++ b/llarp/dht/got_router.cpp
@@ -99,7 +99,7 @@ namespace llarp
           dht.pendingExploreLookups.NotFound(owner, K);
         else
         {
-          dht.pendingExploreLookups.Found(owner, From.data(), N);
+          dht.pendingExploreLookups.Found(owner, From.as_array(), N);
         }
         return true;
       }

--- a/llarp/dht/key.hpp
+++ b/llarp/dht/key.hpp
@@ -9,18 +9,22 @@ namespace llarp
 {
   namespace dht
   {
-    struct Key_t : public llarp::AlignedBuffer< 32 >
+    struct Key_t : public AlignedBuffer< 32 >
     {
-      Key_t(const byte_t* buf) : llarp::AlignedBuffer< SIZE >(buf)
+      explicit Key_t(const byte_t* buf) : AlignedBuffer< SIZE >(buf)
       {
       }
 
-      Key_t(const std::array< byte_t, SIZE >& val)
-          : llarp::AlignedBuffer< SIZE >(val)
+      explicit Key_t(const Data& val) : AlignedBuffer< SIZE >(val)
       {
       }
 
-      Key_t() : llarp::AlignedBuffer< SIZE >()
+      explicit Key_t(const AlignedBuffer< SIZE >& val)
+          : AlignedBuffer< SIZE >(val)
+      {
+      }
+
+      Key_t() : AlignedBuffer< SIZE >()
       {
       }
 
@@ -28,8 +32,7 @@ namespace llarp
       operator^(const Key_t& other) const
       {
         Key_t dist;
-        std::transform(begin(), end(),
-                       other.begin(), dist.begin(),
+        std::transform(begin(), end(), other.begin(), dist.begin(),
                        std::bit_xor< byte_t >());
         return dist;
       }

--- a/llarp/dht/key.hpp
+++ b/llarp/dht/key.hpp
@@ -28,8 +28,8 @@ namespace llarp
       operator^(const Key_t& other) const
       {
         Key_t dist;
-        std::transform(as_array().begin(), as_array().end(),
-                       other.as_array().begin(), dist.as_array().begin(),
+        std::transform(begin(), end(),
+                       other.begin(), dist.begin(),
                        std::bit_xor< byte_t >());
         return dist;
       }

--- a/llarp/dht/node.hpp
+++ b/llarp/dht/node.hpp
@@ -23,7 +23,7 @@ namespace llarp
       RCNode(const llarp::RouterContact& other)
       {
         rc = other;
-        ID = other.pubkey.data();
+        ID = other.pubkey.as_array();
       }
 
       bool
@@ -47,7 +47,7 @@ namespace llarp
       ISNode(const llarp::service::IntroSet& other)
       {
         introset = other;
-        introset.A.CalculateAddress(ID);
+        introset.A.CalculateAddress(ID.as_array());
       }
 
       bool

--- a/llarp/dht/node.hpp
+++ b/llarp/dht/node.hpp
@@ -20,10 +20,8 @@ namespace llarp
         ID.Zero();
       }
 
-      RCNode(const llarp::RouterContact& other)
+      RCNode(const llarp::RouterContact& other) : rc(other), ID(other.pubkey)
       {
-        rc = other;
-        ID = other.pubkey.as_array();
       }
 
       bool

--- a/llarp/dht/publish_intro.cpp
+++ b/llarp/dht/publish_intro.cpp
@@ -65,7 +65,7 @@ namespace llarp
         return true;
       }
       llarp::dht::Key_t addr;
-      if(!I.A.CalculateAddress(addr))
+      if(!I.A.CalculateAddress(addr.as_array()))
       {
         llarp::LogWarn(
             "failed to calculate hidden service address for PubIntro message");

--- a/llarp/dns_dotlokilookup.cpp
+++ b/llarp/dns_dotlokilookup.cpp
@@ -46,7 +46,7 @@ decode_request_name(const std::string &name, llarp::AlignedBuffer< 32 > &addr,
     {
       return false;
     }
-    addr    = snodeAddr.as_array();
+    addr    = snodeAddr;
     isSNode = true;
   }
   else
@@ -55,7 +55,7 @@ decode_request_name(const std::string &name, llarp::AlignedBuffer< 32 > &addr,
     {
       return false;
     }
-    addr    = serviceAddr.as_array();
+    addr    = serviceAddr;
     isSNode = false;
   }
   return true;
@@ -330,7 +330,7 @@ ReverseHandlerIter(struct llarp::service::Context::endpoint_iter *endpointCfg)
     }
     else
     {
-      llarp::service::Address saddr = addr.as_array();
+      llarp::service::Address saddr(addr);
       // llarp::LogInfo("Returning [", saddr.ToString(), "]");
       writesend_dnss_revresponse(saddr.ToString(), context->request);
     }
@@ -457,7 +457,7 @@ llarp_dotlokilookup_handler(std::string name,
     }
     else
     {
-      if(tun->HasPathToService(addr.as_array()))
+      if(tun->HasPathToService(llarp::service::Address(addr)))
       {
         llarp_dotlokilookup_checkQuery(qr, 0, 0);
         response->dontSendResponse = true;  // will send it shortly

--- a/llarp/dns_dotlokilookup.cpp
+++ b/llarp/dns_dotlokilookup.cpp
@@ -41,8 +41,8 @@ decode_request_name(const std::string &name, llarp::AlignedBuffer< 32 > &addr,
   auto pos = name.find(".snode");
   if(pos != std::string::npos)
   {
-    if(!llarp::HexDecode(name.substr(0, pos).c_str(),
-                         serviceAddr.as_array().data(), serviceAddr.size()))
+    if(!llarp::HexDecode(name.substr(0, pos).c_str(), serviceAddr.begin(),
+                         serviceAddr.size()))
     {
       return false;
     }

--- a/llarp/dns_dotlokilookup.cpp
+++ b/llarp/dns_dotlokilookup.cpp
@@ -41,12 +41,12 @@ decode_request_name(const std::string &name, llarp::AlignedBuffer< 32 > &addr,
   auto pos = name.find(".snode");
   if(pos != std::string::npos)
   {
-    if(!llarp::HexDecode(name.substr(0, pos).c_str(), serviceAddr.data().data(),
-                         serviceAddr.size()))
+    if(!llarp::HexDecode(name.substr(0, pos).c_str(),
+                         serviceAddr.as_array().data(), serviceAddr.size()))
     {
       return false;
     }
-    addr    = snodeAddr.data();
+    addr    = snodeAddr.as_array();
     isSNode = true;
   }
   else
@@ -55,7 +55,7 @@ decode_request_name(const std::string &name, llarp::AlignedBuffer< 32 > &addr,
     {
       return false;
     }
-    addr    = serviceAddr.data().data();
+    addr    = serviceAddr.as_array();
     isSNode = false;
   }
   return true;
@@ -330,7 +330,7 @@ ReverseHandlerIter(struct llarp::service::Context::endpoint_iter *endpointCfg)
     }
     else
     {
-      llarp::service::Address saddr = addr.data();
+      llarp::service::Address saddr = addr.as_array();
       // llarp::LogInfo("Returning [", saddr.ToString(), "]");
       writesend_dnss_revresponse(saddr.ToString(), context->request);
     }
@@ -448,7 +448,7 @@ llarp_dotlokilookup_handler(std::string name,
     auto tun = routerHiddenServiceContext->getFirstTun();
     if(isSNode)
     {
-      if(tun->HasPathToSNode(addr.data()))
+      if(tun->HasPathToSNode(addr.as_array()))
       {
         llarp_dotlokilookup_checkQuery(qr, 0, 0);
         response->dontSendResponse = true;  // will send it shortly
@@ -457,7 +457,7 @@ llarp_dotlokilookup_handler(std::string name,
     }
     else
     {
-      if(tun->HasPathToService(addr.data()))
+      if(tun->HasPathToService(addr.as_array()))
       {
         llarp_dotlokilookup_checkQuery(qr, 0, 0);
         response->dontSendResponse = true;  // will send it shortly

--- a/llarp/encode.cpp
+++ b/llarp/encode.cpp
@@ -14,16 +14,4 @@ namespace llarp
       return input - 'a' + 10;
     return 0;
   }
-
-  bool
-  HexDecode(const char* src, uint8_t* target, size_t sz)
-  {
-    while(*src && src[1] && sz)
-    {
-      *(target++) = char2int(*src) * 16 + char2int(src[1]);
-      src += 2;
-      --sz;
-    }
-    return sz == 0;
-  }
 }  // namespace llarp

--- a/llarp/encode.hpp
+++ b/llarp/encode.hpp
@@ -133,8 +133,19 @@ namespace llarp
   int
   char2int(char input);
 
+  template < typename OutputIt >
   bool
-  HexDecode(const char* src, uint8_t* target, size_t sz);
+  HexDecode(const char* src, OutputIt target, size_t sz)
+  {
+    while(*src && src[1] && sz)
+    {
+      *(target++) = char2int(*src) * 16 + char2int(src[1]);
+      src += 2;
+      --sz;
+    }
+    return sz == 0;
+  }
+
 }  // namespace llarp
 
 #endif

--- a/llarp/encrypted_frame.cpp
+++ b/llarp/encrypted_frame.cpp
@@ -6,8 +6,8 @@
 namespace llarp
 {
   bool
-  EncryptedFrame::EncryptInPlace(const byte_t* ourSecretKey,
-                                 const byte_t* otherPubkey,
+  EncryptedFrame::EncryptInPlace(const SecretKey& ourSecretKey,
+                                 const PubKey& otherPubkey,
                                  llarp::Crypto* crypto)
   {
     // format of frame is
@@ -65,7 +65,7 @@ namespace llarp
   }
 
   bool
-  EncryptedFrame::DecryptInPlace(const byte_t* ourSecretKey,
+  EncryptedFrame::DecryptInPlace(const SecretKey& ourSecretKey,
                                  llarp::Crypto* crypto)
   {
     // format of frame is
@@ -98,13 +98,13 @@ namespace llarp
       return false;
     }
 
-    if(!MDS(digest.as_array().data(), buf, shared))
+    if(!MDS(digest.data(), buf, shared))
     {
       llarp::LogError("Digest failed");
       return false;
     }
 
-    if(memcmp(digest, hash, digest.size()))
+    if(!std::equal(digest.begin(), digest.end(), hash))
     {
       llarp::LogError("message authentication failed");
       return false;

--- a/llarp/encrypted_frame.cpp
+++ b/llarp/encrypted_frame.cpp
@@ -58,7 +58,7 @@ namespace llarp
 
     if(!MDS(hash, buf, shared))
     {
-      llarp::LogError("Failed to generate messgae auth");
+      llarp::LogError("Failed to generate message auth");
       return false;
     }
     return true;
@@ -79,7 +79,7 @@ namespace llarp
     byte_t* otherPubkey = nonce + TUNNONCESIZE;
     byte_t* body        = otherPubkey + PUBKEYSIZE;
 
-    // use dh_server becuase we are not the creator of this message
+    // use dh_server because we are not the creator of this message
     auto DH      = crypto->dh_server;
     auto Decrypt = crypto->xchacha20;
     auto MDS     = crypto->hmac;
@@ -98,7 +98,7 @@ namespace llarp
       return false;
     }
 
-    if(!MDS(digest, buf, shared))
+    if(!MDS(digest.as_array().data(), buf, shared))
     {
       llarp::LogError("Digest failed");
       return false;

--- a/llarp/encrypted_frame.cpp
+++ b/llarp/encrypted_frame.cpp
@@ -33,7 +33,7 @@ namespace llarp
     buf.sz   = size() - EncryptedFrameOverheadSize;
 
     // set our pubkey
-    memcpy(pubkey, seckey_topublic(ourSecretKey), PUBKEYSIZE);
+    memcpy(pubkey, ourSecretKey.toPublic().data(), PUBKEYSIZE);
     // randomize nonce
     crypto->randbytes(noncePtr, TUNNONCESIZE);
     TunnelNonce nonce(noncePtr);
@@ -76,10 +76,10 @@ namespace llarp
     // <N bytes encrypted payload>
     //
     ShortHash hash(data());
-    byte_t* noncePtr   = data() + SHORTHASHSIZE;
-    PubKey otherPubkey = noncePtr + TUNNONCESIZE;
-    byte_t* body       = data() + EncryptedFrameOverheadSize;
+    byte_t* noncePtr = data() + SHORTHASHSIZE;
+    byte_t* body     = data() + EncryptedFrameOverheadSize;
     TunnelNonce nonce(noncePtr);
+    PubKey otherPubkey(noncePtr + TUNNONCESIZE);
 
     // use dh_server because we are not the creator of this message
     auto DH      = crypto->dh_server;

--- a/llarp/encrypted_frame.hpp
+++ b/llarp/encrypted_frame.hpp
@@ -38,14 +38,14 @@ namespace llarp
     }
 
     bool
-    DecryptInPlace(const byte_t* seckey, llarp::Crypto* crypto);
+    DecryptInPlace(const SecretKey& seckey, llarp::Crypto* crypto);
 
     bool
-    EncryptInPlace(const byte_t* seckey, const byte_t* other,
+    EncryptInPlace(const SecretKey& seckey, const PubKey& other,
                    llarp::Crypto* crypto);
   };
 
-  /// TOOD: can only handle 1 frame at a time
+  /// TODO: can only handle 1 frame at a time
   template < typename User >
   struct AsyncFrameEncrypter
   {
@@ -92,7 +92,7 @@ namespace llarp
     }
   };
 
-  /// TOOD: can only handle 1 frame at a time
+  /// TODO: can only handle 1 frame at a time
   template < typename User >
   struct AsyncFrameDecrypter
   {
@@ -114,7 +114,7 @@ namespace llarp
         ctx->result(nullptr, ctx->context);
     }
 
-    AsyncFrameDecrypter(llarp::Crypto* c, const byte_t* secretkey,
+    AsyncFrameDecrypter(llarp::Crypto* c, const SecretKey& secretkey,
                         DecryptHandler h)
         : result(h), crypto(c), seckey(secretkey)
     {
@@ -123,7 +123,7 @@ namespace llarp
     DecryptHandler result;
     User* context;
     llarp::Crypto* crypto;
-    const byte_t* seckey;
+    const SecretKey& seckey;
     EncryptedFrame target;
 
     void

--- a/llarp/exit/obtain_exit.cpp
+++ b/llarp/exit/obtain_exit.cpp
@@ -6,21 +6,6 @@ namespace llarp
 {
   namespace routing
   {
-    ObtainExitMessage&
-    ObtainExitMessage::operator=(const ObtainExitMessage& other)
-    {
-      B       = other.B;
-      E       = other.E;
-      I       = other.I;
-      T       = other.T;
-      W       = other.W;
-      X       = other.X;
-      version = other.version;
-      S       = other.S;
-      Z       = other.Z;
-      return *this;
-    }
-
     bool
     ObtainExitMessage::Sign(llarp::Crypto* c, const llarp::SecretKey& sk)
     {
@@ -29,7 +14,9 @@ namespace llarp
       I                = llarp::seckey_topublic(sk);
       Z.Zero();
       if(!BEncode(&buf))
+      {
         return false;
+      }
       buf.sz = buf.cur - buf.base;
       return c->sign(Z, sk, buf);
     }
@@ -43,7 +30,9 @@ namespace llarp
       copy = *this;
       copy.Z.Zero();
       if(!copy.BEncode(&buf))
+      {
         return false;
+      }
       // rewind buffer
       buf.sz = buf.cur - buf.base;
       return c->verify(I, buf, Z);

--- a/llarp/exit/session.cpp
+++ b/llarp/exit/session.cpp
@@ -35,10 +35,12 @@ namespace llarp
       // check 30 seconds into the future and see if we need more paths
       const llarp_time_t future = now + (30 * 1000);
       if(NumPathsExistingAt(future) < expect)
-        return llarp::randint() % 4 == 0; // 25% chance for build if we will run out soon
-      // if we don't have the expended number of paths right now try building some if the cooldown timer isn't hit
+        return llarp::randint() % 4
+            == 0;  // 25% chance for build if we will run out soon
+      // if we don't have the expended number of paths right now try building
+      // some if the cooldown timer isn't hit
       if(AvailablePaths(llarp::path::ePathRoleExit) < expect)
-        return !path::Builder::BuildCooldownHit(now); 
+        return !path::Builder::BuildCooldownHit(now);
       // maintain regular number of paths
       return path::Builder::ShouldBuildMore(now);
     }

--- a/llarp/handlers/exit.cpp
+++ b/llarp/handlers/exit.cpp
@@ -96,7 +96,7 @@ namespace llarp
         if(r.FromString(msg.questions[0].qname))
         {
           huint32_t ip;
-          if(m_SNodeKeys.find(r.data()) == m_SNodeKeys.end())
+          if(m_SNodeKeys.find(r.as_array()) == m_SNodeKeys.end())
           {
             // we do not have it mapped
             // map it
@@ -106,7 +106,7 @@ namespace llarp
           else
           {
             // we have it mapped already as a service node
-            auto itr = m_KeyToIP.find(r.data());
+            auto itr = m_KeyToIP.find(r.as_array());
             if(itr != m_KeyToIP.end())
             {
               ip = itr->second;
@@ -194,7 +194,7 @@ namespace llarp
         {
           if(!itr->second->Flush())
           {
-            llarp::LogWarn("failed to flushsnode traffic to ", itr->first,
+            llarp::LogWarn("failed to flush snode traffic to ", itr->first,
                            " via outbound session");
           }
           ++itr;
@@ -485,8 +485,8 @@ namespace llarp
     huint32_t
     ExitEndpoint::ObtainServiceNodeIP(const llarp::RouterID &other)
     {
-      huint32_t ip = GetIPForIdent(other.data());
-      if(m_SNodeKeys.insert(other.data()).second)
+      huint32_t ip = GetIPForIdent(other.as_array());
+      if(m_SNodeKeys.emplace(other.as_array()).second)
       {
         // this is a new service node make an outbound session to them
         m_SNodeSessions.insert(
@@ -509,16 +509,15 @@ namespace llarp
       if(wantInternet && !m_PermitExit)
         return false;
       huint32_t ip = GetIPForIdent(pk);
-      if(Router()->paths.TransitHopPreviousIsRouter(path, pk.data()))
+      if(Router()->paths.TransitHopPreviousIsRouter(path, pk.as_array()))
       {
         // we think this path belongs to a service node
         // mark it as such so we don't make an outbound session to them
-        m_SNodeKeys.insert(pk.data());
+        m_SNodeKeys.emplace(pk.as_array());
       }
-      m_ActiveExits.insert(
-          std::make_pair(pk,
-                         std::make_unique< llarp::exit::Endpoint >(
-                             pk, path, !wantInternet, ip, this)));
+      m_ActiveExits.emplace(pk,
+                            std::make_unique< llarp::exit::Endpoint >(
+                                pk, path, !wantInternet, ip, this));
 
       m_Paths[path] = pk;
       return HasLocalMappedAddrFor(pk);

--- a/llarp/handlers/null.hpp
+++ b/llarp/handlers/null.hpp
@@ -25,7 +25,7 @@ namespace llarp
       }
 
       bool
-      HasAddress(const byte_t *) const override
+      HasAddress(const AlignedBuffer< 32 > &) const override
       {
         return false;
       }

--- a/llarp/handlers/null.hpp
+++ b/llarp/handlers/null.hpp
@@ -19,7 +19,7 @@ namespace llarp
       }
 
       huint32_t
-      ObtainIPForAddr(const byte_t *, bool) override
+      ObtainIPForAddr(const AlignedBuffer< 32 > &, bool) override
       {
         return {0};
       }

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -261,8 +261,8 @@ namespace llarp
           reply(msg);
           return true;
         }
-        llarp::service::Address addr =
-            ObtainAddrForIP< llarp::service::Address >(ip, true);
+        llarp::service::Address addr(
+            ObtainAddrForIP< llarp::service::Address >(ip, true));
         if(!addr.IsZero())
         {
           msg.AddAReply(addr.ToString(".snode"));
@@ -348,9 +348,9 @@ namespace llarp
       }
       llarp::LogInfo(Name() + " map ", addr.ToString(), " to ", ip);
 
-      m_IPToAddr[ip]              = addr.as_array();
-      m_AddrToIP[addr.as_array()] = ip;
-      m_SNodes[addr.as_array()]   = SNode;
+      m_IPToAddr[ip]   = addr;
+      m_AddrToIP[addr] = ip;
+      m_SNodes[addr]   = SNode;
       MarkIPActiveForever(ip);
       return true;
     }

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -343,7 +343,7 @@ namespace llarp
       {
         // XXX is calling inet_ntoa safe in this context? it's MP-unsafe
         llarp::LogWarn(ip, " already mapped to ",
-                       service::Address(itr->second).ToString());
+                       service::Address(itr->second.as_array()).ToString());
         return false;
       }
       llarp::LogInfo(Name() + " map ", addr.ToString(), " to ", ip);
@@ -555,7 +555,7 @@ namespace llarp
     }
 
     huint32_t
-    TunEndpoint::ObtainIPForAddr(const AlignedBuffer< 32 >& addr, bool snode)
+    TunEndpoint::ObtainIPForAddr(const AlignedBuffer< 32 > &addr, bool snode)
     {
       llarp_time_t now = Now();
       huint32_t nextIP = {0};

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -59,7 +59,7 @@ namespace llarp
       {
         llarp::RouterID exitRouter;
         if(!(exitRouter.FromString(v)
-             || HexDecode(v.c_str(), exitRouter, exitRouter.size())))
+             || HexDecode(v.c_str(), exitRouter.begin(), exitRouter.size())))
         {
           llarp::LogError(Name(), " bad exit router key: ", v);
           return false;

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -226,9 +226,9 @@ namespace llarp
         }
         else if(addr.FromString(qname, ".loki"))
         {
-          if(HasAddress(addr.as_array().data()))
+          if(HasAddress(addr))
           {
-            huint32_t ip = ObtainIPForAddr(addr.as_array().data(), false);
+            huint32_t ip = ObtainIPForAddr(addr, false);
             msg.AddINReply(ip);
           }
           else
@@ -243,7 +243,7 @@ namespace llarp
         {
           // TODO: add hook to EnsurePathToSNode
           EnsurePathToSNode(addr.as_array());
-          huint32_t ip = ObtainIPForAddr(addr.as_array().data(), true);
+          huint32_t ip = ObtainIPForAddr(addr, true);
           msg.AddINReply(ip);
         }
         else
@@ -325,7 +325,7 @@ namespace llarp
     {
       if(ctx)
       {
-        huint32_t ip = ObtainIPForAddr(addr.as_array().data(), false);
+        huint32_t ip = ObtainIPForAddr(addr, false);
         request.AddINReply(ip);
       }
       else

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -226,9 +226,9 @@ namespace llarp
         }
         else if(addr.FromString(qname, ".loki"))
         {
-          if(HasAddress(addr.data().data()))
+          if(HasAddress(addr.as_array().data()))
           {
-            huint32_t ip = ObtainIPForAddr(addr.data().data(), false);
+            huint32_t ip = ObtainIPForAddr(addr.as_array().data(), false);
             msg.AddINReply(ip);
           }
           else
@@ -242,8 +242,8 @@ namespace llarp
         else if(addr.FromString(qname, ".snode"))
         {
           // TODO: add hook to EnsurePathToSNode
-          EnsurePathToSNode(addr.data().data());
-          huint32_t ip = ObtainIPForAddr(addr.data().data(), true);
+          EnsurePathToSNode(addr.as_array());
+          huint32_t ip = ObtainIPForAddr(addr.as_array().data(), true);
           msg.AddINReply(ip);
         }
         else
@@ -325,7 +325,7 @@ namespace llarp
     {
       if(ctx)
       {
-        huint32_t ip = ObtainIPForAddr(addr.data().data(), false);
+        huint32_t ip = ObtainIPForAddr(addr.as_array().data(), false);
         request.AddINReply(ip);
       }
       else
@@ -348,9 +348,9 @@ namespace llarp
       }
       llarp::LogInfo(Name() + " map ", addr.ToString(), " to ", ip);
 
-      m_IPToAddr[ip]                 = addr.data().data();
-      m_AddrToIP[addr.data().data()] = ip;
-      m_SNodes[addr.data().data()]   = SNode;
+      m_IPToAddr[ip]              = addr.as_array();
+      m_AddrToIP[addr.as_array()] = ip;
+      m_SNodes[addr.as_array()]   = SNode;
       MarkIPActiveForever(ip);
       return true;
     }
@@ -495,12 +495,12 @@ namespace llarp
         if(m_SNodes.at(itr->second))
         {
           sendFunc = std::bind(&TunEndpoint::SendToSNodeOrQueue, this,
-                               itr->second.data(), std::placeholders::_1);
+                               itr->second.as_array(), std::placeholders::_1);
         }
         else
         {
           sendFunc = std::bind(&TunEndpoint::SendToServiceOrQueue, this,
-                               itr->second.data(), std::placeholders::_1,
+                               itr->second.as_array(), std::placeholders::_1,
                                service::eProtocolTraffic);
         }
         // prepare packet for insertion into network
@@ -555,11 +555,11 @@ namespace llarp
     }
 
     huint32_t
-    TunEndpoint::ObtainIPForAddr(const byte_t *a, bool snode)
+    TunEndpoint::ObtainIPForAddr(const AlignedBuffer< 32 >& addr, bool snode)
     {
       llarp_time_t now = Now();
       huint32_t nextIP = {0};
-      AlignedBuffer< 32 > ident(a);
+      AlignedBuffer< 32 > ident(addr);
       {
         // previously allocated address
         auto itr = m_AddrToIP.find(ident);

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -115,7 +115,7 @@ namespace llarp
       }
 
       bool
-      HasAddress(const byte_t* addr) const override
+      HasAddress(const AlignedBuffer< 32 >& addr) const override
       {
         return m_AddrToIP.find(addr) != m_AddrToIP.end();
       }

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -111,7 +111,7 @@ namespace llarp
           return addr;
         }
         // found
-        return itr->second.as_array();
+        return Addr{itr->second};
       }
 
       bool

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -111,7 +111,7 @@ namespace llarp
           return addr;
         }
         // found
-        return itr->second.data();
+        return itr->second.as_array();
       }
 
       bool
@@ -122,7 +122,8 @@ namespace llarp
 
       /// get ip address for key unconditionally
       huint32_t
-      ObtainIPForAddr(const byte_t* addr, bool serviceNode) override;
+      ObtainIPForAddr(const AlignedBuffer< 32 >& addr,
+                      bool serviceNode) override;
 
       /// flush network traffic
       void

--- a/llarp/link/server.cpp
+++ b/llarp/link/server.cpp
@@ -3,7 +3,7 @@
 
 namespace llarp
 {
-  ILinkLayer::ILinkLayer(const byte_t* routerEncSecret, GetRCFunc getrc,
+  ILinkLayer::ILinkLayer(const SecretKey& routerEncSecret, GetRCFunc getrc,
                          LinkMessageHandler handler, SignBufferFunc signbuf,
                          SessionEstablishedHandler establishedSession,
                          SessionRenegotiateHandler reneg,
@@ -210,7 +210,7 @@ namespace llarp
   }
 
   void
-  ILinkLayer::CloseSessionTo(const byte_t* remote)
+  ILinkLayer::CloseSessionTo(const RouterID& remote)
   {
     Lock l(m_AuthedLinksMutex);
     RouterID r = remote;
@@ -225,7 +225,7 @@ namespace llarp
   }
 
   void
-  ILinkLayer::KeepAliveSessionTo(const byte_t* remote)
+  ILinkLayer::KeepAliveSessionTo(const RouterID& remote)
   {
     Lock l(m_AuthedLinksMutex);
     auto range = m_AuthedLinks.equal_range(remote);
@@ -238,7 +238,7 @@ namespace llarp
   }
 
   bool
-  ILinkLayer::SendTo(const byte_t* remote, llarp_buffer_t buf)
+  ILinkLayer::SendTo(const RouterID& remote, llarp_buffer_t buf)
   {
     ILinkSession* s = nullptr;
     {
@@ -279,7 +279,7 @@ namespace llarp
     return llarp::seckey_topublic(TransportSecretKey());
   }
 
-  const byte_t*
+  const SecretKey&
   ILinkLayer::TransportSecretKey() const
   {
     return m_SecretKey;

--- a/llarp/link/server.cpp
+++ b/llarp/link/server.cpp
@@ -24,10 +24,10 @@ namespace llarp
   }
 
   bool
-  ILinkLayer::HasSessionTo(const byte_t* pk)
+  ILinkLayer::HasSessionTo(const RouterID& id)
   {
     Lock l(m_AuthedLinksMutex);
-    return m_AuthedLinks.find(pk) != m_AuthedLinks.end();
+    return m_AuthedLinks.find(id) != m_AuthedLinks.end();
   }
 
   void
@@ -43,7 +43,7 @@ namespace llarp
   }
 
   bool
-  ILinkLayer::VisitSessionByPubkey(const byte_t* pk,
+  ILinkLayer::VisitSessionByPubkey(const RouterID& pk,
                                    std::function< bool(ILinkSession*) > visit)
   {
     auto itr = m_AuthedLinks.find(pk);
@@ -124,7 +124,7 @@ namespace llarp
   }
 
   void
-  ILinkLayer::MapAddr(const byte_t* pk, ILinkSession* s)
+  ILinkLayer::MapAddr(const RouterID& pk, ILinkSession* s)
   {
     static constexpr size_t MaxSessionsPerKey = 16;
     Lock l_authed(m_AuthedLinksMutex);
@@ -135,7 +135,7 @@ namespace llarp
       if(itr->get() == s)
       {
         if(m_AuthedLinks.count(pk) < MaxSessionsPerKey)
-          m_AuthedLinks.insert(std::make_pair(pk, std::move(*itr)));
+          m_AuthedLinks.emplace(pk, std::move(*itr));
         else
           s->SendClose();
         itr = m_Pending.erase(itr);
@@ -168,7 +168,7 @@ namespace llarp
     llarp::AddressInfo to;
     if(!PickAddress(rc, to))
       return false;
-    llarp::LogInfo("Try establish to ", RouterID(rc.pubkey.data()));
+    llarp::LogInfo("Try establish to ", RouterID(rc.pubkey.as_array()));
     llarp::Addr addr(to);
     auto s = NewOutboundSession(rc, to);
     s->Start();

--- a/llarp/link/server.hpp
+++ b/llarp/link/server.hpp
@@ -42,7 +42,7 @@ namespace llarp
 
   struct ILinkLayer
   {
-    ILinkLayer(const byte_t* routerEncSecret, GetRCFunc getrc,
+    ILinkLayer(const SecretKey& routerEncSecret, GetRCFunc getrc,
                LinkMessageHandler handler, SignBufferFunc signFunc,
                SessionEstablishedHandler sessionEstablish,
                SessionRenegotiateHandler renegotiate, TimeoutHandler timeout,
@@ -82,7 +82,7 @@ namespace llarp
         llarp::LogWarn("no udp set");
         return;
       }
-      // maybe chekc from too?
+      // maybe check from too?
       // no it's never null
       static_cast< ILinkLayer* >(udp->user)->RecvFrom(*from, buf.base, buf.sz);
     }
@@ -116,13 +116,13 @@ namespace llarp
     Name() const = 0;
 
     void
-    CloseSessionTo(const byte_t* remote);
+    CloseSessionTo(const RouterID& remote);
 
     void
-    KeepAliveSessionTo(const byte_t* remote);
+    KeepAliveSessionTo(const RouterID& remote);
 
     bool
-    SendTo(const byte_t* remote, llarp_buffer_t buf);
+    SendTo(const RouterID& remote, llarp_buffer_t buf);
 
     bool
     GetOurAddressInfo(AddressInfo& addr) const;
@@ -140,13 +140,13 @@ namespace llarp
     const byte_t*
     TransportPubKey() const;
 
-    const byte_t*
+    const SecretKey&
     RouterEncryptionSecret() const
     {
       return m_RouterEncSecret;
     }
 
-    const byte_t*
+    const SecretKey&
     TransportSecretKey() const;
 
     bool
@@ -187,7 +187,7 @@ namespace llarp
     ScheduleTick(uint64_t interval);
 
     uint32_t tick_id;
-    const byte_t* m_RouterEncSecret;
+    const SecretKey& m_RouterEncSecret;
 
    protected:
     using Lock  = util::NullLock;

--- a/llarp/link/server.hpp
+++ b/llarp/link/server.hpp
@@ -57,7 +57,7 @@ namespace llarp
     }
 
     bool
-    HasSessionTo(const byte_t* pk);
+    HasSessionTo(const RouterID& pk);
 
     bool
     HasSessionVia(const Addr& addr);
@@ -128,7 +128,7 @@ namespace llarp
     GetOurAddressInfo(AddressInfo& addr) const;
 
     bool
-    VisitSessionByPubkey(const byte_t* pk,
+    VisitSessionByPubkey(const RouterID& pk,
                          std::function< bool(ILinkSession*) > visit);
 
     virtual uint16_t
@@ -156,7 +156,7 @@ namespace llarp
     GenEphemeralKeys();
 
     void
-    MapAddr(const byte_t* pk, ILinkSession* s);
+    MapAddr(const RouterID& pk, ILinkSession* s);
 
     virtual void Tick(llarp_time_t)
     {

--- a/llarp/link/session.hpp
+++ b/llarp/link/session.hpp
@@ -42,7 +42,7 @@ namespace llarp
     std::function< bool(llarp_time_t) > TimedOut;
 
     /// get remote public identity key
-    std::function< const byte_t *(void) > GetPubKey;
+    std::function< const PubKey &(void) > GetPubKey;
 
     /// get remote address
     std::function< Addr(void) > GetRemoteEndpoint;

--- a/llarp/link/utp.cpp
+++ b/llarp/link/utp.cpp
@@ -140,7 +140,7 @@ namespace llarp
       }
 
       // K = TKE(a.p, B_a.e, sk, t_h)
-      if(!dh(K, other, secret, t_h))
+      if(!dh(K, other, secret, t_h.as_array().data()))
       {
         llarp::LogError("key exchange with ", other, " failed");
         return false;

--- a/llarp/link/utp_internal.hpp
+++ b/llarp/link/utp_internal.hpp
@@ -55,7 +55,8 @@ namespace llarp
       MessageBuffer _msg;
 
       /// for accessing message buffer
-      llarp_buffer_t buffer = llarp::InitBuffer(_msg.data(), _msg.size());
+      llarp_buffer_t buffer =
+          llarp::InitBuffer(_msg.as_array().data(), _msg.size());
 
       bool
       operator==(const InboundMessage& other) const

--- a/llarp/link/utp_internal.hpp
+++ b/llarp/link/utp_internal.hpp
@@ -55,8 +55,7 @@ namespace llarp
       MessageBuffer _msg;
 
       /// for accessing message buffer
-      llarp_buffer_t buffer =
-          llarp::InitBuffer(_msg.as_array().data(), _msg.size());
+      llarp_buffer_t buffer = _msg.as_buffer();
 
       bool
       operator==(const InboundMessage& other) const
@@ -209,7 +208,7 @@ namespace llarp
       bool
       DoKeyExchange(transport_dh_func dh, SharedSecret& K,
                     const KeyExchangeNonce& n, const PubKey& other,
-                    const byte_t* secret);
+                    const SecretKey& secret);
 
       /// does K = HS(K + A)
       bool
@@ -284,7 +283,7 @@ namespace llarp
       OnLog(utp_callback_arguments* arg);
 
       /// construct
-      LinkLayer(llarp::Crypto* crypto, const byte_t* routerEncSecret,
+      LinkLayer(llarp::Crypto* crypto, const SecretKey& routerEncSecret,
                 llarp::GetRCFunc getrc, llarp::LinkMessageHandler h,
                 llarp::SignBufferFunc sign,
                 llarp::SessionEstablishedHandler established,

--- a/llarp/messages/exit.hpp
+++ b/llarp/messages/exit.hpp
@@ -20,7 +20,7 @@ namespace llarp
       llarp_time_t X;
       llarp::Signature Z;
 
-      ObtainExitMessage() : IMessage()
+      ObtainExitMessage() : IMessage(), E(0), T(0), X(0)
       {
       }
 
@@ -28,11 +28,8 @@ namespace llarp
       {
       }
 
-      ObtainExitMessage&
-      operator=(const ObtainExitMessage& other);
-
       void
-      Clear() override 
+      Clear() override
       {
         B.clear();
         W.clear();
@@ -87,8 +84,10 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override;
 
-      void 
-      Clear() override {}
+      void
+      Clear() override
+      {
+      }
     };
 
     struct RejectExitMessage final : public IMessage
@@ -108,7 +107,7 @@ namespace llarp
       {
       }
 
-      void 
+      void
       Clear() override
       {
         R.clear();
@@ -148,8 +147,10 @@ namespace llarp
       {
       }
 
-      void 
-      Clear() override {}
+      void
+      Clear() override
+      {
+      }
 
       UpdateExitVerifyMessage&
       operator=(const UpdateExitVerifyMessage& other);
@@ -204,8 +205,10 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override;
 
-      void 
-      Clear() override {}
+      void
+      Clear() override
+      {
+      }
     };
 
     struct CloseExitMessage final : public IMessage
@@ -240,9 +243,11 @@ namespace llarp
 
       bool
       Verify(llarp::Crypto* c, const llarp::PubKey& pk) const;
-      
-      void 
-      Clear() override {}
+
+      void
+      Clear() override
+      {
+      }
     };
 
   }  // namespace routing

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -105,7 +105,7 @@ llarp_nodedb::Insert(const llarp::RouterContact &rc)
   auto buf = llarp::StackBuffer< decltype(tmp) >(tmp);
   {
     llarp::util::Lock lock(access);
-    entries.insert(std::make_pair(rc.pubkey.data(), rc));
+    entries.emplace(rc.pubkey.as_array(), rc);
   }
   if(!rc.BEncode(&buf))
     return false;
@@ -182,7 +182,7 @@ llarp_nodedb::loadfile(const fs::path &fpath)
   }
   {
     llarp::util::Lock lock(access);
-    entries.insert(std::make_pair(rc.pubkey.data(), rc));
+    entries.emplace(rc.pubkey.as_array(), rc);
   }
   return true;
 }

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -15,7 +15,7 @@ static const char skiplist_subdirs[] = "0123456789abcdef";
 static const std::string RC_FILE_EXT = ".signed";
 
 bool
-llarp_nodedb::Remove(const byte_t *pk)
+llarp_nodedb::Remove(const llarp::RouterID &pk)
 {
   llarp::util::Lock lock(access);
   auto itr = entries.find(pk);
@@ -34,7 +34,7 @@ llarp_nodedb::Clear()
 }
 
 bool
-llarp_nodedb::Get(const byte_t *pk, llarp::RouterContact &result)
+llarp_nodedb::Get(const llarp::RouterID &pk, llarp::RouterContact &result)
 {
   llarp::util::Lock lock(access);
   auto itr = entries.find(pk);
@@ -45,7 +45,7 @@ llarp_nodedb::Get(const byte_t *pk, llarp::RouterContact &result)
 }
 
 bool
-llarp_nodedb::Has(const byte_t *pk)
+llarp_nodedb::Has(const llarp::RouterID &pk)
 {
   llarp::util::Lock lock(access);
   return entries.find(pk) != entries.end();
@@ -54,7 +54,7 @@ llarp_nodedb::Has(const byte_t *pk)
 /// skiplist directory is hex encoded first nibble
 /// skiplist filename is <base32encoded>.snode.signed
 std::string
-llarp_nodedb::getRCFilePath(const byte_t *pubkey) const
+llarp_nodedb::getRCFilePath(const llarp::RouterID &pubkey) const
 {
   char ftmp[68] = {0};
   const char *hexname =

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -47,19 +47,19 @@ struct llarp_nodedb
   fs::path nodePath;
 
   bool
-  Remove(const byte_t *pk);
+  Remove(const llarp::RouterID &pk);
 
   void
   Clear();
 
   bool
-  Get(const byte_t *pk, llarp::RouterContact &result);
+  Get(const llarp::RouterID &pk, llarp::RouterContact &result);
 
   bool
-  Has(const byte_t *pk);
+  Has(const llarp::RouterID &pk);
 
   std::string
-  getRCFilePath(const byte_t *pubkey) const;
+  getRCFilePath(const llarp::RouterID &pubkey) const;
 
   /// insert and write to disk
   bool

--- a/llarp/path.cpp
+++ b/llarp/path.cpp
@@ -61,14 +61,15 @@ namespace llarp
     bool
     PathContext::HopIsUs(const RouterID& k) const
     {
-      return memcmp(k.data(), m_Router->pubkey(), PUBKEYSIZE) == 0;
+      return std::equal(m_Router->pubkey(), m_Router->pubkey() + PUBKEYSIZE,
+                        k.begin());
     }
 
     bool
     PathContext::ForwardLRCM(const RouterID& nextHop,
                              const std::array< EncryptedFrame, 8 >& frames)
     {
-      llarp::LogDebug("fowarding LRCM to ", nextHop);
+      llarp::LogDebug("forwarding LRCM to ", nextHop);
       LR_CommitMessage msg;
       msg.frames = frames;
       return m_Router->SendToOrQueue(nextHop, &msg);

--- a/llarp/path.cpp
+++ b/llarp/path.cpp
@@ -52,7 +52,7 @@ namespace llarp
       return m_Router->logic;
     }
 
-    byte_t*
+    llarp::SecretKey&
     PathContext::EncryptionSecretKey()
     {
       return m_Router->encryption;

--- a/llarp/path.hpp
+++ b/llarp/path.hpp
@@ -74,30 +74,27 @@ namespace llarp
             || upstream < other.upstream || downstream < other.downstream;
       }
 
+      struct PathIDHash
+      {
+        std::size_t
+        operator()(const PathID_t& a) const
+        {
+          return AlignedBuffer< PathID_t::SIZE >::Hash()(a);
+        }
+      };
+
       struct Hash
       {
         std::size_t
         operator()(TransitHopInfo const& a) const
         {
-          std::size_t idx0, idx1, idx2, idx3;
-          memcpy(&idx0, a.upstream, sizeof(std::size_t));
-          memcpy(&idx1, a.downstream, sizeof(std::size_t));
-          memcpy(&idx2, a.txID, sizeof(std::size_t));
-          memcpy(&idx3, a.rxID, sizeof(std::size_t));
-          return idx0 ^ idx1 ^ idx2;
+          std::size_t idx0 = RouterID::Hash()(a.upstream);
+          std::size_t idx1 = RouterID::Hash()(a.downstream);
+          std::size_t idx2 = PathIDHash()(a.txID);
+          std::size_t idx3 = PathIDHash()(a.rxID);
+          return idx0 ^ idx1 ^ idx2 ^ idx3;
         }
       };
-    };
-
-    struct PathIDHash
-    {
-      std::size_t
-      operator()(const PathID_t& a) const
-      {
-        std::size_t idx0;
-        memcpy(&idx0, a, sizeof(std::size_t));
-        return idx0;
-      }
     };
 
     struct IHopHandler

--- a/llarp/path.hpp
+++ b/llarp/path.hpp
@@ -660,7 +660,7 @@ namespace llarp
       llarp::Router*
       Router();
 
-      byte_t*
+      llarp::SecretKey&
       EncryptionSecretKey();
 
       const byte_t*

--- a/llarp/pathbuilder.cpp
+++ b/llarp/pathbuilder.cpp
@@ -49,7 +49,7 @@ namespace llarp
       hop.nonce.Randomize();
       // do key exchange
       if(!ctx->crypto->dh_client(hop.shared, hop.rc.enckey, hop.commkey,
-                                 hop.nonce.data()))
+                                 hop.nonce))
       {
         llarp::LogError("Failed to generate shared key for path build");
         delete ctx;

--- a/llarp/pathbuilder.cpp
+++ b/llarp/pathbuilder.cpp
@@ -63,11 +63,11 @@ namespace llarp
 
       if(isFarthestHop)
       {
-        hop.upstream = hop.rc.pubkey.data();
+        hop.upstream = hop.rc.pubkey.as_array();
       }
       else
       {
-        hop.upstream = ctx->path->hops[ctx->idx].rc.pubkey.data();
+        hop.upstream = ctx->path->hops[ctx->idx].rc.pubkey.as_array();
       }
 
       // build record
@@ -219,8 +219,7 @@ namespace llarp
     bool
     Builder::BuildCooldownHit(llarp_time_t now) const
     {
-      return now < lastBuild
-          || now - lastBuild < buildIntervalLimit;
+      return now < lastBuild || now - lastBuild < buildIntervalLimit;
     }
 
     bool
@@ -304,7 +303,8 @@ namespace llarp
     {
       // linear backoff
       static constexpr llarp_time_t MaxBuildInterval = 10 * 1000;
-      buildIntervalLimit = std::max(1000 + buildIntervalLimit, MaxBuildInterval);
+      buildIntervalLimit =
+          std::max(1000 + buildIntervalLimit, MaxBuildInterval);
       PathSet::HandlePathBuildTimeout(p);
     }
 

--- a/llarp/pathbuilder.hpp
+++ b/llarp/pathbuilder.hpp
@@ -48,7 +48,7 @@ namespace llarp
       ShouldBuildMore(llarp_time_t now) const override;
 
       /// return true if we hit our soft limit for building paths too fast
-      bool 
+      bool
       BuildCooldownHit(llarp_time_t now) const;
 
       virtual bool
@@ -74,7 +74,7 @@ namespace llarp
       void
       ManualRebuild(size_t N, PathRole roles = ePathRoleAny);
 
-      virtual const byte_t*
+      virtual const SecretKey&
       GetTunnelEncryptionSecretKey() const;
 
       virtual void

--- a/llarp/pathset.cpp
+++ b/llarp/pathset.cpp
@@ -91,7 +91,7 @@ namespace llarp
       Lock_t l(m_PathsMutex);
       Path* path = nullptr;
       AlignedBuffer< 32 > dist;
-      AlignedBuffer< 32 > to = id.data();
+      AlignedBuffer< 32 > to = id;
       dist.Fill(0xff);
       for(const auto& item : m_Paths)
       {

--- a/llarp/proofofwork.cpp
+++ b/llarp/proofofwork.cpp
@@ -32,7 +32,7 @@ namespace llarp
     if(now - timestamp > (uint64_t(extendedLifetime) * 1000))
       return false;
 
-    byte_t digest[SHORTHASHSIZE];
+    ShortHash digest;
     byte_t tmp[MaxSize];
     auto buf = llarp::StackBuffer< decltype(tmp) >(tmp);
     // encode

--- a/llarp/relay_commit.cpp
+++ b/llarp/relay_commit.cpp
@@ -278,7 +278,7 @@ namespace llarp
       }
       // generate hash of hop key for nonce mutation
       self->context->Crypto()->shorthash(self->hop->nonceXOR,
-                                         llarp::Buffer(self->hop->pathKey));
+                                         self->hop->pathKey.as_buffer());
       if(self->record.work
          && self->record.work->IsValid(self->context->Crypto()->shorthash, now))
       {

--- a/llarp/router.cpp
+++ b/llarp/router.cpp
@@ -684,7 +684,7 @@ namespace llarp
     // store it in nodedb async
     nodedb->InsertAsync(newrc);
     // update dht if required
-    if(dht->impl.nodes->HasNode(newrc.pubkey.as_array()))
+    if(dht->impl.nodes->HasNode(dht::Key_t{newrc.pubkey}))
     {
       dht->impl.nodes->PutNode(newrc);
     }
@@ -772,7 +772,7 @@ namespace llarp
         for(const auto &rc : bootstrapRCList)
         {
           llarp_router_try_connect(this, rc, 4);
-          dht->impl.ExploreNetworkVia(rc.pubkey.as_array());
+          dht->impl.ExploreNetworkVia(dht::Key_t{rc.pubkey});
         }
       }
       else

--- a/llarp/router.cpp
+++ b/llarp/router.cpp
@@ -123,7 +123,7 @@ llarp_router_try_connect(llarp::Router *router,
 
 bool
 llarp_findOrCreateIdentity(llarp::Crypto *crypto, const char *fpath,
-                           byte_t *secretkey)
+                           llarp::SecretKey &secretkey)
 {
   llarp::LogDebug("find or create ", fpath);
   fs::path path(fpath);
@@ -135,13 +135,14 @@ llarp_findOrCreateIdentity(llarp::Crypto *crypto, const char *fpath,
     std::ofstream f(path.string(), std::ios::binary);
     if(f.is_open())
     {
-      f.write((char *)secretkey, SECKEYSIZE);
+      f.write(reinterpret_cast< char * >(secretkey.as_array().data()),
+              SECKEYSIZE);
     }
   }
   std::ifstream f(path.string(), std::ios::binary);
   if(f.is_open())
   {
-    f.read((char *)secretkey, SECKEYSIZE);
+    f.read(reinterpret_cast< char * >(secretkey.as_array().data()), SECKEYSIZE);
     return true;
   }
   llarp::LogInfo("failed to get identity key");

--- a/llarp/router.hpp
+++ b/llarp/router.hpp
@@ -37,8 +37,8 @@ llarp_findOrCreateEncryption(llarp::Crypto *crypto, const char *fpath,
                              llarp::SecretKey &encryption);
 
 bool
-llarp_findOrCreateIdentity(struct llarp::Crypto *crypto, const char *path,
-                           byte_t *secretkey);
+llarp_findOrCreateIdentity(llarp::Crypto *crypto, const char *path,
+                           llarp::SecretKey &secretkey);
 
 struct TryConnectJob;
 
@@ -357,11 +357,12 @@ namespace llarp
     llarp::ILinkLayer *
     GetLinkWithSessionByPubkey(const llarp::RouterID &remote);
 
-
-    /// parse a routing message in a buffer and handle it with a handler if successful parsing
-    /// return true on parse and handle success otherwise return false
+    /// parse a routing message in a buffer and handle it with a handler if
+    /// successful parsing return true on parse and handle success otherwise
+    /// return false
     bool
-    ParseRoutingMessageBuffer(llarp_buffer_t buf, routing::IMessageHandler * h, PathID_t rxid);
+    ParseRoutingMessageBuffer(llarp_buffer_t buf, routing::IMessageHandler *h,
+                              PathID_t rxid);
 
     void
     ConnectToRandomRouters(int N);

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -25,7 +25,9 @@ namespace llarp
 #endif
   NetID::NetID() : AlignedBuffer< 8 >()
   {
-    memcpy(data(), DefaultValue, strnlen((const char *)DefaultValue, size()));
+    size_t len =
+        strnlen(reinterpret_cast< const char * >(DefaultValue), size());
+    std::copy(DefaultValue, DefaultValue + len, as_array().begin());
   }
 
   bool
@@ -37,8 +39,8 @@ namespace llarp
   std::string
   NetID::ToString() const
   {
-    size_t l = strnlen((const char *)data(), size());
-    return std::string((const char *)data(), l);
+    auto term = std::find(begin(), end(), '\0');
+    return std::string(begin(), term);
   }
 
   bool
@@ -50,15 +52,16 @@ namespace llarp
       return false;
     if(strbuf.sz > size())
       return false;
-    memcpy(data(), strbuf.base, strbuf.sz);
+
+    std::copy(strbuf.base, strbuf.base + strbuf.sz, as_array().begin());
     return true;
   }
 
   bool
   NetID::BEncode(llarp_buffer_t *buf) const
   {
-    size_t l = strnlen((const char *)data(), size());
-    return bencode_write_bytestring(buf, data(), l);
+    auto term = std::find(begin(), end(), '\0');
+    return bencode_write_bytestring(buf, begin(), std::distance(begin(), term));
   }
 
   bool
@@ -158,7 +161,8 @@ namespace llarp
       if(strbuf.sz > nickname.size())
         return false;
       nickname.Zero();
-      memcpy(nickname.data(), strbuf.base, strbuf.sz);
+      std::copy(strbuf.base, strbuf.base + strbuf.sz,
+                nickname.as_array().begin());
       return true;
     }
 
@@ -218,8 +222,8 @@ namespace llarp
   std::string
   RouterContact::Nick() const
   {
-    const char *n = (const char *)nickname.data();
-    return std::string(n, strnlen(n, nickname.size()));
+    auto term = std::find(nickname.begin(), nickname.end(), '\0');
+    return std::string(nickname.begin(), term);
   }
 
   bool

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -27,7 +27,7 @@ namespace llarp
   {
     size_t len =
         strnlen(reinterpret_cast< const char * >(DefaultValue), size());
-    std::copy(DefaultValue, DefaultValue + len, as_array().begin());
+    std::copy(DefaultValue, DefaultValue + len, begin());
   }
 
   bool
@@ -53,7 +53,7 @@ namespace llarp
     if(strbuf.sz > size())
       return false;
 
-    std::copy(strbuf.base, strbuf.base + strbuf.sz, as_array().begin());
+    std::copy(strbuf.base, strbuf.base + strbuf.sz, begin());
     return true;
   }
 
@@ -162,7 +162,7 @@ namespace llarp
         return false;
       nickname.Zero();
       std::copy(strbuf.base, strbuf.base + strbuf.sz,
-                nickname.as_array().begin());
+                nickname.begin());
       return true;
     }
 

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -200,7 +200,9 @@ namespace llarp
   RouterContact::SetNick(const std::string &nick)
   {
     nickname.Zero();
-    memcpy(nickname, nick.c_str(), std::min(nick.size(), nickname.size()));
+    std::copy(nick.begin(),
+              nick.begin() + std::min(nick.size(), nickname.size()),
+              nickname.begin());
   }
 
   bool

--- a/llarp/router_id.hpp
+++ b/llarp/router_id.hpp
@@ -32,7 +32,7 @@ namespace llarp
     RouterID&
     operator=(const byte_t* ptr)
     {
-      std::copy(ptr, ptr + SIZE, as_array().begin());
+      std::copy(ptr, ptr + SIZE, begin());
       return *this;
     }
 

--- a/llarp/router_id.hpp
+++ b/llarp/router_id.hpp
@@ -32,7 +32,7 @@ namespace llarp
     RouterID&
     operator=(const byte_t* ptr)
     {
-      memcpy(data(), ptr, SIZE);
+      std::copy(ptr, ptr + SIZE, as_array().begin());
       return *this;
     }
 

--- a/llarp/routing/dht_message.cpp
+++ b/llarp/routing/dht_message.cpp
@@ -51,7 +51,7 @@ namespace llarp
     DHTMessage::HandleMessage(IMessageHandler* h, llarp::Router* r) const
     {
       // set source as us
-      llarp::dht::Key_t us = r->pubkey();
+      llarp::dht::Key_t us{r->pubkey()};
       for(const auto& msg : M)
       {
         msg->From   = us;

--- a/llarp/routing/message.hpp
+++ b/llarp/routing/message.hpp
@@ -15,9 +15,9 @@ namespace llarp
     struct IMessage : public llarp::IBEncodeMessage
     {
       llarp::PathID_t from;
-      uint64_t S = 0;
+      uint64_t S;
 
-      IMessage() : llarp::IBEncodeMessage()
+      IMessage() : llarp::IBEncodeMessage(), S(0)
       {
       }
 
@@ -26,11 +26,10 @@ namespace llarp
       virtual bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const = 0;
 
-      virtual void 
+      virtual void
       Clear() = 0;
     };
 
-    
   }  // namespace routing
 }  // namespace llarp
 

--- a/llarp/service.cpp
+++ b/llarp/service.cpp
@@ -220,14 +220,14 @@ namespace llarp
     }
 
     bool
-    Identity::KeyExchange(path_dh_func dh, byte_t* result,
+    Identity::KeyExchange(path_dh_func dh, SharedSecret& result,
                           const ServiceInfo& other, const byte_t* N) const
     {
       return dh(result, other.EncryptionPublicKey(), enckey, N);
     }
 
     bool
-    Identity::Sign(llarp::Crypto* c, byte_t* sig, llarp_buffer_t buf) const
+    Identity::Sign(Crypto* c, Signature& sig, llarp_buffer_t buf) const
     {
       return c->sign(sig, signkey, buf);
     }

--- a/llarp/service.cpp
+++ b/llarp/service.cpp
@@ -275,7 +275,7 @@ namespace llarp
 
       const byte_t* ptr = nullptr;
       if(!vanity.IsZero())
-        ptr = vanity.data();
+        ptr = vanity.as_array().data();
       // update pubkeys
       pub.Update(llarp::seckey_topublic(enckey),
                  llarp::seckey_topublic(signkey), ptr);

--- a/llarp/service.cpp
+++ b/llarp/service.cpp
@@ -221,7 +221,8 @@ namespace llarp
 
     bool
     Identity::KeyExchange(path_dh_func dh, SharedSecret& result,
-                          const ServiceInfo& other, const byte_t* N) const
+                          const ServiceInfo& other,
+                          const KeyExchangeNonce& N) const
     {
       return dh(result, other.EncryptionPublicKey(), enckey, N);
     }
@@ -273,12 +274,12 @@ namespace llarp
       if(!BDecode(&buf))
         return false;
 
-      const byte_t* ptr = nullptr;
+      ServiceInfo::OptNonce van;
       if(!vanity.IsZero())
-        ptr = vanity.as_array().data();
+        van = vanity;
       // update pubkeys
       pub.Update(llarp::seckey_topublic(enckey),
-                 llarp::seckey_topublic(signkey), ptr);
+                 llarp::seckey_topublic(signkey), van);
       return true;
     }
 

--- a/llarp/service/Identity.hpp
+++ b/llarp/service/Identity.hpp
@@ -41,7 +41,7 @@ namespace llarp
 
       bool
       KeyExchange(llarp::path_dh_func dh, SharedSecret& sharedkey,
-                  const ServiceInfo& other, const byte_t* N) const;
+                  const ServiceInfo& other, const KeyExchangeNonce& N) const;
 
       bool
       DecodeKey(llarp_buffer_t key, llarp_buffer_t* buf) override;

--- a/llarp/service/Identity.hpp
+++ b/llarp/service/Identity.hpp
@@ -40,7 +40,7 @@ namespace llarp
       EnsureKeys(const std::string& fpath, llarp::Crypto* c);
 
       bool
-      KeyExchange(llarp::path_dh_func dh, byte_t* sharedkey,
+      KeyExchange(llarp::path_dh_func dh, SharedSecret& sharedkey,
                   const ServiceInfo& other, const byte_t* N) const;
 
       bool
@@ -50,7 +50,7 @@ namespace llarp
       SignIntroSet(IntroSet& i, llarp::Crypto* c, llarp_time_t now) const;
 
       bool
-      Sign(llarp::Crypto*, byte_t* sig, llarp_buffer_t buf) const;
+      Sign(llarp::Crypto*, Signature& sig, llarp_buffer_t buf) const;
     };
   }  // namespace service
 }  // namespace llarp

--- a/llarp/service/Info.hpp
+++ b/llarp/service/Info.hpp
@@ -5,6 +5,12 @@
 #include <crypto.hpp>
 #include <service/types.hpp>
 
+#if __cplusplus >= 201703L
+#include <optional>
+#else
+#include <tl/optional.hpp>
+#endif
+
 namespace llarp
 {
   namespace service
@@ -17,6 +23,12 @@ namespace llarp
 
      public:
       VanityNonce vanity;
+
+#if __cplusplus >= 201703L
+      using OptNonce = std::optional< VanityNonce >;
+#else
+      using OptNonce = tl::optional< VanityNonce >;
+#endif
 
       ServiceInfo() = default;
 
@@ -52,7 +64,7 @@ namespace llarp
         return crypto->verify(signkey, payload, sig);
       }
 
-      const byte_t*
+      const PubKey&
       EncryptionPublicKey() const
       {
         return enckey;
@@ -60,12 +72,14 @@ namespace llarp
 
       bool
       Update(const byte_t* enc, const byte_t* sign,
-             const byte_t* nonce = nullptr)
+             const OptNonce& nonce = OptNonce())
       {
         enckey  = enc;
         signkey = sign;
         if(nonce)
-          vanity = nonce;
+        {
+          vanity = nonce.value();
+        }
         return UpdateAddr();
       }
 

--- a/llarp/service/Info.hpp
+++ b/llarp/service/Info.hpp
@@ -127,7 +127,7 @@ namespace llarp
       BDecode(llarp_buffer_t* buf) override
       {
         if(IBEncodeMessage::BDecode(buf))
-          return CalculateAddress(m_CachedAddr.data());
+          return CalculateAddress(m_CachedAddr.as_array());
         return false;
       }
 

--- a/llarp/service/address.hpp
+++ b/llarp/service/address.hpp
@@ -26,11 +26,16 @@ namespace llarp
       {
       }
 
-      Address(const Data& buf) : AlignedBuffer< SIZE >(buf)
+      explicit Address(const Data& buf) : AlignedBuffer< SIZE >(buf)
       {
       }
 
       Address(const Address& other) : AlignedBuffer< SIZE >(other.as_array())
+      {
+      }
+
+      explicit Address(const AlignedBuffer< SIZE >& other)
+          : AlignedBuffer< SIZE >(other)
       {
       }
 

--- a/llarp/service/address.hpp
+++ b/llarp/service/address.hpp
@@ -14,88 +14,30 @@ namespace llarp
   namespace service
   {
     /// Snapp/Snode Address
-    struct Address
+    struct Address : public AlignedBuffer< 32 >
     {
-      static constexpr size_t SIZE = 32;
-
-      using Data = std::array< byte_t, SIZE >;
-
       std::string
       ToString(const char* tld = ".loki") const;
 
       bool
       FromString(const std::string& str, const char* tld = ".loki");
 
-      Address()
+      Address() : AlignedBuffer< SIZE >()
       {
-        Zero();
       }
 
-      Address(const byte_t* buf)
+      Address(const Data& buf) : AlignedBuffer< SIZE >(buf)
       {
-        std::copy(buf, buf + SIZE, b.begin());
       }
 
-      Address(const Address& other)
+      Address(const Address& other) : AlignedBuffer< SIZE >(other.as_array())
       {
-        b = other.b;
-      }
-
-      byte_t& operator[](size_t idx)
-      {
-        return b[idx];
-      }
-
-      const byte_t& operator[](size_t idx) const
-      {
-        return b[idx];
-      }
-
-      bool
-      BEncode(llarp_buffer_t* buf) const
-      {
-        return bencode_write_bytestring(buf, b.data(), SIZE);
-      }
-
-      bool
-      BDecode(llarp_buffer_t* buf)
-      {
-        llarp_buffer_t strbuf;
-        if(!bencode_read_string(buf, &strbuf))
-          return false;
-        if(strbuf.sz != SIZE)
-        {
-          llarp::LogErrorTag("Address::BDecode",
-                             "bdecode buffer size missmatch ", strbuf.sz,
-                             "!=32");
-          return false;
-        }
-        std::copy(strbuf.base, strbuf.base + SIZE, b.begin());
-        return true;
-      }
-
-      static constexpr size_t
-      size()
-      {
-        return SIZE;
-      }
-
-      bool
-      IsZero() const
-      {
-        return b == Data{};
-      }
-
-      void
-      Zero()
-      {
-        b.fill(0);
       }
 
       bool
       operator<(const Address& other) const
       {
-        return data() < other.data();
+        return as_array() < other.as_array();
       }
 
       friend std::ostream&
@@ -107,40 +49,28 @@ namespace llarp
       bool
       operator==(const Address& other) const
       {
-        return data() == other.data();
+        return as_array() == other.as_array();
       }
 
       bool
       operator!=(const Address& other) const
       {
-        return !(*this == other);
+        return as_array() != other.as_array();
       }
 
       Address&
       operator=(const Address& other) = default;
 
-      const dht::Key_t
+      dht::Key_t
       ToKey() const
       {
-        return dht::Key_t(data());
+        return dht::Key_t(as_array());
       }
 
-      const RouterID
+      RouterID
       ToRouter() const
       {
-        return RouterID(data().data());
-      }
-
-      const Data&
-      data() const
-      {
-        return b;
-      }
-
-      Data&
-      data()
-      {
-        return b;
+        return RouterID(as_array());
       }
 
       struct Hash
@@ -148,13 +78,10 @@ namespace llarp
         size_t
         operator()(const Address& buf) const
         {
-          return std::accumulate(buf.data().begin(), buf.data().end(), 0,
+          return std::accumulate(buf.begin(), buf.end(), 0,
                                  std::bit_xor< size_t >());
         }
       };
-
-     private:
-      Data b;
     };
 
   }  // namespace service

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -141,7 +141,8 @@ namespace llarp
     }
 
     bool
-    Context::FindBestAddressFor(const byte_t *addr, bool isSNode, huint32_t &ip)
+    Context::FindBestAddressFor(const llarp::AlignedBuffer< 32 > &addr,
+                                bool isSNode, huint32_t &ip)
     {
       auto itr = m_Endpoints.begin();
       while(itr != m_Endpoints.end())

--- a/llarp/service/context.hpp
+++ b/llarp/service/context.hpp
@@ -33,7 +33,8 @@ namespace llarp
       getFirstEndpoint();
 
       bool
-      FindBestAddressFor(const byte_t *addr, bool isSNode, huint32_t &);
+      FindBestAddressFor(const llarp::AlignedBuffer< 32 > &addr, bool isSNode,
+                         huint32_t &);
 
       /// DRY refactor
       llarp::handlers::TunEndpoint *

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -1164,7 +1164,7 @@ namespace llarp
     Endpoint::SendToServiceOrQueue(const RouterID& addr, llarp_buffer_t data,
                                    ProtocolType t)
     {
-      service::Address remote(addr);
+      service::Address remote(addr.as_array());
 
       // inbound converstation
       auto now = Now();

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -467,7 +467,7 @@ namespace llarp
       auto itr = m_Sessions.find(tag);
       if(itr == m_Sessions.end())
         return false;
-      secret = itr->second.sharedKey.data();
+      secret = itr->second.sharedKey.as_array().data();
       return true;
     }
 
@@ -563,7 +563,7 @@ namespace llarp
     Endpoint::PublishIntroSet(llarp::Router* r)
     {
       // publish via near router
-      RouterID location = m_Identity.pub.Addr().data().data();
+      RouterID location = m_Identity.pub.Addr().as_array();
       auto path         = GetEstablishedPathClosestTo(location);
       return path && PublishIntroSetVia(r, path);
     }
@@ -696,7 +696,7 @@ namespace llarp
     Endpoint::PutNewOutboundContext(const llarp::service::IntroSet& introset)
     {
       Address addr;
-      introset.A.CalculateAddress(addr.data());
+      introset.A.CalculateAddress(addr.as_array());
 
       if(m_RemoteSessions.count(addr) >= MAX_OUTBOUND_CONTEXT_COUNT)
       {
@@ -858,10 +858,9 @@ namespace llarp
       if(msg->proto == eProtocolTraffic)
       {
         auto buf = llarp::Buffer(msg->payload);
-        return HandleWriteIPPacket(
-            buf,
-            std::bind(&Endpoint::ObtainIPForAddr, this,
-                      msg->sender.Addr().data().data(), false));
+        return HandleWriteIPPacket(buf,
+                                   std::bind(&Endpoint::ObtainIPForAddr, this,
+                                             msg->sender.Addr(), false));
       }
       else if(msg->proto == eProtocolText)
       {
@@ -1139,7 +1138,7 @@ namespace llarp
     }
 
     bool
-    Endpoint::SendToSNodeOrQueue(const byte_t* addr, llarp_buffer_t buf)
+    Endpoint::SendToSNodeOrQueue(const RouterID& addr, llarp_buffer_t buf)
     {
       llarp::net::IPv4Packet pkt;
       if(!pkt.Load(buf))
@@ -1162,7 +1161,7 @@ namespace llarp
     }
 
     bool
-    Endpoint::SendToServiceOrQueue(const byte_t* addr, llarp_buffer_t data,
+    Endpoint::SendToServiceOrQueue(const RouterID& addr, llarp_buffer_t data,
                                    ProtocolType t)
     {
       service::Address remote(addr);
@@ -1583,7 +1582,7 @@ namespace llarp
       if(randomizePath)
         path = m_Endpoint->PickRandomEstablishedPath();
       else
-        path = m_Endpoint->GetEstablishedPathClosestTo(addr.data());
+        path = m_Endpoint->GetEstablishedPathClosestTo(addr.as_array());
 
       if(path)
       {

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -107,7 +107,7 @@ namespace llarp
       ObtainIPForAddr(const AlignedBuffer< 32 >& addr, bool serviceNode) = 0;
 
       virtual bool
-      HasAddress(const byte_t* addr) const = 0;
+      HasAddress(const AlignedBuffer< 32 >& addr) const = 0;
 
       /// return true if we have a pending job to build to a hidden service but
       /// it's not done yet
@@ -177,7 +177,7 @@ namespace llarp
         llarp_buffer_t
         Buffer()
         {
-          return llarp::InitBuffer(payload.data(), payload.size());
+          return llarp::Buffer(payload);
         }
       };
 
@@ -351,7 +351,7 @@ namespace llarp
 
       bool
       GetCachedSessionKeyFor(const ConvoTag& remote,
-                             const byte_t*& secret) const override;
+                             SharedSecret& secret) const override;
       void
       PutCachedSessionKeyFor(const ConvoTag& remote,
                              const SharedSecret& secret) override;

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -20,7 +20,7 @@ namespace llarp
 {
   namespace service
   {
-    // foward declare
+    // forward declare
     struct AsyncKeyExchange;
 
     struct Endpoint : public path::Builder,
@@ -104,7 +104,7 @@ namespace llarp
       HasPathToService(const Address& remote) const;
 
       virtual huint32_t
-      ObtainIPForAddr(const byte_t* addr, bool serviceNode) = 0;
+      ObtainIPForAddr(const AlignedBuffer< 32 >& addr, bool serviceNode) = 0;
 
       virtual bool
       HasAddress(const byte_t* addr) const = 0;
@@ -154,11 +154,11 @@ namespace llarp
       HandlePathBuilt(path::Path* path) override;
 
       bool
-      SendToServiceOrQueue(const byte_t* addr, llarp_buffer_t payload,
+      SendToServiceOrQueue(const RouterID& addr, llarp_buffer_t payload,
                            ProtocolType t);
 
       bool
-      SendToSNodeOrQueue(const byte_t* addr, llarp_buffer_t payload);
+      SendToSNodeOrQueue(const RouterID& addr, llarp_buffer_t payload);
 
       void
       FlushSNodeTraffic();

--- a/llarp/service/handler.hpp
+++ b/llarp/service/handler.hpp
@@ -20,7 +20,7 @@ namespace llarp
 
       virtual bool
       GetCachedSessionKeyFor(const ConvoTag& remote,
-                             const byte_t*& secret) const = 0;
+                             SharedSecret& secret) const = 0;
       virtual void
       PutCachedSessionKeyFor(const ConvoTag& remote,
                              const SharedSecret& secret) = 0;

--- a/llarp/service/info.cpp
+++ b/llarp/service/info.cpp
@@ -50,7 +50,7 @@ namespace llarp
       if(m_CachedAddr.IsZero())
       {
         Address addr;
-        CalculateAddress(addr.data());
+        CalculateAddress(addr.as_array());
         return addr.ToString();
       }
       return m_CachedAddr.ToString();
@@ -70,7 +70,7 @@ namespace llarp
     bool
     ServiceInfo::UpdateAddr()
     {
-      return CalculateAddress(m_CachedAddr.data());
+      return CalculateAddress(m_CachedAddr.as_array());
     }
 
   }  // namespace service

--- a/llarp/service/protocol.cpp
+++ b/llarp/service/protocol.cpp
@@ -266,11 +266,9 @@ namespace llarp
           delete self;
           return;
         }
-        byte_t tmp[64];
-        // K
-        memcpy(tmp, K, 32);
         // PKE (A, B, N)
-        if(!self->m_LocalIdentity.KeyExchange(crypto->dh_server, tmp + 32,
+        SharedSecret sharedSecret;
+        if(!self->m_LocalIdentity.KeyExchange(crypto->dh_server, sharedSecret,
                                               self->msg->sender, self->frame.N))
         {
           llarp::LogError("x25519 key exchange failed");
@@ -279,7 +277,11 @@ namespace llarp
           delete self;
           return;
         }
+        std::array< byte_t, 64 > tmp;
+        // K
+        std::copy(K.begin(), K.end(), tmp.begin());
         // S = HS( K + PKE( A, B, N))
+        std::copy(sharedSecret.begin(), sharedSecret.end(), tmp.begin() + 32);
         crypto->shorthash(sharedKey, StackBuffer< decltype(tmp) >(tmp));
 
         self->handler->PutIntroFor(self->msg->tag, self->msg->introReply);

--- a/llarp/service/protocol.cpp
+++ b/llarp/service/protocol.cpp
@@ -154,7 +154,7 @@ namespace llarp
 
     bool
     ProtocolFrame::DecryptPayloadInto(llarp::Crypto* crypto,
-                                      const byte_t* sharedkey,
+                                      const SharedSecret& sharedkey,
                                       ProtocolMessage& msg) const
     {
       Encrypted_t tmp = D;
@@ -166,7 +166,7 @@ namespace llarp
     bool
     ProtocolFrame::EncryptAndSign(llarp::Crypto* crypto,
                                   const ProtocolMessage& msg,
-                                  const byte_t* sessionKey,
+                                  const SharedSecret& sessionKey,
                                   const Identity& localIdent)
     {
       byte_t tmp[MAX_PROTOCOL_MESSAGE_SIZE];
@@ -325,7 +325,7 @@ namespace llarp
         llarp_threadpool_queue_job(worker, {dh, &AsyncFrameDecrypt::Work});
         return true;
       }
-      const byte_t* shared = nullptr;
+      SharedSecret shared;
       if(!handler->GetCachedSessionKeyFor(T, shared))
       {
         llarp::LogError("No cached session for T=", T);

--- a/llarp/service/protocol.hpp
+++ b/llarp/service/protocol.hpp
@@ -99,7 +99,7 @@ namespace llarp
 
       bool
       EncryptAndSign(llarp::Crypto* c, const ProtocolMessage& msg,
-                     const byte_t* sharedkey, const Identity& localIdent);
+                     const SharedSecret& sharedkey, const Identity& localIdent);
 
       bool
       AsyncDecryptAndVerify(llarp::Logic* logic, llarp::Crypto* c,
@@ -108,7 +108,7 @@ namespace llarp
                             IDataHandler* handler) const;
 
       bool
-      DecryptPayloadInto(llarp::Crypto* c, const byte_t* sharedkey,
+      DecryptPayloadInto(llarp::Crypto* c, const SharedSecret& sharedkey,
                          ProtocolMessage& into) const;
 
       bool

--- a/llarp/service/tag.cpp
+++ b/llarp/service/tag.cpp
@@ -7,7 +7,7 @@ namespace llarp
     std::string
     Tag::ToString() const
     {
-      return std::string((const char *)data());
+      return std::string(begin(), end());
     }
   }  // namespace service
 }  // namespace llarp

--- a/llarp/service/tag.hpp
+++ b/llarp/service/tag.hpp
@@ -29,7 +29,7 @@ namespace llarp
         // evidently, does nothing on LP64 systems (where size_t is *already*
         // unsigned long but zero-extends this on LLP64 systems
         std::copy(str.begin(), str.begin() + std::min(16UL, str.size()),
-                  as_array().begin());
+                  begin());
       }
 
       Tag&
@@ -43,7 +43,7 @@ namespace llarp
       operator=(const std::string& str)
       {
         std::copy(str.begin(), str.begin() + std::min(16UL, str.size()),
-                  as_array().begin());
+                  begin());
         return *this;
       }
 

--- a/llarp/service/tag.hpp
+++ b/llarp/service/tag.hpp
@@ -16,11 +16,11 @@ namespace llarp
   {
     struct Tag : public llarp::AlignedBuffer< 16 >
     {
-      Tag() : llarp::AlignedBuffer< 16 >()
+      Tag() : llarp::AlignedBuffer< SIZE >()
       {
       }
 
-      Tag(const byte_t* d) : llarp::AlignedBuffer< 16 >(d)
+      Tag(const byte_t* d) : llarp::AlignedBuffer< SIZE >(d)
       {
       }
 
@@ -28,20 +28,22 @@ namespace llarp
       {
         // evidently, does nothing on LP64 systems (where size_t is *already*
         // unsigned long but zero-extends this on LLP64 systems
-        memcpy(data(), str.c_str(), std::min(16UL, (unsigned long)str.size()));
+        std::copy(str.begin(), str.begin() + std::min(16UL, str.size()),
+                  as_array().begin());
       }
 
       Tag&
       operator=(const Tag& other)
       {
-        memcpy(data(), other.data(), 16);
+        as_array() = other.as_array();
         return *this;
       }
 
       Tag&
       operator=(const std::string& str)
       {
-        memcpy(data(), str.data(), std::min(16UL, (unsigned long)str.size()));
+        std::copy(str.begin(), str.begin() + std::min(16UL, str.size()),
+                  as_array().begin());
         return *this;
       }
 

--- a/test/encrypted_frame_unittest.cpp
+++ b/test/encrypted_frame_unittest.cpp
@@ -53,7 +53,7 @@ TEST_F(FrameTest, TestFrameCrypto)
   // rewind buffer
   buf->cur = buf->base + llarp::EncryptedFrameOverheadSize;
   // encrypt to alice
-  ASSERT_TRUE(f.EncryptInPlace(alice, llarp::seckey_topublic(bob), &crypto));
+  ASSERT_TRUE(f.EncryptInPlace(alice, bob.toPublic(), &crypto));
   // decrypt from alice
   ASSERT_TRUE(f.DecryptInPlace(bob, &crypto));
 

--- a/test/hiddenservice_unittest.cpp
+++ b/test/hiddenservice_unittest.cpp
@@ -5,11 +5,10 @@
 
 struct HiddenServiceTest : public ::testing::Test
 {
-    llarp::Crypto crypto;
+  llarp::Crypto crypto;
   llarp::service::Identity ident;
 
-  HiddenServiceTest()
-  : crypto(llarp::Crypto::sodium{})
+  HiddenServiceTest() : crypto(llarp::Crypto::sodium{})
   {
   }
 
@@ -31,7 +30,7 @@ struct HiddenServiceTest : public ::testing::Test
 TEST_F(HiddenServiceTest, TestGenerateIntroSet)
 {
   llarp::service::Address addr;
-  ASSERT_TRUE(ident.pub.CalculateAddress(addr.data()));
+  ASSERT_TRUE(ident.pub.CalculateAddress(addr.as_array()));
   llarp::service::IntroSet I;
   auto now = llarp::time_now_ms();
   I.T      = now;

--- a/test/obtain_exit_unittest.cpp
+++ b/test/obtain_exit_unittest.cpp
@@ -7,11 +7,10 @@ using ObtainExitMessage = llarp::routing::ObtainExitMessage;
 class ObtainExitTest : public ::testing::Test
 {
  public:
-     llarp::Crypto crypto;
+  llarp::Crypto crypto;
   llarp::SecretKey alice;
 
-  ObtainExitTest()
-  : crypto(llarp::Crypto::sodium{})
+  ObtainExitTest() : crypto(llarp::Crypto::sodium{})
   {
   }
 
@@ -32,9 +31,9 @@ TEST_F(ObtainExitTest, TestSignVerify)
   msg.Z.Zero();
   msg.S = llarp::randint();
   msg.T = llarp::randint();
-  ASSERT_TRUE(msg.Sign(&crypto, alice));
-  ASSERT_TRUE(msg.Verify(&crypto));
-  ASSERT_TRUE(msg.I == llarp::PubKey(llarp::seckey_topublic(alice)));
-  ASSERT_FALSE(msg.version != LLARP_PROTO_VERSION);
-  ASSERT_FALSE(msg.Z.IsZero());
+  EXPECT_TRUE(msg.Sign(&crypto, alice));
+  EXPECT_TRUE(msg.Verify(&crypto));
+  EXPECT_TRUE(msg.I == llarp::PubKey(llarp::seckey_topublic(alice)));
+  EXPECT_FALSE(msg.version != LLARP_PROTO_VERSION);
+  EXPECT_FALSE(msg.Z.IsZero());
 };

--- a/test/pq_unittest.cpp
+++ b/test/pq_unittest.cpp
@@ -6,11 +6,10 @@ namespace llarp
 {
   struct PQCryptoTest : public ::testing::Test
   {
-      llarp::Crypto crypto;
+    llarp::Crypto crypto;
     PQKeyPair keys;
 
-    PQCryptoTest()
-    : crypto(llarp::Crypto::sodium{})
+    PQCryptoTest() : crypto(llarp::Crypto::sodium{})
     {
     }
 

--- a/test/pq_unittest.cpp
+++ b/test/pq_unittest.cpp
@@ -33,7 +33,8 @@ namespace llarp
     auto c = Crypto();
 
     ASSERT_TRUE(keys.size() == PQ_KEYPAIRSIZE);
-    ASSERT_TRUE(c->pqe_encrypt(block, shared, pq_keypair_to_public(keys)));
+    ASSERT_TRUE(
+        c->pqe_encrypt(block, shared, PQPubKey(pq_keypair_to_public(keys))));
     ASSERT_TRUE(c->pqe_decrypt(block, otherShared, pq_keypair_to_secret(keys)));
     ASSERT_TRUE(otherShared == shared);
   }

--- a/test/test_llarp_aligned.cpp
+++ b/test/test_llarp_aligned.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(AlignedBufferTest, AltConstructors)
   Buffer c(b.as_array());
   EXPECT_FALSE(c.IsZero());
 
-  Buffer d(c.as_array().data());
+  Buffer d(c.data());
   EXPECT_FALSE(d.IsZero());
 }
 

--- a/test/test_llarp_aligned.cpp
+++ b/test/test_llarp_aligned.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(AlignedBufferTest, AltConstructors)
   Buffer c(b.as_array());
   EXPECT_FALSE(c.IsZero());
 
-  Buffer d(c.data());
+  Buffer d(c.as_array().data());
   EXPECT_FALSE(d.IsZero());
 }
 

--- a/test/utp_unittest.cpp
+++ b/test/utp_unittest.cpp
@@ -230,7 +230,7 @@ TEST_F(UTPTest, TestAliceRenegWithBob)
       [&](llarp::RouterContact rc) {
         ASSERT_EQ(rc, Alice.GetRC());
         llarp::LogInfo("bob established with alice");
-        Bob.link->VisitSessionByPubkey(Alice.GetRC().pubkey.data(),
+        Bob.link->VisitSessionByPubkey(Alice.GetRC().pubkey.as_array(),
                                        sendDiscardMessage);
       },
       [&](llarp::RouterContact newrc, llarp::RouterContact oldrc) -> bool {
@@ -318,7 +318,7 @@ TEST_F(UTPTest, TestAliceConnectToBob)
       [&](llarp::RouterContact rc) {
         ASSERT_EQ(rc, Alice.GetRC());
         llarp::LogInfo("bob established with alice");
-        Bob.link->VisitSessionByPubkey(Alice.GetRC().pubkey.data(),
+        Bob.link->VisitSessionByPubkey(Alice.GetRC().pubkey.as_array(),
                                        sendDiscardMessage);
       },
       [&](llarp::RouterContact, llarp::RouterContact) -> bool { return true; },


### PR DESCRIPTION
I understand parts of this may be controversial.

There are several key components to this PR:
- Explicitly type the crypto APIs where possible
- Pass `AlignedBuffer`s by reference, keeping the same types for as long as possible.
- Reduce the number of copies by lifting further up the stack
  - Notably, there were several `std::unordered_map`s using `RouterID` etc as keys, where each lookup was creating new buffers on the stack, inside loops