### PR TITLE
Fix more address sanitiser issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ if(NOT DEBIAN)
 endif(NOT DEBIAN)
 
 if(ASAN)
-  set(DEBUG_FLAGS ${DEBUG_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer)
+  set(DEBUG_FLAGS ${DEBUG_FLAGS} -fsanitize=address -fno-omit-frame-pointer)
   set(OPTIMIZE_FLAGS "-O0")
 endif(ASAN)
 

--- a/llarp/iwp/linklayer.cpp
+++ b/llarp/iwp/linklayer.cpp
@@ -91,14 +91,14 @@ namespace llarp
       }
     }
 
-    ILinkSession*
+    std::shared_ptr< ILinkSession >
     LinkLayer::NewOutboundSession(const RouterContact& rc,
                                   const AddressInfo& ai)
     {
       (void)rc;
       (void)ai;
       // TODO: implement me
-      return nullptr;
+      return {};
     }
 
     void

--- a/llarp/iwp/linklayer.hpp
+++ b/llarp/iwp/linklayer.hpp
@@ -21,12 +21,19 @@ namespace llarp
                 TimeoutHandler timeout, SessionClosedHandler closed);
 
       ~LinkLayer();
+
       Crypto *const crypto;
+
+      Crypto *
+      OurCrypto() override
+      {
+        return crypto;
+      }
 
       bool
       Start(Logic *l) override;
 
-      ILinkSession *
+      std::shared_ptr< ILinkSession >
       NewOutboundSession(const RouterContact &rc,
                          const AddressInfo &ai) override;
 

--- a/llarp/link/server.cpp
+++ b/llarp/link/server.cpp
@@ -143,10 +143,10 @@ namespace llarp
     {
       if(m_AuthedLinks.count(pk) > MaxSessionsPerKey)
       {
-        s->SendClose();
+        s->Close();
         return false;
       }
-      m_AuthedLinks.emplace(pk, std::move(itr->second));
+      m_AuthedLinks.emplace(pk, itr->second);
       itr = m_Pending.erase(itr);
       return true;
     }
@@ -206,13 +206,12 @@ namespace llarp
     if(!PickAddress(rc, to))
       return false;
     llarp::Addr addr(to);
-    auto s = NewOutboundSession(rc, to);
+    std::shared_ptr< ILinkSession > s = NewOutboundSession(rc, to);
     if(PutSession(s))
     {
       s->Start();
       return true;
     }
-    delete s;
     return false;
   }
 
@@ -258,7 +257,7 @@ namespace llarp
       auto itr = m_AuthedLinks.begin();
       while(itr != m_AuthedLinks.end())
       {
-        itr->second->SendClose();
+        itr->second->Close();
         ++itr;
       }
     }
@@ -267,7 +266,7 @@ namespace llarp
       auto itr = m_Pending.begin();
       while(itr != m_Pending.end())
       {
-        itr->second->SendClose();
+        itr->second->Close();
         ++itr;
       }
     }
@@ -283,7 +282,7 @@ namespace llarp
     auto itr   = range.first;
     while(itr != range.second)
     {
-      itr->second->SendClose();
+      itr->second->Close();
       itr = m_AuthedLinks.erase(itr);
     }
   }
@@ -380,14 +379,14 @@ namespace llarp
   }
 
   bool
-  ILinkLayer::PutSession(ILinkSession* s)
+  ILinkLayer::PutSession(const std::shared_ptr< ILinkSession >& s)
   {
     static constexpr size_t MaxSessionsPerEndpoint = 5;
     Lock lock(&m_PendingMutex);
     llarp::Addr addr = s->GetRemoteEndpoint();
     if(m_Pending.count(addr) >= MaxSessionsPerEndpoint)
       return false;
-    m_Pending.emplace(addr, std::unique_ptr< ILinkSession >(s));
+    m_Pending.emplace(addr, s);
     return true;
   }
 

