### PR TITLE
Remove IStateful virtual inheritance

### DIFF
--- a/llarp/dht/bucket.hpp
+++ b/llarp/dht/bucket.hpp
@@ -14,7 +14,7 @@ namespace llarp
   namespace dht
   {
     template < typename Val_t >
-    struct Bucket : public util::IStateful
+    struct Bucket
     {
       using BucketStorage_t = std::map< Key_t, Val_t, XorMetric >;
       using Random_t        = std::function< uint64_t() >;
@@ -22,7 +22,7 @@ namespace llarp
       Bucket(const Key_t& us, Random_t r) : nodes(XorMetric(us)), random(r){};
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         util::StatusObject obj{};
         for(const auto& item : nodes)

--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -63,7 +63,7 @@ namespace llarp
       void
       LookupRouterRecursive(const RouterID& target, const Key_t& whoasked,
                             uint64_t whoaskedTX, const Key_t& askpeer,
-                            RouterLookupHandler result = nullptr);
+                            RouterLookupHandler result = nullptr) override;
 
       bool
       LookupRouter(const RouterID& target, RouterLookupHandler result) override

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -23,7 +23,7 @@ namespace llarp
 
   namespace dht
   {
-    struct AbstractContext : public util::IStateful
+    struct AbstractContext
     {
       using PendingIntrosetLookups =
           TXHolder< service::Address, service::IntroSet,
@@ -175,6 +175,9 @@ namespace llarp
 
       virtual Bucket< RCNode >*
       Nodes() const = 0;
+
+      virtual util::StatusObject
+      ExtractStatus() const = 0;
     };
 
     std::unique_ptr< AbstractContext >

--- a/llarp/dht/node.hpp
+++ b/llarp/dht/node.hpp
@@ -9,7 +9,7 @@ namespace llarp
 {
   namespace dht
   {
-    struct RCNode : public util::IStateful
+    struct RCNode
     {
       RouterContact rc;
       Key_t ID;
@@ -24,7 +24,7 @@ namespace llarp
       }
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         return rc.ExtractStatus();
       }
@@ -36,7 +36,7 @@ namespace llarp
       }
     };
 
-    struct ISNode : public util::IStateful
+    struct ISNode
     {
       service::IntroSet introset;
 
@@ -53,7 +53,7 @@ namespace llarp
       }
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         return introset.ExtractStatus();
       }

--- a/llarp/dht/tx.hpp
+++ b/llarp/dht/tx.hpp
@@ -16,7 +16,7 @@ namespace llarp
     struct AbstractContext;
 
     template < typename K, typename V >
