### PR TITLE
Fix deadlock in profiling

### DIFF
--- a/llarp/profiling.cpp
+++ b/llarp/profiling.cpp
@@ -190,7 +190,6 @@ namespace llarp
     if(!profile.BDecode(buf))
       return false;
     RouterID pk = k.base;
-    absl::WriterMutexLock l(&m_ProfilesMutex);
     return m_Profiles.emplace(pk, profile).second;
   }
 

--- a/llarp/profiling.hpp
+++ b/llarp/profiling.hpp
@@ -69,13 +69,14 @@ namespace llarp
     MarkPathSuccess(path::Path* p) LOCKS_EXCLUDED(m_ProfilesMutex);
 
     void
-    Tick();
+    Tick() LOCKS_EXCLUDED(m_ProfilesMutex);
 
     bool
     BEncode(llarp_buffer_t* buf) const override LOCKS_EXCLUDED(m_ProfilesMutex);
 
     bool
-    DecodeKey(const llarp_buffer_t& k, llarp_buffer_t* buf) override;
+    DecodeKey(const llarp_buffer_t& k, llarp_buffer_t* buf) override
+        SHARED_LOCKS_REQUIRED(m_ProfilesMutex);
 
     bool
     Load(const char* fname) LOCKS_EXCLUDED(m_ProfilesMutex);


### PR DESCRIPTION
`Profiling::Load` calls `BDecodeReadFile` under a lock, which ends up calling `DecodeKey`, which then tries to lock the mutex again.