### PR TITLE
let's get this show on the road

### DIFF
--- a/include/tl/optional.hpp
+++ b/include/tl/optional.hpp
@@ -343,8 +343,8 @@ namespace tl
     using enable_assign_forward = detail::enable_if_t<
         !std::is_same< optional< T >, detail::decay_t< U > >::value
         && !detail::conjunction<
-            std::is_scalar< T >,
-            std::is_same< T, detail::decay_t< U > > >::value
+               std::is_scalar< T >,
+               std::is_same< T, detail::decay_t< U > > >::value
         && std::is_constructible< T, U >::value
         && std::is_assignable< T &, U >::value >;
 
@@ -465,7 +465,7 @@ namespace tl
                           0))::value &&detail::swap_adl_tests::
                            is_std_swap_noexcept< T >::value)
                       || (!decltype(detail::swap_adl_tests::uses_std< T, U >(
-                          0))::value &&detail::swap_adl_tests::
+                             0))::value &&detail::swap_adl_tests::
                               is_adl_swap_noexcept< T, U >::value)) >
     {
     };

--- a/llarp/ev_win32.hpp
+++ b/llarp/ev_win32.hpp
@@ -57,98 +57,13 @@ struct win32_tun_io
   device* tunif;
   byte_t readbuf[EV_READ_BUF_SZ] = {0};
 
-  struct WriteBuffer
-  {
-    llarp_time_t timestamp = 0;
-    size_t bufsz;
-    byte_t buf[EV_WRITE_BUF_SZ];
-
-    WriteBuffer() = default;
-
-    WriteBuffer(const byte_t* ptr, size_t sz)
-    {
-      if(sz <= sizeof(buf))
-      {
-        bufsz = sz;
-        memcpy(buf, ptr, bufsz);
-      }
-      else
-        bufsz = 0;
-    }
-
-    struct GetTime
-    {
-      llarp_time_t
-      operator()(const WriteBuffer& buf) const
-      {
-        return buf.timestamp;
-      }
-    };
-
-    struct GetNow
-    {
-      void* loop;
-      GetNow(void* l) : loop(l)
-      {
-      }
-
-      llarp_time_t
-      operator()() const
-      {
-        return llarp::time_now_ms();
-      }
-    };
-
-    struct PutTime
-    {
-      void* loop;
-      PutTime(void* l) : loop(l)
-      {
-      }
-      void
-      operator()(WriteBuffer& buf)
-      {
-        buf.timestamp = llarp::time_now_ms();
-      }
-    };
-
-    struct Compare
-    {
-      bool
-      operator()(const WriteBuffer& left, const WriteBuffer& right) const
-      {
-        return left.timestamp < right.timestamp;
-      }
-    };
-  };
-
-  using LossyWriteQueue_t =
-      llarp::util::CoDelQueue< WriteBuffer, WriteBuffer::GetTime,
-                               WriteBuffer::PutTime, WriteBuffer::Compare,
-                               WriteBuffer::GetNow, llarp::util::NullMutex,
-                               llarp::util::NullLock, 5, 100, 128 >;
-
-  std::unique_ptr< LossyWriteQueue_t > m_LossyWriteQueue;
-
-  win32_tun_io(llarp_tun_io* tio) : t(tio), tunif(tuntap_init())
-  {
-    // This is not your normal everyday event loop, this is _advanced_ event
-    // handling :>
-    m_LossyWriteQueue = std::make_unique< LossyWriteQueue_t >("win32_tun_queue",
-                                                              nullptr, nullptr);
-  };
+  win32_tun_io(llarp_tun_io* tio) : t(tio), tunif(tuntap_init()){};
 
   bool
   queue_write(const byte_t* buf, size_t sz)
   {
-    if(m_LossyWriteQueue)
-    {
-      m_LossyWriteQueue->Emplace(buf, sz);
-      flush_write();
-      return true;
-    }
-    else
-      return false;
+    do_write((void*)buf, sz);
+    return true;
   }
 
   bool
