### PR TITLE
Fixup one ASAN warning

### DIFF
--- a/libutp/utp_packedsockaddr.cpp
+++ b/libutp/utp_packedsockaddr.cpp
@@ -71,8 +71,7 @@ void
 PackedSockAddr::set(const SOCKADDR_STORAGE *sa, socklen_t len)
 {
   // on unix, the cast does nothing, socklen_t is _already_ unsigned
-  sockaddr_storage ssa = *sa; // stops member access with misaligned address
-  if( ssa.ss_family == AF_INET)
+  if(sa->ss_family == AF_INET)
   {
     assert((unsigned)len >= sizeof(sockaddr_in));
     const sockaddr_in *sin = (sockaddr_in *)sa;

--- a/llarp/messages/relay_commit.hpp
+++ b/llarp/messages/relay_commit.hpp
@@ -55,16 +55,16 @@ namespace llarp
     ~LR_CommitMessage();
 
     void
-    Clear();
+    Clear() override;
 
     bool
-    DecodeKey(const llarp_buffer_t &key, llarp_buffer_t *buf);
+    DecodeKey(const llarp_buffer_t &key, llarp_buffer_t *buf) override;
 
     bool
-    BEncode(llarp_buffer_t *buf) const;
+    BEncode(llarp_buffer_t *buf) const override;
 
     bool
-    HandleMessage(AbstractRouter *router) const;
+    HandleMessage(AbstractRouter *router) const override;
 
     bool
     AsyncDecrypt(llarp::path::PathContext *context) const;

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -11,7 +11,7 @@
 #include <service/handler.hpp>
 #include <service/protocol.hpp>
 
-// minimum time between interoset shifts
+// minimum time between introset shifts
 #ifndef MIN_SHIFT_INTERVAL
 #define MIN_SHIFT_INTERVAL (5 * 1000)
 #endif
@@ -336,7 +336,7 @@ namespace llarp
         HandleHiddenServiceFrame(path::Path* p, const ProtocolFrame* frame);
 
         std::string
-        Name() const;
+        Name() const override;
 
        private:
         /// swap remoteIntro with next intro
@@ -357,7 +357,7 @@ namespace llarp
             m_BadIntros;
         llarp_time_t lastShift = 0;
         uint16_t m_LookupFails = 0;
-        uint16_t m_BuildFails = 0;
+        uint16_t m_BuildFails  = 0;
       };
 
       // passed a sendto context when we have a path established otherwise


### PR DESCRIPTION
`sa` is not an actual object. here `len` is 16, and `sockaddr_storage` is 100+ bytes.

This fixes *an* issue with the address sanitizer