-    struct TX : public util::IStateful
+    struct TX
     {
       K target;
       AbstractContext* parent;
@@ -39,7 +39,7 @@ namespace llarp
       AskNextPeer(const Key_t& prevPeer, const std::unique_ptr< Key_t >& next);
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         util::StatusObject obj{{"whoasked", whoasked.ExtractStatus()},
                                {"target", target.ToHex()}};

--- a/llarp/dht/txholder.hpp
+++ b/llarp/dht/txholder.hpp
@@ -16,7 +16,7 @@ namespace llarp
   {
     template < typename K, typename V, typename K_Hash,
                llarp_time_t requestTimeoutMS = 5000UL >
-    struct TXHolder : public util::IStateful
+    struct TXHolder
     {
       using TXPtr = std::unique_ptr< TX< K, V > >;
       // tx who are waiting for a reply for each key
@@ -30,7 +30,7 @@ namespace llarp
       GetPendingLookupFrom(const TXOwner& owner) const;
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         util::StatusObject obj{};
         std::vector< util::StatusObject > txObjs, timeoutsObjs, waitingObjs;

--- a/llarp/dht/txowner.hpp
+++ b/llarp/dht/txowner.hpp
@@ -9,7 +9,7 @@ namespace llarp
 {
   namespace dht
   {
-    struct TXOwner : public util::IStateful
+    struct TXOwner
     {
       Key_t node;
       uint64_t txid = 0;
@@ -26,7 +26,7 @@ namespace llarp
       }
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         util::StatusObject obj{
             {"txid", txid},

--- a/llarp/exit/context.hpp
+++ b/llarp/exit/context.hpp
@@ -11,7 +11,7 @@ namespace llarp
   namespace exit
   {
     /// owner of all the exit endpoints
-    struct Context : public util::IStateful
+    struct Context
     {
       using Config_t = std::unordered_multimap< std::string, std::string >;
 
@@ -25,7 +25,7 @@ namespace llarp
       ClearAllEndpoints();
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       /// send close to all exit sessions and remove all sessions
       void

--- a/llarp/exit/endpoint.hpp
+++ b/llarp/exit/endpoint.hpp
@@ -19,7 +19,7 @@ namespace llarp
   namespace exit
   {
     /// persistant exit state for 1 identity on the exit node
-    struct Endpoint : public util::IStateful
+    struct Endpoint
     {
       static constexpr size_t MaxUpstreamQueueSize = 256;
 
@@ -35,7 +35,7 @@ namespace llarp
 
       /// implement istateful
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       /// return true if we are expired right now
       bool

--- a/llarp/exit/session.hpp
+++ b/llarp/exit/session.hpp
@@ -30,7 +30,7 @@ namespace llarp
       virtual ~BaseSession();
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       bool
       ShouldBundleRC() const override

--- a/llarp/handlers/exit.hpp
+++ b/llarp/handlers/exit.hpp
@@ -11,7 +11,7 @@ namespace llarp
   struct AbstractRouter;
   namespace handlers
   {
-    struct ExitEndpoint : public dns::IQueryHandler, public util::IStateful
+    struct ExitEndpoint : public dns::IQueryHandler
     {
       ExitEndpoint(const std::string& name, AbstractRouter* r);
       ~ExitEndpoint();
@@ -26,7 +26,7 @@ namespace llarp
       Name() const;
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       bool
       ShouldHookDNSMessage(const dns::Message& msg) const override;

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -33,7 +33,7 @@ namespace llarp
       Tick(llarp_time_t now) override;
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       bool
       ShouldHookDNSMessage(const dns::Message& msg) const override;

--- a/llarp/link/server.hpp
+++ b/llarp/link/server.hpp
@@ -45,7 +45,7 @@ namespace llarp
   /// handles close of all sessions with pubkey
   using SessionClosedHandler = std::function< void(llarp::RouterID) >;
 
-  struct ILinkLayer : public util::IStateful
+  struct ILinkLayer
   {
     ILinkLayer(const SecretKey& routerEncSecret, GetRCFunc getrc,
                LinkMessageHandler handler, SignBufferFunc signFunc,
@@ -135,7 +135,7 @@ namespace llarp
     Name() const = 0;
 
     util::StatusObject
-    ExtractStatus() const override LOCKS_EXCLUDED(m_AuthedLinksMutex);
+    ExtractStatus() const LOCKS_EXCLUDED(m_AuthedLinksMutex);
 
     void
     CloseSessionTo(const RouterID& remote);

--- a/llarp/link/session.hpp
+++ b/llarp/link/session.hpp
@@ -13,7 +13,7 @@ namespace llarp
   struct LinkIntroMessage;
   struct ILinkMessage;
   struct ILinkLayer;
-  struct ILinkSession : public util::IStateful
+  struct ILinkSession
   {
     virtual ~ILinkSession(){};
 
@@ -81,6 +81,9 @@ namespace llarp
     /// return true if we should send an explicit keepalive message
     virtual bool
     ShouldPing() const = 0;
+
+    virtual util::StatusObject
+    ExtractStatus() const = 0;
   };
 }  // namespace llarp
 

--- a/llarp/path/path.hpp
+++ b/llarp/path/path.hpp
@@ -279,7 +279,7 @@ namespace llarp
     }
 
     /// configuration for a single hop when building a path
-    struct PathHopConfig : public util::IStateful
+    struct PathHopConfig
     {
       /// path id
       PathID_t txID, rxID;
@@ -302,13 +302,11 @@ namespace llarp
       PathHopConfig();
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
     };
 
     /// A path we made
-    struct Path : public IHopHandler,
-                  public llarp::routing::IMessageHandler,
-                  public util::IStateful
+    struct Path : public IHopHandler, public llarp::routing::IMessageHandler
     {
       using BuildResultHookFunc = std::function< void(Path*) >;
       using CheckForDeadFunc    = std::function< bool(Path*, llarp_time_t) >;
@@ -336,7 +334,7 @@ namespace llarp
            PathRole startingRoles);
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       PathRole
       Role() const

--- a/llarp/path/pathbuilder.hpp
+++ b/llarp/path/pathbuilder.hpp
@@ -15,7 +15,7 @@ namespace llarp
     // milliseconds waiting between builds on a path
     constexpr llarp_time_t MIN_PATH_BUILD_INTERVAL = 1000;
 
-    struct Builder : public PathSet, public util::IStateful
+    struct Builder : public PathSet
     {
      protected:
       /// flag for PathSet::Stop()
@@ -38,8 +38,8 @@ namespace llarp
 
       virtual ~Builder();
 
-      virtual util::StatusObject
-      ExtractStatus() const override;
+      util::StatusObject
+      ExtractStatus() const;
 
       virtual bool
       SelectHop(llarp_nodedb* db, const RouterContact& prev, RouterContact& cur,

--- a/llarp/router/abstractrouter.cpp
+++ b/llarp/router/abstractrouter.cpp
@@ -2,4 +2,7 @@
 
 namespace llarp
 {
+  AbstractRouter::~AbstractRouter()
+  {
+  }
 }  // namespace llarp

--- a/llarp/router/abstractrouter.hpp
+++ b/llarp/router/abstractrouter.hpp
@@ -45,8 +45,10 @@ namespace llarp
     struct Context;
   }
 
-  struct AbstractRouter : public util::IStateful
+  struct AbstractRouter
   {
+    virtual ~AbstractRouter() = 0;
+
     virtual bool
     OnSessionEstablished(ILinkSession *) = 0;
 
@@ -192,6 +194,9 @@ namespace llarp
 
     virtual bool
     ConnectionToRouterAllowed(const RouterID &router) const = 0;
+
+    virtual util::StatusObject
+    ExtractStatus() const = 0;
   };
 }  // namespace llarp
 

--- a/llarp/router_contact.hpp
+++ b/llarp/router_contact.hpp
@@ -65,7 +65,7 @@ namespace llarp
   }
 
   /// RouterContact
-  struct RouterContact final : public IBEncodeMessage, public util::IStateful
+  struct RouterContact final : public IBEncodeMessage
   {
     /// for unit tests
     static bool IgnoreBogons;
@@ -117,7 +117,7 @@ namespace llarp
     uint64_t last_updated = 0;
 
     util::StatusObject
-    ExtractStatus() const override;
+    ExtractStatus() const;
 
     bool
     BEncode(llarp_buffer_t *buf) const override;

--- a/llarp/router_id.hpp
+++ b/llarp/router_id.hpp
@@ -6,7 +6,7 @@
 
 namespace llarp
 {
-  struct RouterID : public AlignedBuffer< 32 >, public util::IStateful
+  struct RouterID : public AlignedBuffer< 32 >
   {
     static constexpr size_t SIZE = 32;
 
@@ -25,7 +25,7 @@ namespace llarp
     }
 
     util::StatusObject
-    ExtractStatus() const override;
+    ExtractStatus() const;
 
     std::string
     ToString() const;

--- a/llarp/service/Intro.hpp
+++ b/llarp/service/Intro.hpp
@@ -12,11 +12,10 @@ namespace llarp
 {
   namespace service
   {
-    struct Introduction final : public llarp::IBEncodeMessage,
-                                public util::IStateful
+    struct Introduction final : public IBEncodeMessage
     {
-      llarp::PubKey router;
-      llarp::PathID_t pathID;
+      PubKey router;
+      PathID_t pathID;
       uint64_t latency   = 0;
       uint64_t version   = 0;
       uint64_t expiresAt = 0;
@@ -32,7 +31,7 @@ namespace llarp
       }
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       bool
       IsExpired(llarp_time_t now) const

--- a/llarp/service/IntroSet.hpp
+++ b/llarp/service/IntroSet.hpp
@@ -24,11 +24,10 @@ namespace llarp
     constexpr std::size_t MAX_INTROSET_SIZE = 4096;
     // 10 seconds clock skew permitted for introset expiration
     constexpr llarp_time_t MAX_INTROSET_TIME_DELTA = (10 * 1000);
-    struct IntroSet final : public llarp::IBEncodeMessage,
-                            public util::IStateful
+    struct IntroSet final : public llarp::IBEncodeMessage
     {
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       ServiceInfo A;
       std::vector< Introduction > I;

--- a/llarp/service/context.hpp
+++ b/llarp/service/context.hpp
@@ -13,7 +13,7 @@ namespace llarp
   namespace service
   {
     /// holds all the hidden service endpoints we own
-    struct Context : public util::IStateful
+    struct Context
     {
       Context(AbstractRouter *r);
       ~Context();
@@ -26,7 +26,7 @@ namespace llarp
       StopAll();
 
       util::StatusObject
-      ExtractStatus() const override;
+      ExtractStatus() const;
 
       bool
       hasEndpoints();

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -40,8 +40,8 @@ namespace llarp
       Endpoint(const std::string& nickname, AbstractRouter* r, Context* parent);
       ~Endpoint();
 
-      virtual util::StatusObject
-      ExtractStatus() const override;
+      util::StatusObject
+      ExtractStatus() const;
 
       void
       SetHandler(IDataHandler* h);
@@ -281,7 +281,7 @@ namespace llarp
         ~OutboundContext();
 
         util::StatusObject
-        ExtractStatus() const override;
+        ExtractStatus() const;
 
         bool
         ShouldBundleRC() const override
@@ -574,7 +574,7 @@ namespace llarp
       /// on initialize functions
       std::list< std::function< bool(void) > > m_OnInit;
 
-      struct Session : public util::IStateful
+      struct Session
       {
         Introduction replyIntro;
         SharedSecret sharedKey;
@@ -584,7 +584,7 @@ namespace llarp
         uint64_t seqno        = 0;
 
         util::StatusObject
-        ExtractStatus() const override
+        ExtractStatus() const
         {
           util::StatusObject obj{{"lastUsed", lastUsed},
                                  {"replyIntro", replyIntro.ExtractStatus()},

--- a/llarp/service/lookup.hpp
+++ b/llarp/service/lookup.hpp
@@ -20,7 +20,7 @@ namespace llarp
 
     constexpr size_t MaxConcurrentLookups = size_t(4);
 
-    struct IServiceLookup : public util::IStateful
+    struct IServiceLookup
     {
       IServiceLookup() = delete;
       virtual ~IServiceLookup(){};
@@ -56,7 +56,7 @@ namespace llarp
       RouterID endpoint;
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         auto now = llarp::time_now_ms();
         util::StatusObject obj{{"txid", txid},

--- a/llarp/service/tag.hpp
+++ b/llarp/service/tag.hpp
@@ -15,7 +15,7 @@ namespace llarp
 {
   namespace service
   {
-    struct Tag : public llarp::AlignedBuffer< 16 >, public util::IStateful
+    struct Tag : public llarp::AlignedBuffer< 16 >
     {
       Tag() : llarp::AlignedBuffer< SIZE >()
       {
@@ -54,7 +54,7 @@ namespace llarp
       }
 
       util::StatusObject
-      ExtractStatus() const override
+      ExtractStatus() const
       {
         return util::StatusObject{{"name", ToString()}};
       }

--- a/llarp/util/status.hpp
+++ b/llarp/util/status.hpp
@@ -45,16 +45,6 @@ namespace llarp
       friend struct StatusVisitor;
       nlohmann::json Impl;
     };
-
-    /// an entity that has a status that can be extracted
-    struct IStateful
-    {
-      virtual ~IStateful(){};
-
-      virtual StatusObject
-      ExtractStatus() const = 0;
-    };
-
   }  // namespace util
 }  // namespace llarp
 


### PR DESCRIPTION
This makes a whole lot of otherwise simple classes virtual with no real benefit. "Convention" around the `ExtractStatus` method should be sufficient.

If required, we could make a trait for this instead, but I don't think it's needed.