@@ -210,7 +125,6 @@ struct win32_tun_io
   void
   do_write(void* data, size_t sz)
   {
-    llarp::LogInfo("writing some data");
     asio_evt_pkt* pkt = new asio_evt_pkt;
     pkt->buf          = data;
     pkt->sz           = sz;
@@ -226,11 +140,6 @@ struct win32_tun_io
   {
     if(t->before_write)
       t->before_write(t);
-    m_LossyWriteQueue->Process([&](WriteBuffer& buffer) {
-      do_write(buffer.buf, buffer.bufsz);
-      // we are NEVER going to block
-      // because Windows NT implements true async io
-    });
   }
 
   void
@@ -279,17 +188,21 @@ tun_ev_loop(void* unused)
     if(!pkt->write)
     {
       // llarp::LogInfo("read tun ", size, " bytes, pass to handler");
+      // skip if our buffer remains empty
+      if(*(byte_t*)pkt->buf == '\0')
+        continue;
       if(ev->t->recvpkt)
         ev->t->recvpkt(ev->t, llarp::InitBuffer(pkt->buf, size));
-      ev->flush_write();
       ev->read(ev->readbuf, sizeof(ev->readbuf));
     }
     else
     {
-      llarp::LogInfo("write ", size, " bytes to tunnel interface");
       // ok let's queue another read!
       ev->read(ev->readbuf, sizeof(ev->readbuf));
     }
+    if(ev->t->tick)
+      ev->t->tick(ev->t);
+    ev->flush_write();
     delete pkt;  // don't leak
   }
   llarp::LogInfo("exit TUN event loop thread from system managed thread pool");

--- a/llarp/exit/endpoint.cpp
+++ b/llarp/exit/endpoint.cpp
@@ -78,7 +78,7 @@ namespace llarp
       if(!path)
         return true;
       auto lastPing = path->LastRemoteActivityAt();
-      if(lastPing == 0 || ( now > lastPing && now - lastPing > timeout))
+      if(lastPing == 0 || (now > lastPing && now - lastPing > timeout))
         return now > m_LastActive && now - m_LastActive > timeout;
       else if(lastPing)
         return now > lastPing && now - lastPing > timeout;

--- a/llarp/exit/session.cpp
+++ b/llarp/exit/session.cpp
@@ -35,10 +35,12 @@ namespace llarp
       // check 30 seconds into the future and see if we need more paths
       const llarp_time_t future = now + (30 * 1000);
       if(NumPathsExistingAt(future) < expect)
-        return llarp::randint() % 4 == 0; // 25% chance for build if we will run out soon
-      // if we don't have the expended number of paths right now try building some if the cooldown timer isn't hit
+        return llarp::randint() % 4
+            == 0;  // 25% chance for build if we will run out soon
+      // if we don't have the expended number of paths right now try building
+      // some if the cooldown timer isn't hit
       if(AvailablePaths(llarp::path::ePathRoleExit) < expect)
-        return !path::Builder::BuildCooldownHit(now); 
+        return !path::Builder::BuildCooldownHit(now);
       // maintain regular number of paths
       return path::Builder::ShouldBuildMore(now);
     }

--- a/llarp/exit/session.cpp
+++ b/llarp/exit/session.cpp
@@ -189,7 +189,7 @@ namespace llarp
       {
         for(auto& item : m_Upstream)
         {
-          auto& queue = item.second;
+          auto& queue = item.second;// XXX: uninitialised memory here!
           while(queue.size())
           {
             auto& msg = queue.front();

--- a/llarp/logger.hpp
+++ b/llarp/logger.hpp
@@ -229,8 +229,8 @@ namespace llarp
     std::string tag = fname;
     if(_glog.nodeName.size())
       ss << _glog.nodeName << " ";
-    ss << "(" << thread_id_string() << ") "
-       << log_timestamp() << " " << tag << ":" << lineno;
+    ss << "(" << thread_id_string() << ") " << log_timestamp() << " " << tag
+       << ":" << lineno;
     ss << "\t";
     LogAppend(ss, std::forward< TArgs >(args)...);
 #ifndef ANDROID

--- a/llarp/messages/dht.hpp
+++ b/llarp/messages/dht.hpp
@@ -25,12 +25,11 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override;
 
-      void 
-      Clear() override 
+      void
+      Clear() override
       {
         M.clear();
       }
-
     };
   }  // namespace routing
 }  // namespace llarp

--- a/llarp/messages/discard.hpp
+++ b/llarp/messages/discard.hpp
@@ -61,7 +61,10 @@ namespace llarp
         version = LLARP_PROTO_VERSION;
       }
 
-      void Clear() override {}
+      void
+      Clear() override
+      {
+      }
 
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override

--- a/llarp/messages/exit.hpp
+++ b/llarp/messages/exit.hpp
@@ -32,7 +32,7 @@ namespace llarp
       operator=(const ObtainExitMessage& other);
 
       void