--- a/llarp/link/server.hpp
+++ b/llarp/link/server.hpp
@@ -11,6 +11,7 @@
 #include <util/status.hpp>
 
 #include <list>
+#include <memory>
 #include <unordered_map>
 
 namespace llarp
@@ -60,6 +61,9 @@ namespace llarp
       return llarp_ev_loop_time_now_ms(m_Loop);
     }
 
+    virtual Crypto*
+    OurCrypto() = 0;
+
     bool
     HasSessionTo(const RouterID& pk);
 
@@ -105,7 +109,7 @@ namespace llarp
     Configure(llarp_ev_loop* loop, const std::string& ifname, int af,
               uint16_t port);
 
-    virtual ILinkSession*
+    virtual std::shared_ptr< ILinkSession >
     NewOutboundSession(const RouterContact& rc, const AddressInfo& ai) = 0;
 
     virtual void
@@ -225,7 +229,7 @@ namespace llarp
     using Mutex = util::NullMutex;
 
     bool
-    PutSession(ILinkSession* s);
+    PutSession(const std::shared_ptr< ILinkSession >& s);
 
     llarp::Logic* m_Logic = nullptr;
     llarp_ev_loop* m_Loop = nullptr;
@@ -234,10 +238,10 @@ namespace llarp
     SecretKey m_SecretKey;
 
     using AuthedLinks =
-        std::unordered_multimap< RouterID, std::unique_ptr< ILinkSession >,
+        std::unordered_multimap< RouterID, std::shared_ptr< ILinkSession >,
                                  RouterID::Hash >;
     using Pending =
-        std::unordered_multimap< llarp::Addr, std::unique_ptr< ILinkSession >,
+        std::unordered_multimap< llarp::Addr, std::shared_ptr< ILinkSession >,
                                  llarp::Addr::Hash >;
 
     Mutex m_AuthedLinksMutex ACQUIRED_BEFORE(m_PendingMutex);

--- a/llarp/link/session.hpp
+++ b/llarp/link/session.hpp
@@ -17,53 +17,70 @@ namespace llarp
   {
     virtual ~ILinkSession(){};
 
+    /// hook for utp for when we have established a connection
+    virtual void
+    OnLinkEstablished(ILinkLayer *p) = 0;
+
     /// called every event loop tick
-    std::function< void(void) > Pump;
+    virtual void
+    Pump() = 0;
 
     /// called every timer tick
-    std::function< void(llarp_time_t) > Tick;
+    virtual void Tick(llarp_time_t) = 0;
 
     /// send a message buffer to the remote endpoint
-    std::function< bool(const llarp_buffer_t &) > SendMessageBuffer;
+    virtual bool
+    SendMessageBuffer(const llarp_buffer_t &) = 0;
 
     /// start the connection
-    std::function< void(void) > Start;
+    virtual void
+    Start() = 0;
+
+    virtual void
+    Close() = 0;
 
     /// send a keepalive to the remote endpoint
-    std::function< bool(void) > SendKeepAlive;
-
-    /// send close message
-    std::function< void(void) > SendClose;
+    virtual bool
+    SendKeepAlive() = 0;
 
     /// return true if we are established
-    std::function< bool(void) > IsEstablished;
+    virtual bool
+    IsEstablished() = 0;
 
     /// return true if this session has timed out
-    std::function< bool(llarp_time_t) > TimedOut;
+    virtual bool
+    TimedOut(llarp_time_t now) const = 0;
 
     /// get remote public identity key
-    std::function< PubKey(void) > GetPubKey;
+    virtual PubKey
+    GetPubKey() const = 0;
 
     /// get remote address
-    std::function< Addr(void) > GetRemoteEndpoint;
+    virtual Addr
+    GetRemoteEndpoint() const = 0;
 
     // get remote rc
-    std::function< RouterContact(void) > GetRemoteRC;
+    virtual RouterContact
+    GetRemoteRC() const = 0;
 
     /// handle a valid LIM
     std::function< bool(const LinkIntroMessage *msg) > GotLIM;
 
     /// send queue current blacklog
-    std::function< size_t(void) > SendQueueBacklog;
+    virtual size_t
+    SendQueueBacklog() const = 0;
 
     /// get parent link layer
-    std::function< ILinkLayer *(void) > GetLinkLayer;
+    virtual ILinkLayer *
+    GetLinkLayer() const = 0;
 
     /// renegotiate session when we have a new RC locally
-    std::function< bool(void) > RenegotiateSession;
+    virtual bool
+    RenegotiateSession() = 0;
 
     /// return true if we should send an explicit keepalive message
-    std::function< bool(void) > ShouldPing;
+    virtual bool
+    ShouldPing() const = 0;
   };
 }  // namespace llarp
 

