### PR TITLE
Add flag to generate coverage data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ rapidjson/
 .vscode
 build64/
 build2/
+default.profraw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(JEMALLOC "use jemalloc. Not required on BSD" )
 option(DEBIAN "build for debian" )
 option(TESTNET "testnet build" )
 option(WITH_SHARED "build shared library")
+option(WITH_COVERAGE "generate coverage data")
 
 if(WIN32)
   set(CMAKE_CXX_STANDARD 17)
@@ -43,6 +44,16 @@ add_compile_options(-Wall -Wextra -Werror -Wno-unknown-pragmas -Wno-unknown-warn
 add_compile_options(-Wvla)
 add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
 add_compile_options(-Wno-unused-function -Wno-deprecated-declarations -Wno-unknown-pragmas)
+
+if (WITH_COVERAGE)
+  if (USING_CLANG)
+    add_compile_options( -fprofile-instr-generate -fcoverage-mapping )
+    link_libraries( -fprofile-instr-generate )
+  else()
+    add_compile_options( --coverage -g0 )
+    link_libraries( --coverage )
+  endif()
+endif()
 
 # these vars are set by the cmake toolchain spec
 if (WOW64_CROSS_COMPILE OR WIN64_CROSS_COMPILE)

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ CLANG ?= OFF
 CROSS ?= OFF
 # build liblokinet-shared.so
 SHARED_LIB ?= ON
+# enable generating coverage
+COVERAGE =? OFF
 # cmake generator type
 CMAKE_GEN ?= Unix Makefiles
 
@@ -67,7 +69,7 @@ BUILD_ROOT = $(REPO)/build
 
 SCAN_BUILD ?= scan-build
 
-CONFIG_CMD = $(shell /bin/echo -n "cd '$(BUILD_ROOT)' && " ; /bin/echo -n "cmake -G'$(CMAKE_GEN)' -DCMAKE_CROSSCOMPILING=$(CROSS) -DUSING_CLANG=$(CLANG) -DSTATIC_LINK=$(STATIC_LINK) -DUSE_NETNS=$(NETNS) -DUSE_AVX2=$(AVX2) -DUSE_LIBABYSS=$(JSONRPC) -DNON_PC_TARGET=$(NON_PC_TARGET) -DWITH_SHARED=$(SHARED_LIB) '$(REPO)'")
+CONFIG_CMD = $(shell /bin/echo -n "cd '$(BUILD_ROOT)' && " ; /bin/echo -n "cmake -G'$(CMAKE_GEN)' -DCMAKE_CROSSCOMPILING=$(CROSS) -DUSING_CLANG=$(CLANG) -DSTATIC_LINK=$(STATIC_LINK) -DUSE_NETNS=$(NETNS) -DUSE_AVX2=$(AVX2) -DUSE_LIBABYSS=$(JSONRPC) -DNON_PC_TARGET=$(NON_PC_TARGET) -DWITH_SHARED=$(SHARED_LIB) -DWITH_COVERAGE=$(COVERAGE) '$(REPO)'")
 
 ANALYZE_CONFIG_CMD = $(shell /bin/echo -n "cd '$(BUILD_ROOT)' && " ; /bin/echo -n "$(SCAN_BUILD) cmake -G'$(CMAKE_GEN)' -DCMAKE_CROSSCOMPILING=$(CROSS) -DUSING_CLANG=$(CLANG) -DSTATIC_LINK=$(STATIC_LINK) -DUSE_NETNS=$(NETNS) -DUSE_AVX2=$(AVX2) -DUSE_LIBABYSS=$(JSONRPC) -DNON_PC_TARGET=$(NON_PC_TARGET) -DWITH_SHARED=$(SHARED_LIB) '$(REPO)'")
 
@@ -209,13 +211,13 @@ debian-configure:
 
 debian: debian-configure
 	$(MAKE) -C '$(BUILD_ROOT)'
-	cp $(EXE) lokinet 
+	cp $(EXE) lokinet
 	cp $(BUILD_ROOT)/rcutil lokinet-rcutil
 
 debian-test:
 	$(TEST_EXE)
 
-install: 
+install:
 	$(MAKE) -C '$(BUILD_ROOT)' install
 
 fuzz-configure: clean

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ CROSS ?= OFF
 # build liblokinet-shared.so
 SHARED_LIB ?= ON
 # enable generating coverage
-COVERAGE =? OFF
+COVERAGE ?= OFF
+COVERAGE_OUTDIR ?= "$(TMPDIR)/lokinet-coverage"
 # cmake generator type
 CMAKE_GEN ?= Unix Makefiles
 
@@ -69,9 +70,11 @@ BUILD_ROOT = $(REPO)/build
 
 SCAN_BUILD ?= scan-build
 
-CONFIG_CMD = $(shell /bin/echo -n "cd '$(BUILD_ROOT)' && " ; /bin/echo -n "cmake -G'$(CMAKE_GEN)' -DCMAKE_CROSSCOMPILING=$(CROSS) -DUSING_CLANG=$(CLANG) -DSTATIC_LINK=$(STATIC_LINK) -DUSE_NETNS=$(NETNS) -DUSE_AVX2=$(AVX2) -DUSE_LIBABYSS=$(JSONRPC) -DNON_PC_TARGET=$(NON_PC_TARGET) -DWITH_SHARED=$(SHARED_LIB) -DWITH_COVERAGE=$(COVERAGE) '$(REPO)'")
+CONFIG_CMD = $(shell /bin/echo -n "cd '$(BUILD_ROOT)' && " ; /bin/echo -n "cmake -G'$(CMAKE_GEN)' -DCMAKE_CROSSCOMPILING=$(CROSS) -DUSING_CLANG=$(CLANG) -DSTATIC_LINK=$(STATIC_LINK) -DUSE_NETNS=$(NETNS) -DUSE_AVX2=$(AVX2) -DUSE_LIBABYSS=$(JSONRPC) -DNON_PC_TARGET=$(NON_PC_TARGET) -DWITH_SHARED=$(SHARED_LIB) '$(REPO)'")
 
 ANALYZE_CONFIG_CMD = $(shell /bin/echo -n "cd '$(BUILD_ROOT)' && " ; /bin/echo -n "$(SCAN_BUILD) cmake -G'$(CMAKE_GEN)' -DCMAKE_CROSSCOMPILING=$(CROSS) -DUSING_CLANG=$(CLANG) -DSTATIC_LINK=$(STATIC_LINK) -DUSE_NETNS=$(NETNS) -DUSE_AVX2=$(AVX2) -DUSE_LIBABYSS=$(JSONRPC) -DNON_PC_TARGET=$(NON_PC_TARGET) -DWITH_SHARED=$(SHARED_LIB) '$(REPO)'")
+
+COVERAGE_CONFIG_CMD = $(shell /bin/echo -n "cd '$(BUILD_ROOT)' && " ; /bin/echo -n "cmake -G'$(CMAKE_GEN)' -DCMAKE_CROSSCOMPILING=$(CROSS) -DUSING_CLANG=$(CLANG) -DSTATIC_LINK=$(STATIC_LINK) -DUSE_NETNS=$(NETNS) -DUSE_AVX2=$(AVX2) -DUSE_LIBABYSS=$(JSONRPC) -DNON_PC_TARGET=$(NON_PC_TARGET) -DWITH_SHARED=$(SHARED_LIB) -DWITH_COVERAGE=yes '$(REPO)'")
 
 TARGETS = $(REPO)/lokinet
 SIGS = $(TARGETS:=.sig)
@@ -193,6 +196,21 @@ analyze-config: clean
 
 analyze: analyze-config
 	cd '$(BUILD_ROOT)' && $(SCAN_BUILD) $(MAKE)
+
+coverage-config: clean
+	mkdir -p '$(BUILD_ROOT)'
+	$(COVERAGE_CONFIG_CMD)
+
+coverage: coverage-config
+	$(MAKE) -C $(BUILD_ROOT) -j 12
+	$(TEST_EXE) || true # continue even if tests fail
+	mkdir -p "$(COVERAGE_OUTDIR)"
+ifeq ($(CLANG),OFF)
+	gcovr -r . --branches --html --html-details -o "$(COVERAGE_OUTDIR)/lokinet.html"
+else
+	llvm-profdata merge default.profraw -output $(BUILD_ROOT)/profdata
+	llvm-cov show -format=html -output-dir="$(COVERAGE_OUTDIR)" -instr-profile "$(BUILD_ROOT)/profdata" "$(BUILD_ROOT)/testAll" $(shell find ./llarp -type f)
+endif
 
 lint: $(LINT_CHECK)
 

--- a/llarp/ev/ev_kqueue.hpp
+++ b/llarp/ev/ev_kqueue.hpp
@@ -21,7 +21,7 @@
 
 namespace llarp
 {
-  int
+  inline int
   tcp_conn::read(byte_t* buf, size_t sz)
   {
     if(sz == 0)
@@ -53,14 +53,14 @@ namespace llarp
     return 0;
   }
 
-  void
+  inline void
   tcp_conn::flush_write()
   {
     connected();
     ev_io::flush_write();
   }
 
-  ssize_t
+  inline ssize_t
   tcp_conn::do_write(void* buf, size_t sz)
   {
     if(_shouldClose)
@@ -74,7 +74,7 @@ namespace llarp
 #endif
   }
 
-  void
+  inline void
   tcp_conn::connect()
   {
     socklen_t slen = sizeof(sockaddr_in);
@@ -100,7 +100,7 @@ namespace llarp
     }
   }
 
-  int
+  inline int
   tcp_serv::read(byte_t*, size_t)
   {
     int new_fd = ::accept(fd, nullptr, nullptr);

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ Build requirements:
 * CMake
 * C++ 17 capable C++ compiler
 * rapidjson (if enabling jsonrpc server)
+* gcovr (if generating test coverage with gcc)
 
 ### Linux
 
@@ -27,22 +28,22 @@ build:
     $ make -j8
 
 install:
-    
+
     $ sudo make install
 
 
 ### FreeBSD
 
-build: 
+build:
 
     $ pkg install wget cmake git
     $ git clone https://github.com/loki-project/loki-network
     $ cd loki-network
     $ gmake -j8
-    
+
 install (root):
-    
-    # gmake install 
+
+    # gmake install
 
 ## Windows
 
@@ -55,10 +56,10 @@ build (where `$ARCH` is your platform - `i686` or `x86_64`):
     $ cmake .. -DCMAKE_BUILD_TYPE=[Debug|Release] -DSTATIC_LINK=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DDNS_PORT=53 -G 'Unix Makefiles'
 
 install (elevated) to `$PROGRAMFILES/lokinet` or `$ProgramFiles(x86)/lokinet`:
-    
+
     $ make install
 
-if cross-compiling, install mingw-w64 from your distro's package manager, or [build from source](https://sourceforge.net/p/mingw-w64/wiki2/Cross%20Win32%20and%20Win64%20compiler/), then: 
+if cross-compiling, install mingw-w64 from your distro's package manager, or [build from source](https://sourceforge.net/p/mingw-w64/wiki2/Cross%20Win32%20and%20Win64%20compiler/), then:
 
     $ mkdir -p build; cd build
     $ export COMPILER=clang # if using clang for windows


### PR DESCRIPTION
See the initial data with https://michael-loki.github.io/loki-network/

To generate with clang tools:

1. `cmake -DWITH_COVERAGE=ON -DUSING_CLANG=ON`
2. `<make>`
3. `./testAll`
4. `llvm-profdata merge default.profraw -output profdata`
5. `llvm-cov show -format=html -output-dir=<outdir> -instr-profile profdata ./testAll $(find ../llarp -type f)`