-      Clear() override 
+      Clear() override
       {
         B.clear();
         W.clear();
@@ -87,8 +87,10 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override;
 
-      void 
-      Clear() override {}
+      void
+      Clear() override
+      {
+      }
     };
 
     struct RejectExitMessage final : public IMessage
@@ -108,7 +110,7 @@ namespace llarp
       {
       }
 
-      void 
+      void
       Clear() override
       {
         R.clear();
@@ -148,8 +150,10 @@ namespace llarp
       {
       }
 
-      void 
-      Clear() override {}
+      void
+      Clear() override
+      {
+      }
 
       UpdateExitVerifyMessage&
       operator=(const UpdateExitVerifyMessage& other);
@@ -204,8 +208,10 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override;
 
-      void 
-      Clear() override {}
+      void
+      Clear() override
+      {
+      }
     };
 
     struct CloseExitMessage final : public IMessage
@@ -240,9 +246,11 @@ namespace llarp
 
       bool
       Verify(llarp::Crypto* c, const llarp::PubKey& pk) const;
-      
-      void 
-      Clear() override {}
+
+      void
+      Clear() override
+      {
+      }
     };
 
   }  // namespace routing

--- a/llarp/messages/path_confirm.hpp
+++ b/llarp/messages/path_confirm.hpp
@@ -24,8 +24,8 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override;
 
-      void 
-      Clear() override {};
+      void
+      Clear() override{};
     };
   }  // namespace routing
 }  // namespace llarp

--- a/llarp/messages/path_latency.hpp
+++ b/llarp/messages/path_latency.hpp
@@ -19,7 +19,8 @@ namespace llarp
       bool
       DecodeKey(llarp_buffer_t key, llarp_buffer_t* val) override;
 
-      void Clear() override {};
+      void
+      Clear() override{};
 
       bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const override;

--- a/llarp/messages/path_transfer.hpp
+++ b/llarp/messages/path_transfer.hpp
@@ -33,8 +33,8 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler*, llarp::Router* r) const override;
 
-      void 
-      Clear() override 
+      void
+      Clear() override
       {
         T.Clear();
       }

--- a/llarp/messages/transfer_traffic.hpp
+++ b/llarp/messages/transfer_traffic.hpp
@@ -19,7 +19,8 @@ namespace llarp
       std::vector< llarp::Encrypted< MaxExitMTU + ExitOverhead > > X;
       size_t _size = 0;
 
-      void Clear() override
+      void
+      Clear() override
       {
         X.clear();
       }

--- a/llarp/path.cpp
+++ b/llarp/path.cpp
@@ -586,6 +586,10 @@ namespace llarp
     {
       byte_t tmp[MAX_LINK_MSG_SIZE / 2];
       auto buf = llarp::StackBuffer< decltype(tmp) >(tmp);
+      // should help prevent bad paths with uninitialised members
+      // FIXME: Why would we get uninitialised IMessages?
+      if(msg->version != LLARP_PROTO_VERSION)
+        return false;
       if(!msg->BEncode(&buf))
       {
         llarp::LogError("Bencode failed");

--- a/llarp/pathbuilder.cpp
+++ b/llarp/pathbuilder.cpp
@@ -219,8 +219,7 @@ namespace llarp
     bool
     Builder::BuildCooldownHit(llarp_time_t now) const
     {
-      return now < lastBuild
-          || now - lastBuild < buildIntervalLimit;
+      return now < lastBuild || now - lastBuild < buildIntervalLimit;
     }
 
     bool

--- a/llarp/pathbuilder.hpp
+++ b/llarp/pathbuilder.hpp
@@ -48,7 +48,7 @@ namespace llarp
       ShouldBuildMore(llarp_time_t now) const override;
 
       /// return true if we hit our soft limit for building paths too fast
-      bool 
+      bool
       BuildCooldownHit(llarp_time_t now) const;
 
       virtual bool

--- a/llarp/resource.h
+++ b/llarp/resource.h
@@ -4,12 +4,12 @@
 //
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        101
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1000
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_RESOURCE_VALUE 101
+#define _APS_NEXT_COMMAND_VALUE 40001
+#define _APS_NEXT_CONTROL_VALUE 1000
+#define _APS_NEXT_SYMED_VALUE 101
 #endif
 #endif

--- a/llarp/router.cpp
+++ b/llarp/router.cpp
@@ -526,7 +526,8 @@ namespace llarp
   }
 
   bool
-  Router::ParseRoutingMessageBuffer(llarp_buffer_t buf, routing::IMessageHandler * h, PathID_t rxid)
+  Router::ParseRoutingMessageBuffer(llarp_buffer_t buf,
+                                    routing::IMessageHandler *h, PathID_t rxid)
   {
     return inbound_routing_msg_parser.ParseMessageBuffer(buf, h, rxid, this);
   }

--- a/llarp/router.hpp
+++ b/llarp/router.hpp
@@ -340,11 +340,12 @@ namespace llarp
     llarp::ILinkLayer *
     GetLinkWithSessionByPubkey(const llarp::RouterID &remote);
 
-
-    /// parse a routing message in a buffer and handle it with a handler if successful parsing
-    /// return true on parse and handle success otherwise return false
+    /// parse a routing message in a buffer and handle it with a handler if
+    /// successful parsing return true on parse and handle success otherwise
+    /// return false
     bool
-    ParseRoutingMessageBuffer(llarp_buffer_t buf, routing::IMessageHandler * h, PathID_t rxid);
+    ParseRoutingMessageBuffer(llarp_buffer_t buf, routing::IMessageHandler *h,
+                              PathID_t rxid);
 
     void
     ConnectToRandomRouters(int N);

--- a/llarp/routing/handler.hpp
+++ b/llarp/routing/handler.hpp
@@ -18,8 +18,6 @@ namespace llarp
     // handles messages on the routing level
     struct IMessageHandler
     {
-      
-
       virtual bool
       HandleObtainExitMessage(const ObtainExitMessage *msg,
                               llarp::Router *r) = 0;

--- a/llarp/routing/message.hpp
+++ b/llarp/routing/message.hpp
@@ -26,11 +26,10 @@ namespace llarp
       virtual bool
       HandleMessage(IMessageHandler* h, llarp::Router* r) const = 0;
 
-      virtual void 
+      virtual void
       Clear() = 0;
     };
 
-    
   }  // namespace routing
 }  // namespace llarp
 

