### PR TITLE
downgrade DNS server failure to a warning, autodetection delay, and don't create config if explicitly and no options

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -476,8 +476,9 @@ namespace llarp
       }
       if(!m_Resolver.Start(m_LocalResolverAddr, m_UpstreamResolvers))
       {
-        llarp::LogError(Name(), " failed to start dns server");
-        return false;
+        // downgrade DNS server failure to a warning
+        llarp::LogWarn(Name(), " failed to start dns server");
+        // return false;
       }
       return true;
     }

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -196,7 +196,7 @@ namespace llarp
   Router::OnSessionEstablished(llarp::RouterContact rc)
   {
     async_verify_RC(rc, nullptr);
-    llarp::LogInfo("session with ", rc.pubkey, "established");
+    llarp::LogInfo("session with ", rc.pubkey, " established");
   }
 
   Router::Router(struct llarp_threadpool *_tp, struct llarp_ev_loop *_netloop,

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1407,11 +1407,13 @@ namespace llarp
   {
     // fallback defaults
     // To NeuroScr: why run findFree* here instead of in tun.cpp?
+    // I think it should be in tun.cpp, better to closer to time of usage
+    // that way new tun may have grab a range we may have also grabbed here
     static const std::unordered_map< std::string,
                                      std::function< std::string(void) > >
         netConfigDefaults = {
-            {"ifname", llarp::findFreeLokiTunIfName},
-            {"ifaddr", llarp::findFreePrivateRange},
+            {"ifname", []() -> std::string { return "auto"; }},
+            {"ifaddr", []() -> std::string { return "auto"; }},
             {"local-dns", []() -> std::string { return "127.0.0.1:53"; }},
             {"upstream-dns", []() -> std::string { return "1.1.1.1:53"; }}};
     // populate with fallback defaults if values not present
@@ -1607,6 +1609,7 @@ namespace llarp
     else if(StrEq(section, "connect")
             || (StrEq(section, "bootstrap") && StrEq(key, "add-node")))
     {
+      //llarp::LogDebug("connect section has ", key, "=", val);
       self->bootstrapRCList.emplace_back();
       auto &rc = self->bootstrapRCList.back();
       if(!rc.Read(val))


### PR DESCRIPTION
We usually fail because there's already a DNS server there.

When doing advanced configuration, it's very easy to bind two DNS to the same port but it doesn't really matter, we just need one working lokinet DNS servers, the 2nd really doesn't matter (unless you're doing static HS mappings)

My future hope is to warn if it's a lokinet DNS server otherwise fail/exit

UPDATE:
- Delaying autodetection for better results
- Address #251 (if I say 404.ini don't make it without -g or -c)
- Improve UX: 
  - resolves ~/symlinks to final path on disk
  - output CWD/PWD making support easier