### PR TITLE
when SunOS 4.x/Sun386i compatibilty was yanked,

### DIFF
--- a/llarp/metrics/metrictank_publisher.cpp
+++ b/llarp/metrics/metrictank_publisher.cpp
@@ -11,6 +11,9 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+// bzero and friends graduated from /usr/ucb*
+// not too long ago
+#include <strings.h>
 #else
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
some of the more useful functions graduated to the main libc