--- a/llarp/routing/message_parser.hpp
+++ b/llarp/routing/message_parser.hpp
@@ -9,11 +9,11 @@
 #include <messages/path_latency.hpp>
 #include <messages/path_transfer.hpp>
 
-namespace llarp 
+namespace llarp
 {
   struct Router;
 
-  namespace routing 
+  namespace routing
   {
     struct IMessageHandler;
 
@@ -31,8 +31,8 @@ namespace llarp
       bool firstKey;
       char key;
       dict_reader reader;
-      
-      struct MessageHolder 
+
+      struct MessageHolder
       {
         DataDiscardMessage D;
         PathLatencyMessage L;
@@ -48,9 +48,9 @@ namespace llarp
         CloseExitMessage C;
       };
 
-      IMessage * msg = nullptr;
+      IMessage* msg = nullptr;
       MessageHolder m_Holder;
     };
-  }
-}
+  }  // namespace routing
+}  // namespace llarp
 #endif

--- a/llarp/win32_upoll.c
+++ b/llarp/win32_upoll.c
@@ -176,9 +176,6 @@ upoll_ctl(upoll_t* upq, int op, intptr_t fd, upoll_event_t* event)
 int
 upoll_wait_select(upoll_t* upq, upoll_event_t* evs, int nev, int timeout)
 {
-  /* ok we need to test each file descriptor to see whether it is a real file
-   * or a socket. select any file handles (they are always ready)
-   */
   if(nev > FD_SETSIZE)
     nev = FD_SETSIZE;
 

--- a/llarp/win32_upoll.h
+++ b/llarp/win32_upoll.h
@@ -29,10 +29,12 @@
 #include <sys/stat.h>
 
 // this is probably big enough to get
-// the lesser of 4096 sockets or whatever
+// the lesser of 96 sockets or whatever
 // the system allows
+// this used to be 4096, but i think
+// that took ages to process
 #ifndef FD_SETSIZE
-#define FD_SETSIZE 4096
+#define FD_SETSIZE 96
 #endif
 
 #include <io.h>


### PR DESCRIPTION
windows port should be working now
still need to do some testing on my other devices
features such as setting lokinet as default route will be the next pull
but hidden service and service node access is working
```
i'd think the event loop queues are a thing because
of the way unix handles non-blocking i/o
[got to wait for files/sockets to become writable, 
so once you get the data off the network card, 
you still have to wait for the device to become ready, 
so you put the data on the queue until then]

but on windows, async i/o to sockets, files, or devices is easy
no need to wait for anything
```