--- a/llarp/utp/linklayer.hpp
+++ b/llarp/utp/linklayer.hpp
@@ -58,11 +58,11 @@ namespace llarp
 
       /// get AI rank
       uint16_t
-      Rank() const;
+      Rank() const override;
 
       /// handle low level recv
       void
-      RecvFrom(const Addr& from, const void* buf, size_t sz);
+      RecvFrom(const Addr& from, const void* buf, size_t sz) override;
 
 #ifdef __linux__
       /// process ICMP stuff on linux
@@ -71,11 +71,14 @@ namespace llarp
 #endif
 
       Crypto*
-      OurCrypto();
+      OurCrypto() override
+      {
+        return _crypto;
+      }
 
       /// pump sessions
       void
-      Pump();
+      Pump() override;
 
       /// stop link layer
       void
@@ -83,15 +86,16 @@ namespace llarp
 
       /// regenerate transport keypair
       bool
-      KeyGen(SecretKey& k);
+      KeyGen(SecretKey& k) override;
 
       /// do tick
       void
       Tick(llarp_time_t now);
 
       /// create new outbound session
-      ILinkSession*
-      NewOutboundSession(const RouterContact& rc, const AddressInfo& addr);
+      std::shared_ptr< ILinkSession >
+      NewOutboundSession(const RouterContact& rc,
+                         const AddressInfo& addr) override;
 
       /// create new socket
       utp_socket*
@@ -99,7 +103,7 @@ namespace llarp
 
       /// get ai name
       const char*
-      Name() const;
+      Name() const override;
     };
 
   }  // namespace utp

