### PR TITLE
Consolidate multiple CONTRIBUTING files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,0 @@
-
-* RUN `make format && make lint -j8` BEFORE COMMITING ALWAYS.
-
-* no tabs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 * Act like a responsible adult.
 
-* RUN `make format && make lint -j8` BEFORE COMMITING ALWAYS.
+* RUN `make format` BEFORE COMMITING ALWAYS.
 
 # Do NOT
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 * Act like a responsible adult.
 
-* RUN `make format` BEFORE COMMITING ALWAYS.
+* RUN `make format && make lint -j8` BEFORE COMMITING ALWAYS.
 
 # Do NOT
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,3 @@
 
 * Merge large and pointless or pedantic changes, (i.e. code formatting shift)
 
-## additional notes
-
-github's ui doesn't seem accept this file as a real code of conduct.


### PR DESCRIPTION
1. The .github copy is what currently appears when creating pull requests
2. The .github copy is older and sparser
3. I'm pretty sure the presence of the .github copy is what prevents the root copy from being respected <https://blog.github.com/2016-02-17-issue-and-pull-request-templates/>

All that being said, I don't have an easy way to test that this does what I expect before it is merged.  And is the `lint` pass still requested?
