### PR TITLE
Convert llarp::Router into an abstract base class

### DIFF
--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -400,14 +400,14 @@ extern "C"
   void
   llarp_main_abort(struct llarp_main *ptr)
   {
-    ptr->ctx->router->logic->stop_timer();
+    ptr->ctx->router->logic()->stop_timer();
   }
 
   void
   llarp_main_queryDHT_RC(struct llarp_main *ptr,
                          struct llarp_router_lookup_job *job)
   {
-    llarp_dht_lookup_router(ptr->ctx->router->dht, job);
+    llarp_dht_lookup_router(ptr->ctx->router->dht(), job);
   }
 
   bool
@@ -495,8 +495,8 @@ extern "C"
     // llarp::Info("checkOnline - DHT nodes ",
     // request->ptr->ctx->router->dht->impl.nodes->nodes.size());
     request->online = false;
-    request->nodes  = request->ptr->ctx->router->dht->impl.nodes->nodes.size();
-    if(request->ptr->ctx->router->dht->impl.nodes->nodes.size())
+    request->nodes = request->ptr->ctx->router->dht()->impl.nodes->nodes.size();
+    if(request->ptr->ctx->router->dht()->impl.nodes->nodes.size())
     {
       // llarp::Info("checkOnline - Going to say we're online");
       request->online = true;
@@ -516,7 +516,7 @@ extern "C"
       request->first = true;
       llarp::LogInfo("llarp_main_queryDHT_online - We're online");
       llarp::LogInfo("llarp_main_queryDHT_online - Querying DHT");
-      llarp_dht_lookup_router(request->ptr->ctx->router->dht, request->job);
+      llarp_dht_lookup_router(request->ptr->ctx->router->dht(), request->job);
     }
   }
 
@@ -525,7 +525,7 @@ extern "C"
   {
     // llarp::Info("llarp_main_queryDHT - setting up timer");
     request->hook = &llarp_main_queryDHT_online;
-    request->ptr->ctx->router->logic->call_later(
+    request->ptr->ctx->router->logic()->call_later(
         {1000, request, &llarp_main_checkOnline});
     // llarp_dht_lookup_router(ptr->ctx->router->dht, job);
   }

--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -66,7 +66,7 @@ namespace llarp
         return;
       Context *ctx = static_cast< Context * >(u);
       ctx->Explore(1);
-      ctx->router->logic->call_later({orig, ctx, &handle_explore_timer});
+      ctx->router->logic()->call_later({orig, ctx, &handle_explore_timer});
     }
 
     void
@@ -233,7 +233,7 @@ namespace llarp
       llarp::LogDebug("initialize dht with key ", ourKey);
       // start exploring
 
-      r->logic->call_later(
+      r->logic()->call_later(
           {exploreInterval, this, &llarp::dht::Context::handle_explore_timer});
       // start cleanup timer
       ScheduleCleanupTimer();
@@ -242,7 +242,7 @@ namespace llarp
     void
     Context::ScheduleCleanupTimer()
     {
-      router->logic->call_later({1000, this, &handle_cleaner_timer});
+      router->logic()->call_later({1000, this, &handle_cleaner_timer});
     }
 
     void
@@ -262,11 +262,11 @@ namespace llarp
     Context::RelayRequestForPath(const llarp::PathID_t &id, const IMessage *msg)
     {
       llarp::routing::DHTMessage reply;
-      if(!msg->HandleMessage(router->dht, reply.M))
+      if(!msg->HandleMessage(router->dht(), reply.M))
         return false;
       if(!reply.M.empty())
       {
-        auto path = router->paths.GetByUpstream(router->pubkey(), id);
+        auto path = router->pathContext().GetByUpstream(router->pubkey(), id);
         return path && path->SendRoutingMessage(&reply, router);
       }
       return true;
@@ -419,13 +419,13 @@ namespace llarp
     llarp::Crypto *
     Context::Crypto() const
     {
-      return router->crypto.get();
+      return router->crypto();
     }
 
     llarp_time_t
     Context::Now() const
     {
-      return llarp_ev_loop_time_now_ms(router->netloop);
+      return router->Now();
     }
 
   }  // namespace dht

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -17,7 +17,7 @@
 
 namespace llarp
 {
-  struct Router;
+  struct AbstractRouter;
 
   namespace dht
   {
@@ -58,7 +58,7 @@ namespace llarp
       virtual llarp::Crypto*
       Crypto() const = 0;
 
-      virtual llarp::Router*
+      virtual llarp::AbstractRouter*
       GetRouter() const = 0;
 
       virtual const Key_t&
@@ -193,7 +193,7 @@ namespace llarp
       void
       Explore(size_t N = 3);
 
-      llarp::Router* router;
+      llarp::AbstractRouter* router;
       // for router contacts
       std::unique_ptr< Bucket< RCNode > > nodes;
 
@@ -213,7 +213,7 @@ namespace llarp
         return ourKey;
       }
 
-      llarp::Router*
+      llarp::AbstractRouter*
       GetRouter() const override
       {
         return router;

--- a/llarp/dht/explorenetworkjob.cpp
+++ b/llarp/dht/explorenetworkjob.cpp
@@ -25,7 +25,9 @@ namespace llarp
       {
         // lookup router
         parent->LookupRouter(
-            pk, std::bind(&Router::HandleDHTLookupForExplore, router, pk, _1));
+            pk,
+            std::bind(&AbstractRouter::HandleDHTLookupForExplore, router, pk,
+                      _1));
       }
     }
   }  // namespace dht