--- a/llarp/utp/session.hpp
+++ b/llarp/utp/session.hpp
@@ -13,14 +13,14 @@ namespace llarp
   {
     struct LinkLayer;
 
-    struct Session final : public ILinkSession
+    struct Session : public ILinkSession
     {
       /// remote router's rc
       RouterContact remoteRC;
       /// underlying socket
       utp_socket* sock;
       /// link layer parent
-      LinkLayer* parent;
+      ILinkLayer* parent;
       /// did we get a LIM from the remote yet?
       bool gotLIM;
       /// remote router's transport pubkey
@@ -68,15 +68,10 @@ namespace llarp
       util::StatusObject
       ExtractStatus() const override;
 
+      virtual ~Session() = 0;
+
       /// base
-      Session(LinkLayer* p);
-
-      /// outbound
-      Session(LinkLayer* p, utp_socket* s, const RouterContact& rc,
-              const AddressInfo& addr);
-
-      /// inbound
-      Session(LinkLayer* p, utp_socket* s, const Addr& remote);
+      explicit Session(LinkLayer* p);
 
       enum State
       {
@@ -88,26 +83,19 @@ namespace llarp
         eClose             // utp connection is closed
       };
 
-      /// get router
-      // Router*
-      // Router();
-
-      Crypto*
-      OurCrypto();
-
       /// session state, call EnterState(State) to set
       State state;
 
       /// hook for utp for when we have established a connection
       void
-      OnLinkEstablished(LinkLayer* p);
+      OnLinkEstablished(ILinkLayer* p) override;
+
+      Crypto*
+      OurCrypto();
 
       /// switch states
       void
       EnterState(State st);
-
-      Session();
-      ~Session();
 
       /// handle LIM after handshake
       bool
@@ -115,14 +103,29 @@ namespace llarp
 
       /// re negotiate session with our new local RC
       bool
-      Rehandshake();
+      RenegotiateSession() override;
+
+      bool
+      ShouldPing() const override;
 
       /// pump tx queue
       void
       PumpWrite();
 
       void
-      DoPump();
+      Pump() override;
+
+      bool
+      SendKeepAlive() override;
+
+      bool
+      IsEstablished() override
+      {
+        return state == eSessionReady || state == eLinkEstablished;
+      }
+
+      bool
+      TimedOut(llarp_time_t now) const override;
 
       /// verify a fragment buffer and the decrypt it
       /// buf is assumed to be FragmentBufferSize bytes long
@@ -136,7 +139,7 @@ namespace llarp
 
       /// queue a fully formed message
       bool
-      QueueWriteBuffers(const llarp_buffer_t& buf);
+      SendMessageBuffer(const llarp_buffer_t& buf) override;
 
       /// prune expired inbound messages
       void
@@ -165,42 +168,67 @@ namespace llarp
       MutateKey(SharedSecret& K, const AlignedBuffer< 24 >& A);
 
       void
-      TickImpl(llarp_time_t now);
+      Tick(llarp_time_t now) override;
 
       /// close session
       void
-      Close();
+      Close() override;
 
       /// low level read
       bool
       Recv(const byte_t* buf, size_t sz);
 
-      /// handle inbound LIM
-      bool
-      InboundLIM(const LinkIntroMessage* msg);
-
-      /// handle outbound LIM
-      bool
-      OutboundLIM(const LinkIntroMessage* msg);
-
-      /// return true if timed out
-      bool
-      IsTimedOut(llarp_time_t now) const;
-
       /// get remote identity pubkey
-      const PubKey&
-      RemotePubKey() const;
+      PubKey
+      GetPubKey() const override;
 
       /// get remote address
       Addr
-      RemoteEndpoint();
+      GetRemoteEndpoint() const override;
+
+      RouterContact
+      GetRemoteRC() const override
+      {
+        return remoteRC;
+      }
 
       /// get parent link
       ILinkLayer*
-      GetParent();
+      GetLinkLayer() const override;
 
       void
       MarkEstablished();
+
+      size_t
+      SendQueueBacklog() const override
+      {
+        return sendq.size();
+      }
+    };
+
+    struct InboundSession final : public Session
+    {
+      InboundSession(LinkLayer* p, utp_socket* s, const Addr& addr);
+
+      bool
+      InboundLIM(const LinkIntroMessage* msg);
+
+      void
+      Start() override
+      {
+      }
+    };
+
+    struct OutboundSession final : public Session
+    {
+      OutboundSession(LinkLayer* p, utp_socket* s, const RouterContact& rc,
+                      const AddressInfo& addr);
+
+      bool
+      OutboundLIM(const LinkIntroMessage* msg);
+
+      void
+      Start() override;
     };
   }  // namespace utp
 }  // namespace llarp

--- a/test/util/test_llarp_util_thread_pool.cpp
+++ b/test/util/test_llarp_util_thread_pool.cpp
@@ -419,10 +419,10 @@ TEST(TestThreadPool, recurseJob)
   static constexpr size_t depth    = 10;
   static constexpr size_t capacity = 100;
 
-  ThreadPool pool(threads, capacity);
-
   util::Barrier barrier(threads + 1);
   std::atomic_size_t counter{0};
+
+  ThreadPool pool(threads, capacity);
 
   pool.start();
 


### PR DESCRIPTION
fixes 2 of the 3 outstanding asan issues.

notes:
- ownership of the `ILinkSession` is shared between AuthedLinks and PendingLinks
- hoist common methods up to the interface to avoid use of bare `new`