### PR TITLE
Add support for building with ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ option(TESTNET "testnet build" )
 option(WITH_SHARED "build shared library")
 option(WITH_COVERAGE "generate coverage data")
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 if(WIN32)
   set(CMAKE_CXX_STANDARD 17)
   ENABLE_LANGUAGE(RC)


### PR DESCRIPTION
If ccache is in the path, use it to accelerate builds.

see https://cmake.org/cmake/help/latest/prop_gbl/RULE_LAUNCH_COMPILE.html 