--- a/llarp/dht/localrouterlookup.cpp
+++ b/llarp/dht/localrouterlookup.cpp
@@ -22,7 +22,7 @@ namespace llarp
     void
     LocalRouterLookup::SendReply()
     {
-      auto path = parent->GetRouter()->paths.GetByUpstream(
+      auto path = parent->GetRouter()->pathContext().GetByUpstream(
           parent->OurKey().as_array(), localPath);
       if(!path)
       {

--- a/llarp/dht/localserviceaddresslookup.cpp
+++ b/llarp/dht/localserviceaddresslookup.cpp
@@ -21,7 +21,7 @@ namespace llarp
     void
     LocalServiceAddressLookup::SendReply()
     {
-      auto path = parent->GetRouter()->paths.GetByUpstream(
+      auto path = parent->GetRouter()->pathContext().GetByUpstream(
           parent->OurKey().as_array(), localPath);
       if(!path)
       {

--- a/llarp/dht/localtaglookup.cpp
+++ b/llarp/dht/localtaglookup.cpp
@@ -20,7 +20,7 @@ namespace llarp
     void
     LocalTagLookup::SendReply()
     {
-      auto path = parent->GetRouter()->paths.GetByUpstream(
+      auto path = parent->GetRouter()->pathContext().GetByUpstream(
           parent->OurKey().as_array(), localPath);
       if(!path)
       {

--- a/llarp/dht/messages/findrouter.cpp
+++ b/llarp/dht/messages/findrouter.cpp
@@ -20,7 +20,7 @@ namespace llarp
       Key_t k{K};
       if(K == us)
       {
-        auto path = dht.router->paths.GetByUpstream(K, pathID);
+        auto path = dht.router->pathContext().GetByUpstream(K, pathID);
         if(path)
         {
           replies.emplace_back(
@@ -33,7 +33,7 @@ namespace llarp
       Key_t peer;
       // check if we know this in our nodedb first
       RouterContact found;
-      if(dht.router->nodedb->Get(K, found))
+      if(dht.router->nodedb()->Get(K, found))
       {
         replies.emplace_back(new GotRouterMessage(k, txid, {found}, false));
         return true;
@@ -159,7 +159,7 @@ namespace llarp
       Key_t k{K};
       if(exploritory)
         return dht.HandleExploritoryRouterLookup(From, txid, K, replies);
-      else if(dht.router->nodedb->Get(K, found))
+      else if(dht.router->nodedb()->Get(K, found))
       {
         replies.emplace_back(new GotRouterMessage(k, txid, {found}, false));
         return true;

--- a/llarp/dht/messages/gotintro.cpp
+++ b/llarp/dht/messages/gotintro.cpp
@@ -25,7 +25,7 @@ namespace llarp
         std::vector< std::unique_ptr< IMessage > > &replies) const
     {
       auto &dht   = ctx->impl;
-      auto crypto = dht.router->crypto.get();
+      auto crypto = dht.router->crypto();
 
       for(const auto &introset : I)
       {
@@ -70,7 +70,7 @@ namespace llarp
         std::vector< std::unique_ptr< IMessage > > &replies) const
     {
       // TODO: implement me better?
-      auto pathset = ctx->impl.router->paths.GetLocalPathSet(pathID);
+      auto pathset = ctx->impl.router->pathContext().GetLocalPathSet(pathID);
       if(pathset)
       {
         return pathset->HandleGotIntroMessage(this);

--- a/llarp/dht/messages/gotrouter.cpp
+++ b/llarp/dht/messages/gotrouter.cpp
@@ -87,7 +87,7 @@ namespace llarp
       auto &dht = ctx->impl;
       if(relayed)
       {
-        auto pathset = ctx->impl.router->paths.GetLocalPathSet(pathID);
+        auto pathset = ctx->impl.router->pathContext().GetLocalPathSet(pathID);
         return pathset && pathset->HandleGotRouterMessage(this);
       }
       // not relayed

--- a/llarp/dht/messages/pubintro.cpp
+++ b/llarp/dht/messages/pubintro.cpp
@@ -53,7 +53,7 @@ namespace llarp
         return false;
       }
       auto &dht = ctx->impl;
-      if(!I.Verify(dht.router->crypto.get(), now))
+      if(!I.Verify(dht.router->crypto(), now))
       {
         llarp::LogWarn("invalid introset: ", I);
         // don't propogate or store
@@ -63,7 +63,7 @@ namespace llarp
 
       using namespace std::placeholders;
       shorthash_func shorthash =
-          std::bind(&Crypto::shorthash, dht.router->crypto.get(), _1, _2);
+          std::bind(&Crypto::shorthash, dht.router->crypto(), _1, _2);
       if(I.W && !I.W->IsValid(shorthash, now))
       {
         llarp::LogWarn("proof of work not good enough for IntroSet");

--- a/llarp/exit/session.cpp
+++ b/llarp/exit/session.cpp
@@ -11,13 +11,13 @@ namespace llarp
         const llarp::RouterID& router,
         std::function< bool(const llarp_buffer_t&) > writepkt, llarp::Router* r,
         size_t numpaths, size_t hoplen)
-        : llarp::path::Builder(r, r->dht, numpaths, hoplen)
+        : llarp::path::Builder(r, r->dht(), numpaths, hoplen)
         , m_ExitRouter(router)
         , m_WritePacket(writepkt)
         , m_Counter(0)
         , m_LastUse(0)
     {
-      r->crypto->identity_keygen(m_ExitIdentity);
+      r->crypto()->identity_keygen(m_ExitIdentity);
     }
 
     BaseSession::~BaseSession()
@@ -79,7 +79,7 @@ namespace llarp
       obtain.S = p->NextSeqNo();
       obtain.T = llarp::randint();
       PopulateRequest(obtain);
-      if(!obtain.Sign(router->crypto.get(), m_ExitIdentity))
+      if(!obtain.Sign(router->crypto(), m_ExitIdentity))
       {
         llarp::LogError("Failed to sign exit request");
         return;
@@ -108,7 +108,7 @@ namespace llarp
         {
           llarp::LogInfo(p->Name(), " closing exit path");
           llarp::routing::CloseExitMessage msg;
-          if(!(msg.Sign(router->crypto.get(), m_ExitIdentity)
+          if(!(msg.Sign(router->crypto(), m_ExitIdentity)
                && p->SendExitClose(&msg, router)))
             llarp::LogWarn(p->Name(), " failed to send exit close message");
         }

--- a/llarp/handlers/exit.cpp
+++ b/llarp/handlers/exit.cpp
@@ -246,7 +246,7 @@ namespace llarp
     Crypto *
     ExitEndpoint::GetCrypto()
     {
-      return m_Router->crypto.get();
+      return m_Router->crypto();
     }
 
     huint32_t

--- a/llarp/link/utp.cpp
+++ b/llarp/link/utp.cpp
@@ -551,7 +551,7 @@ namespace llarp
     NewServerFromRouter(llarp::Router* r)
     {
       return NewServer(
-          r->crypto.get(), r->encryption, std::bind(&llarp::Router::rc, r),
+          r->crypto(), r->encryption, std::bind(&llarp::Router::rc, r),
           std::bind(&llarp::Router::HandleRecvLinkMessageBuffer, r,
                     std::placeholders::_1, std::placeholders::_2),
           std::bind(&llarp::Router::OnSessionEstablished, r,

--- a/llarp/messages/dht_immediate.cpp
+++ b/llarp/messages/dht_immediate.cpp
@@ -72,7 +72,7 @@ namespace llarp
     bool result   = true;
     for(auto &msg : msgs)
     {
-      result &= msg->HandleMessage(router->dht, reply.msgs);
+      result &= msg->HandleMessage(router->dht(), reply.msgs);
     }
     if(reply.msgs.size())
     {

--- a/llarp/messages/link_intro.cpp
+++ b/llarp/messages/link_intro.cpp
@@ -117,7 +117,7 @@ namespace llarp
   bool
   LinkIntroMessage::HandleMessage(llarp::Router* router) const
   {
-    if(!Verify(router->crypto.get()))
+    if(!Verify(router->crypto()))
       return false;
     return session->GotLIM(this);
   }

--- a/llarp/path/path.hpp
+++ b/llarp/path/path.hpp
@@ -32,6 +32,7 @@
 
 namespace llarp
 {
+  struct AbstractRouter;
   struct Crypto;
   struct LR_CommitMessage;
   struct LR_CommitRecord;
@@ -112,17 +113,17 @@ namespace llarp
       /// send routing message and increment sequence number
       virtual bool
       SendRoutingMessage(const llarp::routing::IMessage* msg,
-                         llarp::Router* r) = 0;
+                         llarp::AbstractRouter* r) = 0;
 
       // handle data in upstream direction
       virtual bool
       HandleUpstream(const llarp_buffer_t& X, const TunnelNonce& Y,
-                     llarp::Router* r) = 0;
+                     AbstractRouter* r) = 0;
 
       // handle data in downstream direction
       virtual bool
       HandleDownstream(const llarp_buffer_t& X, const TunnelNonce& Y,
-                       llarp::Router* r) = 0;
+                       AbstractRouter* r) = 0;
 
       /// return timestamp last remote activity happened at
       virtual llarp_time_t
@@ -188,12 +189,12 @@ namespace llarp
       // send routing message when end of path
       bool
       SendRoutingMessage(const llarp::routing::IMessage* msg,
-                         llarp::Router* r) override;
+                         AbstractRouter* r) override;
 
       // handle routing message when end of path
       bool
       HandleRoutingMessage(const llarp::routing::IMessage* msg,
-                           llarp::Router* r);
+                           AbstractRouter* r);
 
       bool
       HandleDataDiscardMessage(const llarp::routing::DataDiscardMessage* msg,
@@ -257,12 +258,12 @@ namespace llarp
       // handle data in upstream direction
       bool
       HandleUpstream(const llarp_buffer_t& X, const TunnelNonce& Y,
-                     llarp::Router* r) override;
+                     AbstractRouter* r) override;
 
       // handle data in downstream direction
       bool
       HandleDownstream(const llarp_buffer_t& X, const TunnelNonce& Y,
-                       llarp::Router* r) override;
+                       AbstractRouter* r) override;
     };
 
     /// configuration for a single hop when building a path
@@ -417,7 +418,7 @@ namespace llarp
 
       bool
       SendRoutingMessage(const llarp::routing::IMessage* msg,
-                         llarp::Router* r) override;
+                         llarp::AbstractRouter* r) override;
 
       bool
       HandleObtainExitMessage(const llarp::routing::ObtainExitMessage* msg,
@@ -475,17 +476,17 @@ namespace llarp
                        llarp::Router* r) override;
 
       bool
-      HandleRoutingMessage(const llarp_buffer_t& buf, llarp::Router* r);
+      HandleRoutingMessage(const llarp_buffer_t& buf, AbstractRouter* r);
 
       // handle data in upstream direction
       bool
       HandleUpstream(const llarp_buffer_t& X, const TunnelNonce& Y,
-                     llarp::Router* r) override;
+                     AbstractRouter* r) override;
 
       // handle data in downstream direction
       bool
       HandleDownstream(const llarp_buffer_t& X, const TunnelNonce& Y,
-                       llarp::Router* r) override;
+                       AbstractRouter* r) override;
 
       bool
       IsReady() const;

--- a/llarp/path/pathbuilder.cpp
+++ b/llarp/path/pathbuilder.cpp
@@ -173,8 +173,8 @@ namespace llarp
         , dht(p_dht)
         , numHops(hops)
     {
-      p_router->paths.AddPathBuilder(this);
-      p_router->crypto->encryption_keygen(enckey);
+      p_router->pathContext().AddPathBuilder(this);
+      p_router->crypto()->encryption_keygen(enckey);
       _run.store(true);
       keygens.store(0);
     }
@@ -246,7 +246,7 @@ namespace llarp
     Builder::BuildOne(PathRole roles)
     {
       std::vector< RouterContact > hops;
-      if(SelectHops(router->nodedb, hops, roles))
+      if(SelectHops(router->nodedb(), hops, roles))
         Build(hops, roles);
     }
 
@@ -294,14 +294,14 @@ namespace llarp
       lastBuild = Now();
       // async generate keys
       AsyncPathKeyExchangeContext< Builder >* ctx =
-          new AsyncPathKeyExchangeContext< Builder >(router->crypto.get());
+          new AsyncPathKeyExchangeContext< Builder >(router->crypto());
       ctx->router  = router;
       ctx->pathset = this;
       auto path    = new llarp::path::Path(hops, this, roles);
       path->SetBuildResultHook(std::bind(&llarp::path::Builder::HandlePathBuilt,
                                          this, std::placeholders::_1));
       ++keygens;
-      ctx->AsyncGenerateKeys(path, router->logic, router->tp, this,
+      ctx->AsyncGenerateKeys(path, router->logic(), router->tp, this,
                              &PathBuilderKeysGenerated);
     }
 

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -80,7 +80,9 @@ struct TryConnectJob
     if(!router->IsServiceNode())
     {
       if(router->routerProfiling.IsBad(rc.pubkey))
-        router->nodedb->Remove(rc.pubkey);
+      {
+        router->nodedb()->Remove(rc.pubkey);
+      }
     }
     // delete this
     router->pendingEstablishJobs.erase(rc.pubkey);
@@ -164,6 +166,10 @@ llarp_findOrCreateEncryption(llarp::Crypto *crypto, const fs::path &path,
 
 namespace llarp
 {
+  AbstractRouter::~AbstractRouter()
+  {
+  }
+
   bool
   Router::TryConnectAsync(llarp::RouterContact remote, uint16_t numretries)
   {
@@ -186,7 +192,7 @@ namespace llarp
         // only try establishing if we inserted a new element
         TryConnectJob *job = itr.first->second.get();
         // try establishing async
-        logic->queue_job({job, &on_try_connecting});
+        _logic->queue_job({job, &on_try_connecting});
         return true;
       }
     }
@@ -201,15 +207,15 @@ namespace llarp
   }
 
   Router::Router(struct llarp_threadpool *_tp, struct llarp_ev_loop *_netloop,
-                 llarp::Logic *_logic)
+                 llarp::Logic *l)
       : ready(false)
       , netloop(_netloop)
       , tp(_tp)
-      , logic(_logic)
-      , crypto(std::make_unique< sodium::CryptoLibSodium >())
+      , _logic(l)
+      , _crypto(std::make_unique< sodium::CryptoLibSodium >())
       , paths(this)
       , exitContext(this)
-      , dht(llarp_dht_context_new(this))
+      , _dht(llarp_dht_context_new(this))
       , inbound_link_msg_parser(this)
       , hiddenServiceContext(this)
   {
@@ -228,7 +234,7 @@ namespace llarp
 
   Router::~Router()
   {
-    llarp_dht_context_free(dht);
+    llarp_dht_context_free(_dht);
   }
 
   bool
@@ -257,10 +263,10 @@ namespace llarp
   bool
   Router::GetRandomGoodRouter(RouterID &router)
   {
-    auto sz = nodedb->entries.size();
+    auto sz = nodedb()->entries.size();
     if(sz == 0)
       return false;
-    auto itr = nodedb->entries.begin();
+    auto itr = nodedb()->entries.begin();
     if(sz > 1)
       std::advance(itr, randint() % sz);
     router = itr->first;
@@ -317,7 +323,7 @@ namespace llarp
     }
     llarp::RouterContact remoteRC;
     // we don't have an open session to that router right now
-    if(nodedb->Get(remote, remoteRC))
+    if(nodedb()->Get(remote, remoteRC))
     {
       // try connecting directly as the rc is loaded from disk
       TryConnectAsync(remoteRC, 10);
@@ -325,9 +331,9 @@ namespace llarp
     }
 
     // we don't have the RC locally so do a dht lookup
-    dht->impl.LookupRouter(remote,
-                           std::bind(&Router::HandleDHTLookupForSendTo, this,
-                                     remote, std::placeholders::_1));
+    _dht->impl.LookupRouter(remote,
+                            std::bind(&Router::HandleDHTLookupForSendTo, this,
+                                      remote, std::placeholders::_1));
     return true;
   }
 
@@ -343,9 +349,9 @@ namespace llarp
       {
         return;
       }
-      if(results[0].Verify(crypto.get(), Now()))
+      if(results[0].Verify(crypto(), Now()))
       {
-        nodedb->Insert(results[0]);
+        nodedb()->Insert(results[0]);
         TryConnectAsync(results[0], 10);
         return;
       }
@@ -391,11 +397,11 @@ namespace llarp
       llarp::LogError("failure to decode or verify of remote RC");
       return;
     }
-    if(remote.Verify(crypto.get(), Now()))
+    if(remote.Verify(crypto(), Now()))
     {
       llarp::LogDebug("verified signature");
       // store into filesystem
-      if(!nodedb->Insert(remote))
+      if(!nodedb()->Insert(remote))
       {
         llarp::LogWarn("failed to store");
       }
@@ -415,16 +421,16 @@ namespace llarp
     if(!EnsureEncryptionKey())
       return false;
     if(usingSNSeed)
-      return llarp_loadServiceNodeIdentityKey(crypto.get(), ident_keyfile,
+      return llarp_loadServiceNodeIdentityKey(crypto(), ident_keyfile,
                                               identity);
     else
-      return llarp_findOrCreateIdentity(crypto.get(), ident_keyfile, identity);
+      return llarp_findOrCreateIdentity(crypto(), ident_keyfile, identity);
   }
 
   bool
   Router::EnsureEncryptionKey()
   {
-    return llarp_findOrCreateEncryption(crypto.get(), encryption_keyfile,
+    return llarp_findOrCreateEncryption(crypto(), encryption_keyfile,
                                         this->encryption);
   }
 
@@ -460,7 +466,7 @@ namespace llarp
   Router::SaveRC()
   {
     llarp::LogDebug("verify RC signature");
-    if(!_rc.Verify(crypto.get(), Now()))
+    if(!_rc.Verify(crypto(), Now()))
     {
       rc().Dump< MAX_RC_SIZE >();
       llarp::LogError("RC is invalid, not saving");
@@ -532,7 +538,7 @@ namespace llarp
     router->validRouters.emplace(pk, rc);
 
     // track valid router in dht
-    router->dht->impl.nodes->PutNode(rc);
+    router->dht()->impl.nodes->PutNode(rc);
 
     // mark success in profile
     router->routerProfiling.MarkSuccess(pk);
@@ -586,8 +592,8 @@ namespace llarp
       return;
     for(const auto &rc : results)
     {
-      if(rc.Verify(crypto.get(), Now()))
-        nodedb->Insert(rc);
+      if(rc.Verify(crypto(), Now()))
+        nodedb()->Insert(rc);
       else
         return;
     }
@@ -608,18 +614,18 @@ namespace llarp
     }
 
     llarp::RouterContact rc;
-    if(nodedb->Get(remote, rc))
+    if(nodedb()->Get(remote, rc))
     {
       // try connecting async
       TryConnectAsync(rc, 5);
     }
     else if(IsServiceNode() || !routerProfiling.IsBad(remote))
     {
-      if(dht->impl.HasRouterLookup(remote))
+      if(dht()->impl.HasRouterLookup(remote))
         return;
       llarp::LogInfo("looking up router ", remote);
       // dht lookup as we don't know it
-      dht->impl.LookupRouter(
+      dht()->impl.LookupRouter(
           remote,
           std::bind(&Router::HandleDHTLookupForTryEstablishTo, this, remote,
                     std::placeholders::_1));
@@ -655,7 +661,7 @@ namespace llarp
       if(whitelistRouters
          && lokinetRouters.find(result.pubkey) == lokinetRouters.end())
         continue;
-      nodedb->Insert(result);
+      nodedb()->Insert(result);
       TryConnectAsync(result, 10);
     }
   }
@@ -673,7 +679,7 @@ namespace llarp
     llarp::RouterContact nextRC = _rc;
     if(rotateKeys)
     {
-      crypto->encryption_keygen(nextOnionKey);
+      crypto()->encryption_keygen(nextOnionKey);
       std::string f = encryption_keyfile.string();
       if(nextOnionKey.SaveToFile(f.c_str()))
       {
@@ -682,7 +688,7 @@ namespace llarp
       }
     }
     nextRC.last_updated = Now();
-    if(!nextRC.Sign(crypto.get(), identity))
+    if(!nextRC.Sign(crypto(), identity))
       return false;
     _rc = nextRC;
     // propagate RC by renegotiating sessions
@@ -705,11 +711,11 @@ namespace llarp
       return false;
 
     // store it in nodedb async
-    nodedb->InsertAsync(newrc);
+    nodedb()->InsertAsync(newrc);
     // update dht if required
-    if(dht->impl.nodes->HasNode(dht::Key_t{newrc.pubkey}))
+    if(dht()->impl.nodes->HasNode(dht::Key_t{newrc.pubkey}))
     {
-      dht->impl.nodes->PutNode(newrc);
+      dht()->impl.nodes->PutNode(newrc);
     }
     // update valid routers
     {
@@ -726,9 +732,9 @@ namespace llarp
   void
   Router::ServiceNodeLookupRouterWhenExpired(RouterID router)
   {
-    dht->impl.LookupRouter(router,
-                           std::bind(&Router::HandleDHTLookupForExplore, this,
-                                     router, std::placeholders::_1));
+    dht()->impl.LookupRouter(router,
+                             std::bind(&Router::HandleDHTLookupForExplore, this,
+                                       router, std::placeholders::_1));
   }
 
   void
@@ -748,7 +754,7 @@ namespace llarp
     {
       // only do this as service node
       // client endpoints do this on their own
-      nodedb->visit([&](const RouterContact &rc) -> bool {
+      nodedb()->visit([&](const RouterContact &rc) -> bool {
         if(rc.ExpiresSoon(now, llarp::randint() % 10000))
           ServiceNodeLookupRouterWhenExpired(rc.pubkey);
         return true;
@@ -783,7 +789,7 @@ namespace llarp
       }
     }
 
-    size_t N = nodedb->num_loaded();
+    size_t N = nodedb()->num_loaded();
     if(N < minRequiredRouters)
     {
       llarp::LogInfo("We need at least ", minRequiredRouters,
@@ -795,7 +801,7 @@ namespace llarp
         for(const auto &rc : bootstrapRCList)
         {
           TryConnectAsync(rc, 4);
-          dht->impl.ExploreNetworkVia(dht::Key_t{rc.pubkey});
+          dht()->impl.ExploreNetworkVia(dht::Key_t{rc.pubkey});
         }
       }
       else
@@ -819,7 +825,7 @@ namespace llarp
   bool
   Router::Sign(llarp::Signature &sig, const llarp_buffer_t &buf) const
   {
-    return crypto->sign(sig, identity, buf);
+    return crypto()->sign(sig, identity, buf);
   }
 
   void
@@ -859,13 +865,13 @@ namespace llarp
   void
   Router::ScheduleTicker(uint64_t ms)
   {
-    ticker_job_id = logic->call_later({ms, this, &handle_router_ticker});
+    ticker_job_id = _logic->call_later({ms, this, &handle_router_ticker});
   }
 
   void
   Router::SessionClosed(llarp::RouterID remote)
   {
-    __llarp_dht_remove_peer(dht, remote.data());
+    __llarp_dht_remove_peer(dht(), remote.data());
     // remove from valid routers if it's a valid router
     validRouters.erase(remote);
     llarp::LogInfo("Session to ", remote, " fully closed");
@@ -966,9 +972,8 @@ namespace llarp
     job->valid = false;
     job->hook  = nullptr;
 
-    job->nodedb = nodedb;
-    job->logic  = logic;
-    // job->crypto = crypto.get(); // we already have this
+    job->nodedb       = _nodedb;
+    job->logic        = _logic;
     job->cryptoworker = tp;
     job->diskworker   = disk;
     if(rc.IsPublicRouter())
@@ -984,7 +989,7 @@ namespace llarp
   {
     if(_running || _stopping)
       return false;
-    this->nodedb = nodedb;
+    this->_nodedb = nodedb;
 
     if(enableRPCServer)
     {
@@ -1066,7 +1071,7 @@ namespace llarp
           a);
     }
     llarp::LogInfo("Signing rc...");
-    if(!_rc.Sign(crypto.get(), identity))
+    if(!_rc.Sign(crypto(), identity))
     {
       llarp::LogError("failed to sign rc");
       return false;
@@ -1083,7 +1088,7 @@ namespace llarp
     llarp::LogInfo("starting outbound ", outboundLinks.size(), " links");
     for(const auto &link : outboundLinks)
     {
-      if(!link->Start(logic))
+      if(!link->Start(_logic))
       {
         llarp::LogWarn("outbound link '", link->Name(), "' failed to start");
         return false;
@@ -1095,7 +1100,7 @@ namespace llarp
     // start links
     for(const auto &link : inboundLinks)
     {
-      if(link->Start(logic))
+      if(link->Start(_logic))
       {
         llarp::LogDebug("Link ", link->Name(), " started");
         IBLinksStarted++;
@@ -1119,11 +1124,11 @@ namespace llarp
     {
       // we are a client
       // regenerate keys and resign rc before everything else
-      crypto->identity_keygen(identity);
-      crypto->encryption_keygen(encryption);
+      crypto()->identity_keygen(identity);
+      crypto()->encryption_keygen(encryption);
       _rc.pubkey = llarp::seckey_topublic(identity);
       _rc.enckey = llarp::seckey_topublic(encryption);
-      if(!_rc.Sign(crypto.get(), identity))
+      if(!_rc.Sign(crypto(), identity))
       {
         llarp::LogError("failed to regenerate keys and sign RC");
         return false;
@@ -1148,7 +1153,7 @@ namespace llarp
       llarp::LogError("Failed to start hidden service context");
       return false;
     }
-    llarp_dht_context_start(dht, pubkey());
+    llarp_dht_context_start(dht(), pubkey());
     ScheduleTicker(1000);
     _running.store(true);
     return _running;
@@ -1166,7 +1171,7 @@ namespace llarp
   {
     Router *self = static_cast< Router * >(u);
     self->StopLinks();
-    self->logic->call_later({200, self, &RouterAfterStopLinks});
+    self->_logic->call_later({200, self, &RouterAfterStopLinks});
   }
 
   void
@@ -1271,7 +1276,7 @@ namespace llarp
     exitContext.Stop();
     if(rpcServer)
       rpcServer->Stop();
-    logic->call_later({200, this, &RouterAfterStopIssued});
+    _logic->call_later({200, this, &RouterAfterStopIssued});
   }
 
   bool
@@ -1286,7 +1291,7 @@ namespace llarp
     int wanted   = want;
     Router *self = this;
 
-    self->nodedb->visit(
+    self->nodedb()->visit(
         [self, &want](const llarp::RouterContact &other) -> bool {
           // check if we really want to
           if(other.ExpiresSoon(self->Now(), 30000))
@@ -1312,7 +1317,7 @@ namespace llarp
   {
     llarp::LogInfo("accepting transit traffic");
     paths.AllowTransit();
-    llarp_dht_allow_transit(dht);
+    llarp_dht_allow_transit(dht());
     return exitContext.AddExitEndpoint("default-connectivity", netConfig);
   }
 
@@ -1643,7 +1648,7 @@ namespace llarp
         self->bootstrapRCList.pop_back();
         return;
       }
-      if(rc.Verify(self->crypto.get(), self->Now()))
+      if(rc.Verify(self->crypto(), self->Now()))
       {
         llarp::LogInfo("Added bootstrap node ", RouterID(rc.pubkey));
       }

--- a/llarp/rpc/rpc.cpp
+++ b/llarp/rpc/rpc.cpp
@@ -332,7 +332,7 @@ namespace llarp
         saddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
         saddr.sin_family      = AF_INET;
         saddr.sin_port        = htons(port);
-        return _handler.ServeAsync(router->netloop, router->logic,
+        return _handler.ServeAsync(router->netloop, router->logic(),
                                    (const sockaddr*)&saddr);
       }
     };

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -82,7 +82,7 @@ namespace llarp
           ++itr;
         }
       }
-      m_Router->nodedb->visit([&](const RouterContact &rc) -> bool {
+      m_Router->nodedb()->visit([&](const RouterContact &rc) -> bool {
         if(rc.IsExpired(now))
           getFirstEndpoint()->LookupRouterAnon(rc.pubkey);
         return true;

--- a/llarp/service/lookup.cpp
+++ b/llarp/service/lookup.cpp
@@ -1,6 +1,7 @@
 #include <service/lookup.hpp>
 
 #include <path/path.hpp>
+#include <router/router.hpp>
 #include <service/endpoint.hpp>
 #include <util/time.hpp>
 
@@ -17,8 +18,7 @@ namespace llarp
     }
 
     bool
-    IServiceLookup::SendRequestViaPath(llarp::path::Path *path,
-                                       llarp::Router *r)
+    IServiceLookup::SendRequestViaPath(path::Path *path, Router *r)
     {
       auto msg = BuildRequestMessage();
       if(!msg)

--- a/test/dht/mock_context.hpp
+++ b/test/dht/mock_context.hpp
@@ -33,7 +33,7 @@ namespace llarp
 
       MOCK_CONST_METHOD0(Crypto, llarp::Crypto*());
 
-      MOCK_CONST_METHOD0(GetRouter, llarp::Router*());
+      MOCK_CONST_METHOD0(GetRouter, llarp::AbstractRouter*());
 
       MOCK_CONST_METHOD0(OurKey, const dht::Key_t&());
 


### PR DESCRIPTION
This doesn't convert it everywhere, but in "most" places. Further iterations on this would be:

- Move `AbstractRouter` into its own header, which would hopefully break some of the dependency cycles and improve compile times
- Replace the rest of the usage of `Router` in the majority of places with the interface.