### PR TITLE
Refactor service::Endpoint into multiple chunks

### DIFF
--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -214,23 +214,24 @@ set(LIB_SRC
   routing/path_latency.cpp
   routing/path_transfer.cpp
   rpc/rpc.cpp
-  service/async_key_exchange.cpp
-  service/hidden_service_address_lookup.cpp
-  service/Identity.cpp
-  service/Intro.cpp
-  service/IntroSet.cpp
   service/address.cpp
+  service/async_key_exchange.cpp
   service/config.cpp
   service/context.cpp
   service/endpoint.cpp
   service/handler.cpp
+  service/hidden_service_address_lookup.cpp
+  service/Identity.cpp
   service/info.cpp
+  service/Intro.cpp
+  service/IntroSet.cpp
   service/lookup.cpp
   service/outbound_context.cpp
   service/pendingbuffer.cpp
   service/protocol.cpp
   service/sendcontext.cpp
   service/tag.cpp
+  service/tag_lookup_job.cpp
   service/types.cpp
   service/vanity.cpp
   utp/inbound_message.cpp

--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -214,6 +214,8 @@ set(LIB_SRC
   routing/path_latency.cpp
   routing/path_transfer.cpp
   rpc/rpc.cpp
+  service/async_key_exchange.cpp
+  service/hidden_service_address_lookup.cpp
   service/Identity.cpp
   service/Intro.cpp
   service/IntroSet.cpp
@@ -224,6 +226,7 @@ set(LIB_SRC
   service/handler.cpp
   service/info.cpp
   service/lookup.cpp
+  service/outbound_context.cpp
   service/pendingbuffer.cpp
   service/protocol.cpp
   service/sendcontext.cpp

--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -230,6 +230,7 @@ set(LIB_SRC
   service/pendingbuffer.cpp
   service/protocol.cpp
   service/sendcontext.cpp
+  service/session.cpp
   service/tag.cpp
   service/tag_lookup_job.cpp
   service/types.cpp

--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -224,7 +224,9 @@ set(LIB_SRC
   service/handler.cpp
   service/info.cpp
   service/lookup.cpp
+  service/pendingbuffer.cpp
   service/protocol.cpp
+  service/sendcontext.cpp
   service/tag.cpp
   service/types.cpp
   service/vanity.cpp

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -336,9 +336,11 @@ namespace llarp
           else
           {
             dns::Message *replyMsg = new dns::Message(std::move(msg));
+            using service::Address;
+            using service::OutboundContext;
             return EnsurePathToService(
                 addr,
-                [=](const service::Address &remote, OutboundContext *ctx) {
+                [=](const Address &remote, OutboundContext *ctx) {
                   SendDNSReply(remote, ctx, replyMsg, reply, false, isV6);
                 },
                 2000);

--- a/llarp/service/async_key_exchange.cpp
+++ b/llarp/service/async_key_exchange.cpp
@@ -1,0 +1,86 @@
+#include <service/async_key_exchange.hpp>
+
+#include <crypto/crypto.hpp>
+#include <crypto/types.hpp>
+#include <util/logic.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    AsyncKeyExchange::AsyncKeyExchange(Logic* l, Crypto* c,
+                                       const ServiceInfo& r,
+                                       const Identity& localident,
+                                       const PQPubKey& introsetPubKey,
+                                       const Introduction& remote,
+                                       IDataHandler* h, const ConvoTag& t)
+        : logic(l)
+        , crypto(c)
+        , remote(r)
+        , m_LocalIdentity(localident)
+        , introPubKey(introsetPubKey)
+        , remoteIntro(remote)
+        , handler(h)
+        , tag(t)
+    {
+    }
+
+    void
+    AsyncKeyExchange::Result(void* user)
+    {
+      AsyncKeyExchange* self = static_cast< AsyncKeyExchange* >(user);
+      // put values
+      self->handler->PutCachedSessionKeyFor(self->msg.tag, self->sharedKey);
+      self->handler->PutIntroFor(self->msg.tag, self->remoteIntro);
+      self->handler->PutSenderFor(self->msg.tag, self->remote);
+      self->handler->PutReplyIntroFor(self->msg.tag, self->msg.introReply);
+      self->hook(self->frame);
+      delete self;
+    }
+
+    void
+    AsyncKeyExchange::Encrypt(void* user)
+    {
+      AsyncKeyExchange* self = static_cast< AsyncKeyExchange* >(user);
+      // derive ntru session key component
+      SharedSecret K;
+      self->crypto->pqe_encrypt(self->frame.C, K, self->introPubKey);
+      // randomize Nonce
+      self->frame.N.Randomize();
+      // compure post handshake session key
+      // PKE (A, B, N)
+      SharedSecret sharedSecret;
+      using namespace std::placeholders;
+      path_dh_func dh_client =
+          std::bind(&Crypto::dh_client, self->crypto, _1, _2, _3, _4);
+      if(!self->m_LocalIdentity.KeyExchange(dh_client, sharedSecret,
+                                            self->remote, self->frame.N))
+      {
+        LogError("failed to derive x25519 shared key component");
+      }
+      std::array< byte_t, 64 > tmp = {{0}};
+      // K
+      std::copy(K.begin(), K.end(), tmp.begin());
+      // H (K + PKE(A, B, N))
+      std::copy(sharedSecret.begin(), sharedSecret.end(), tmp.begin() + 32);
+      self->crypto->shorthash(self->sharedKey, llarp_buffer_t(tmp));
+      // set tag
+      self->msg.tag = self->tag;
+      // set sender
+      self->msg.sender = self->m_LocalIdentity.pub;
+      // set version
+      self->msg.version = LLARP_PROTO_VERSION;
+      // set protocol
+      self->msg.proto = eProtocolTraffic;
+      // encrypt and sign
+      if(self->frame.EncryptAndSign(self->crypto, self->msg, K,
+                                    self->m_LocalIdentity))
+        self->logic->queue_job({self, &Result});
+      else
+      {
+        LogError("failed to encrypt and sign");
+        delete self;
+      }
+    }
+  }  // namespace service
+}  // namespace llarp

--- a/llarp/service/async_key_exchange.hpp
+++ b/llarp/service/async_key_exchange.hpp
@@ -1,0 +1,48 @@
+#ifndef LLARP_SERVICE_ASYNC_KEY_EXCHANGE_HPP
+#define LLARP_SERVICE_ASYNC_KEY_EXCHANGE_HPP
+
+#include <crypto/types.hpp>
+#include <service/Identity.hpp>
+#include <service/protocol.hpp>
+
+namespace llarp
+{
+  class Logic;
+  struct Crypto;
+
+  namespace service
+  {
+    struct AsyncKeyExchange
+    {
+      Logic* logic;
+      Crypto* crypto;
+      SharedSecret sharedKey;
+      ServiceInfo remote;
+      const Identity& m_LocalIdentity;
+      ProtocolMessage msg;
+      ProtocolFrame frame;
+      Introduction intro;
+      const PQPubKey introPubKey;
+      Introduction remoteIntro;
+      std::function< void(ProtocolFrame&) > hook;
+      IDataHandler* handler;
+      ConvoTag tag;
+
+      AsyncKeyExchange(Logic* l, Crypto* c, const ServiceInfo& r,
+                       const Identity& localident,
+                       const PQPubKey& introsetPubKey,
+                       const Introduction& remote, IDataHandler* h,
+                       const ConvoTag& t);
+
+      static void
+      Result(void* user);
+
+      /// given protocol message make protocol frame
+      static void
+      Encrypt(void* user);
+    };
+
+  }  // namespace service
+}  // namespace llarp
+
+#endif

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -10,6 +10,8 @@
 #include <nodedb.hpp>
 #include <profiling.hpp>
 #include <router/abstractrouter.hpp>
+#include <service/hidden_service_address_lookup.hpp>
+#include <service/outbound_context.hpp>
 #include <service/protocol.hpp>
 #include <util/logic.hpp>
 #include <util/str.hpp>
@@ -353,13 +355,6 @@ namespace llarp
     }
 
     bool
-    Endpoint::OutboundContext::Stop()
-    {
-      markedBad = true;
-      return path::Builder::Stop();
-    }
-
-    bool
     Endpoint::Stop()
     {
       // stop remote sessions
@@ -373,13 +368,6 @@ namespace llarp
         item.second->Stop();
       }
       return path::Builder::Stop();
-    }
-
-    bool
-    Endpoint::OutboundContext::IsDone(llarp_time_t now) const
-    {
-      (void)now;
-      return AvailablePaths(path::ePathRoleAny) == 0 && ShouldRemove();
     }
 
     uint64_t
@@ -753,50 +741,6 @@ namespace llarp
       LogInfo(Name(), " IntroSet publish confirmed");
     }
 
-    struct HiddenServiceAddressLookup : public IServiceLookup
-    {
-      ~HiddenServiceAddressLookup()
-      {
-      }
-
-      Address remote;
-      typedef std::function< bool(const Address&, const IntroSet*,
-                                  const RouterID&) >
-          HandlerFunc;
-      HandlerFunc handle;
-
-      HiddenServiceAddressLookup(Endpoint* p, HandlerFunc h,
-                                 const Address& addr, uint64_t tx)
-          : IServiceLookup(p, tx, "HSLookup"), remote(addr), handle(h)
-      {
-      }
-
-      bool
-      HandleResponse(const std::set< IntroSet >& results)
-      {
-        LogInfo("found ", results.size(), " for ", remote.ToString());
-        if(results.size() > 0)
-        {
-          IntroSet selected;
-          for(const auto& introset : results)
-          {
-            if(selected.OtherIsNewer(introset) && introset.A.Addr() == remote)
-              selected = introset;
-          }
-          return handle(remote, &selected, endpoint);
-        }
-        return handle(remote, nullptr, endpoint);
-      }
-
-      routing::IMessage*
-      BuildRequestMessage()
-      {
-        routing::DHTMessage* msg = new routing::DHTMessage();
-        msg->M.emplace_back(new dht::FindIntroMessage(txid, remote, 0));
-        return msg;
-      }
-    };
-
     bool
     Endpoint::DoNetworkIsolation(bool failed)
     {
@@ -936,25 +880,6 @@ namespace llarp
     }
 
     bool
-    Endpoint::OutboundContext::HandleDataDrop(path::Path* p,
-                                              const PathID_t& dst, uint64_t seq)
-    {
-      // pick another intro
-      if(dst == remoteIntro.pathID && remoteIntro.router == p->Endpoint())
-      {
-        LogWarn(Name(), " message ", seq, " dropped by endpoint ",
-                p->Endpoint(), " via ", dst);
-        if(MarkCurrentIntroBad(Now()))
-        {
-          LogInfo(Name(), " switched intros to ", remoteIntro.router, " via ",
-                  remoteIntro.pathID);
-        }
-        UpdateIntroSet(true);
-      }
-      return true;
-    }
-
-    bool
     Endpoint::HandleDataMessage(const PathID_t& src, ProtocolMessage* msg)
     {
       auto path = GetPathByID(src);
@@ -1042,101 +967,15 @@ namespace llarp
     }
 
     void
-    Endpoint::OutboundContext::HandlePathBuilt(path::Path* p)
-    {
-      path::Builder::HandlePathBuilt(p);
-      /// don't use it if we are marked bad
-      if(markedBad)
-        return;
-      p->SetDataHandler(
-          std::bind(&Endpoint::OutboundContext::HandleHiddenServiceFrame, this,
-                    std::placeholders::_1, std::placeholders::_2));
-      p->SetDropHandler(std::bind(
-          &Endpoint::OutboundContext::HandleDataDrop, this,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-    }
-
-    void
     Endpoint::HandlePathDied(path::Path*)
     {
       RegenAndPublishIntroSet(Now(), true);
-    }
-
-    void
-    Endpoint::OutboundContext::HandlePathDied(path::Path* path)
-    {
-      // unconditionally update introset
-      UpdateIntroSet(true);
-      const RouterID endpoint(path->Endpoint());
-      // if a path to our current intro died...
-      if(endpoint == remoteIntro.router)
-      {
-        // figure out how many paths to this router we have
-        size_t num = 0;
-        ForEachPath([&](path::Path* p) {
-          if(p->Endpoint() == endpoint && p->IsReady())
-            ++num;
-        });
-        // if we have more than two then we are probably fine
-        if(num > 2)
-          return;
-        // if we have one working one ...
-        if(num == 1)
-        {
-          num = 0;
-          ForEachPath([&](path::Path* p) {
-            if(p->Endpoint() == endpoint)
-              ++num;
-          });
-          // if we have 2 or more established or pending don't do anything
-          if(num > 2)
-            return;
-          BuildOneAlignedTo(endpoint);
-        }
-        else if(num == 0)
-        {
-          // we have no paths to this router right now
-          // hop off it
-          Introduction picked;
-          // get the latest intro that isn't on that endpoint
-          for(const auto& intro : currentIntroSet.I)
-          {
-            if(intro.router == endpoint)
-              continue;
-            if(intro.expiresAt > picked.expiresAt)
-              picked = intro;
-          }
-          // we got nothing
-          if(picked.router.IsZero())
-          {
-            return;
-          }
-          m_NextIntro = picked;
-          // check if we have a path to this router
-          num = 0;
-          ForEachPath([&](path::Path* p) {
-            if(p->Endpoint() == m_NextIntro.router)
-              ++num;
-          });
-          // build a path if one isn't already pending build or established
-          if(num == 0)
-            BuildOneAlignedTo(m_NextIntro.router);
-          SwapIntros();
-        }
-      }
     }
 
     bool
     Endpoint::CheckPathIsDead(path::Path*, llarp_time_t dlt)
     {
       return dlt > path::alive_timeout;
-    }
-
-    bool
-    Endpoint::OutboundContext::HandleHiddenServiceFrame(
-        path::Path* p, const ProtocolFrame* frame)
-    {
-      return m_Endpoint->HandleHiddenServiceFrame(p, frame);
     }
 
     bool
@@ -1210,78 +1049,6 @@ namespace llarp
       }
       LogError("send via path failed");
       return false;
-    }
-
-    Endpoint::OutboundContext::OutboundContext(const IntroSet& introset,
-                                               Endpoint* parent)
-        : path::Builder(parent->m_Router, parent->m_Router->dht(), 3,
-                        path::default_len)
-        , SendContext(introset.A, {}, this, parent)
-        , currentIntroSet(introset)
-
-    {
-      updatingIntroSet = false;
-      for(const auto intro : introset.I)
-      {
-        if(intro.expiresAt > m_NextIntro.expiresAt)
-          m_NextIntro = intro;
-      }
-    }
-
-    Endpoint::OutboundContext::~OutboundContext()
-    {
-    }
-
-    /// actually swap intros
-    void
-    Endpoint::OutboundContext::SwapIntros()
-    {
-      remoteIntro = m_NextIntro;
-      m_DataHandler->PutIntroFor(currentConvoTag, remoteIntro);
-    }
-
-    bool
-    Endpoint::OutboundContext::OnIntroSetUpdate(__attribute__((unused))
-                                                const Address& addr,
-                                                const IntroSet* i,
-                                                const RouterID& endpoint)
-    {
-      if(markedBad)
-        return true;
-      updatingIntroSet = false;
-      if(i)
-      {
-        if(currentIntroSet.T >= i->T)
-        {
-          LogInfo("introset is old, dropping");
-          return true;
-        }
-        auto now = Now();
-        if(i->IsExpired(now))
-        {
-          LogError("got expired introset from lookup from ", endpoint);
-          return true;
-        }
-        currentIntroSet = *i;
-        if(!ShiftIntroduction())
-        {
-          LogWarn("failed to pick new intro during introset update");
-        }
-        if(GetPathByRouter(m_NextIntro.router) == nullptr)
-          BuildOneAlignedTo(m_NextIntro.router);
-        else
-          SwapIntros();
-      }
-      else
-        ++m_LookupFails;
-      return true;
-    }
-
-    bool
-    Endpoint::OutboundContext::ReadyToSend() const
-    {
-      return (!remoteIntro.router.IsZero())
-          && GetPathByRouter(remoteIntro.router) != nullptr;
     }
 
     void
@@ -1424,434 +1191,16 @@ namespace llarp
           5000, true);
     }
 
-    bool
-    Endpoint::OutboundContext::BuildOneAlignedTo(const RouterID& remote)
-    {
-      LogInfo(Name(), " building path to ", remote);
-      auto nodedb = m_Endpoint->Router()->nodedb();
-      std::vector< RouterContact > hops;
-      hops.resize(numHops);
-      for(size_t hop = 0; hop < numHops; ++hop)
-      {
-        if(hop == 0)
-        {
-          if(!SelectHop(nodedb, hops[0], hops[0], 0, path::ePathRoleAny))
-            return false;
-        }
-        else if(hop == numHops - 1)
-        {
-          // last hop
-          if(!nodedb->Get(remote, hops[hop]))
-            return false;
-        }
-        // middle hop
-        else
-        {
-          size_t tries = 5;
-          do
-          {
-            nodedb->select_random_hop_excluding(hops[hop],
-                                                {hops[hop - 1].pubkey, remote});
-            --tries;
-          } while(m_Endpoint->Router()->routerProfiling().IsBadForPath(
-                      hops[hop].pubkey)
-                  && tries > 0);
-          return tries > 0;
-        }
-        return false;
-      }
-      Build(hops);
-      return true;
-    }
-
-    bool
-    Endpoint::OutboundContext::MarkCurrentIntroBad(llarp_time_t now)
-    {
-      // insert bad intro
-      m_BadIntros[remoteIntro] = now;
-      // unconditional shift
-      bool shiftedRouter = false;
-      bool shiftedIntro  = false;
-      // try same router
-      for(const auto& intro : currentIntroSet.I)
-      {
-        if(intro.ExpiresSoon(now))
-          continue;
-        if(router->routerProfiling().IsBadForPath(intro.router))
-          continue;
-        auto itr = m_BadIntros.find(intro);
-        if(itr == m_BadIntros.end() && intro.router == m_NextIntro.router)
-        {
-          shiftedIntro = true;
-          m_NextIntro  = intro;
-          break;
-        }
-      }
-      if(!shiftedIntro)
-      {
-        // try any router
-        for(const auto& intro : currentIntroSet.I)
-        {
-          if(intro.ExpiresSoon(now))
-            continue;
-          auto itr = m_BadIntros.find(intro);
-          if(itr == m_BadIntros.end())
-          {
-            // TODO: this should always be true but idk if it really is
-            shiftedRouter = m_NextIntro.router != intro.router;
-            shiftedIntro  = true;
-            m_NextIntro   = intro;
-            break;
-          }
-        }
-      }
-      if(shiftedRouter)
-      {
-        lastShift = now;
-        BuildOneAlignedTo(m_NextIntro.router);
-      }
-      else if(shiftedIntro)
-      {
-        SwapIntros();
-      }
-      else
-      {
-        LogInfo(Name(), " updating introset");
-        UpdateIntroSet(true);
-      }
-      return shiftedIntro;
-    }
-
-    bool
-    Endpoint::OutboundContext::ShiftIntroduction(bool rebuild)
-    {
-      bool success = false;
-      auto now     = Now();
-      if(now - lastShift < MIN_SHIFT_INTERVAL)
-        return false;
-      bool shifted = false;
-      // to find a intro on the same router as before
-      for(const auto& intro : currentIntroSet.I)
-      {
-        if(intro.ExpiresSoon(now))
-          continue;
-        if(m_BadIntros.find(intro) == m_BadIntros.end()
-           && remoteIntro.router == intro.router)
-        {
-          m_NextIntro = intro;
-          return true;
-        }
-      }
-      for(const auto& intro : currentIntroSet.I)
-      {
-        m_Endpoint->EnsureRouterIsKnown(intro.router);
-        if(intro.ExpiresSoon(now))
-          continue;
-        if(m_BadIntros.find(intro) == m_BadIntros.end() && m_NextIntro != intro)
-        {
-          shifted = intro.router != m_NextIntro.router
-              || (now < intro.expiresAt
-                  && intro.expiresAt - now
-                      > 10 * 1000);  // TODO: hardcoded value
-          m_NextIntro = intro;
-          success     = true;
-          break;
-        }
-      }
-      if(shifted && rebuild)
-      {
-        lastShift = now;
-        BuildOneAlignedTo(m_NextIntro.router);
-      }
-      return success;
-    }
-
-    struct AsyncKeyExchange
-    {
-      Logic* logic;
-      Crypto* crypto;
-      SharedSecret sharedKey;
-      ServiceInfo remote;
-      const Identity& m_LocalIdentity;
-      ProtocolMessage msg;
-      ProtocolFrame frame;
-      Introduction intro;
-      const PQPubKey introPubKey;
-      Introduction remoteIntro;
-      std::function< void(ProtocolFrame&) > hook;
-      IDataHandler* handler;
-      ConvoTag tag;
-
-      AsyncKeyExchange(Logic* l, Crypto* c, const ServiceInfo& r,
-                       const Identity& localident,
-                       const PQPubKey& introsetPubKey,
-                       const Introduction& remote, IDataHandler* h,
-                       const ConvoTag& t)
-          : logic(l)
-          , crypto(c)
-          , remote(r)
-          , m_LocalIdentity(localident)
-          , introPubKey(introsetPubKey)
-          , remoteIntro(remote)
-          , handler(h)
-          , tag(t)
-      {
-      }
-
-      static void
-      Result(void* user)
-      {
-        AsyncKeyExchange* self = static_cast< AsyncKeyExchange* >(user);
-        // put values
-        self->handler->PutCachedSessionKeyFor(self->msg.tag, self->sharedKey);
-        self->handler->PutIntroFor(self->msg.tag, self->remoteIntro);
-        self->handler->PutSenderFor(self->msg.tag, self->remote);
-        self->handler->PutReplyIntroFor(self->msg.tag, self->msg.introReply);
-        self->hook(self->frame);
-        delete self;
-      }
-
-      /// given protocol message make protocol frame
-      static void
-      Encrypt(void* user)
-      {
-        AsyncKeyExchange* self = static_cast< AsyncKeyExchange* >(user);
-        // derive ntru session key component
-        SharedSecret K;
-        self->crypto->pqe_encrypt(self->frame.C, K, self->introPubKey);
-        // randomize Nonce
-        self->frame.N.Randomize();
-        // compure post handshake session key
-        // PKE (A, B, N)
-        SharedSecret sharedSecret;
-        using namespace std::placeholders;
-        path_dh_func dh_client =
-            std::bind(&Crypto::dh_client, self->crypto, _1, _2, _3, _4);
-        if(!self->m_LocalIdentity.KeyExchange(dh_client, sharedSecret,
-                                              self->remote, self->frame.N))
-        {
-          LogError("failed to derive x25519 shared key component");
-        }
-        std::array< byte_t, 64 > tmp = {{0}};
-        // K
-        std::copy(K.begin(), K.end(), tmp.begin());
-        // H (K + PKE(A, B, N))
-        std::copy(sharedSecret.begin(), sharedSecret.end(), tmp.begin() + 32);
-        self->crypto->shorthash(self->sharedKey, llarp_buffer_t(tmp));
-        // set tag
-        self->msg.tag = self->tag;
-        // set sender
-        self->msg.sender = self->m_LocalIdentity.pub;
-        // set version
-        self->msg.version = LLARP_PROTO_VERSION;
-        // set protocol
-        self->msg.proto = eProtocolTraffic;
-        // encrypt and sign
-        if(self->frame.EncryptAndSign(self->crypto, self->msg, K,
-                                      self->m_LocalIdentity))
-          self->logic->queue_job({self, &Result});
-        else
-        {
-          LogError("failed to encrypt and sign");
-          delete self;
-        }
-      }
-    };
-
     void
     Endpoint::EnsureReplyPath(const ServiceInfo& ident)
     {
       m_AddressToService[ident.Addr()] = ident;
     }
 
-    void
-    Endpoint::OutboundContext::AsyncGenIntro(const llarp_buffer_t& payload,
-                                             __attribute__((unused))
-                                             ProtocolType t)
-    {
-      auto path = m_PathSet->GetPathByRouter(remoteIntro.router);
-      if(path == nullptr)
-      {
-        // try parent as fallback
-        path = m_Endpoint->GetPathByRouter(remoteIntro.router);
-        if(path == nullptr)
-        {
-          BuildOneAlignedTo(remoteIntro.router);
-          LogWarn(Name(), " dropping intro frame, no path to ",
-                  remoteIntro.router);
-          return;
-        }
-      }
-      currentConvoTag.Randomize();
-      AsyncKeyExchange* ex = new AsyncKeyExchange(
-          m_Endpoint->RouterLogic(), m_Endpoint->Crypto(), remoteIdent,
-          m_Endpoint->GetIdentity(), currentIntroSet.K, remoteIntro,
-          m_DataHandler, currentConvoTag);
-
-      ex->hook = std::bind(&Endpoint::OutboundContext::Send, this,
-                           std::placeholders::_1);
-
-      ex->msg.PutBuffer(payload);
-      ex->msg.introReply = path->intro;
-      ex->frame.F        = ex->msg.introReply.pathID;
-      llarp_threadpool_queue_job(m_Endpoint->Worker(),
-                                 {ex, &AsyncKeyExchange::Encrypt});
-    }
-
-    std::string
-    Endpoint::OutboundContext::Name() const
-    {
-      return "OBContext:" + m_Endpoint->Name() + "-"
-          + currentIntroSet.A.Addr().ToString();
-    }
-
-    void
-    Endpoint::OutboundContext::UpdateIntroSet(bool randomizePath)
-    {
-      if(updatingIntroSet || markedBad)
-        return;
-      auto addr = currentIntroSet.A.Addr();
-
-      path::Path* path = nullptr;
-      if(randomizePath)
-        path = m_Endpoint->PickRandomEstablishedPath();
-      else
-        path = m_Endpoint->GetEstablishedPathClosestTo(addr.as_array());
-
-      if(path)
-      {
-        HiddenServiceAddressLookup* job = new HiddenServiceAddressLookup(
-            m_Endpoint,
-            std::bind(&Endpoint::OutboundContext::OnIntroSetUpdate, this,
-                      std::placeholders::_1, std::placeholders::_2,
-                      std::placeholders::_3),
-            addr, m_Endpoint->GenTXID());
-
-        updatingIntroSet = job->SendRequestViaPath(path, m_Endpoint->Router());
-      }
-      else
-      {
-        LogWarn("Cannot update introset no path for outbound session to ",
-                currentIntroSet.A.Addr().ToString());
-      }
-    }
-
-    util::StatusObject
-    Endpoint::OutboundContext::ExtractStatus() const
-    {
-      auto obj = path::Builder::ExtractStatus();
-      obj.Put("currentConvoTag", currentConvoTag.ToHex());
-      obj.Put("remoteIntro", remoteIntro.ExtractStatus());
-      obj.Put("sessionCreatedAt", createdAt);
-      obj.Put("lastGoodSend", lastGoodSend);
-      obj.Put("seqno", sequenceNo);
-      obj.Put("markedBad", markedBad);
-      obj.Put("lastShift", lastShift);
-      obj.Put("remoteIdentity", remoteIdent.Addr().ToString());
-      obj.Put("currentRemoteIntroset", currentIntroSet.ExtractStatus());
-      obj.Put("nextIntro", m_NextIntro.ExtractStatus());
-      std::vector< util::StatusObject > badIntrosObj;
-      std::transform(m_BadIntros.begin(), m_BadIntros.end(),
-                     std::back_inserter(badIntrosObj),
-                     [](const auto& item) -> util::StatusObject {
-                       util::StatusObject o{
-                           {"count", item.second},
-                           {"intro", item.first.ExtractStatus()}};
-                       return o;
-                     });
-      obj.Put("badIntros", badIntrosObj);
-      return obj;
-    }
-
-    bool
-    Endpoint::OutboundContext::Tick(llarp_time_t now)
-    {
-      // we are probably dead af
-      if(m_LookupFails > 16 || m_BuildFails > 10)
-        return true;
-      // check for expiration
-      if(remoteIntro.ExpiresSoon(now))
-      {
-        // shift intro if it expires "soon"
-        ShiftIntroduction();
-      }
-      // swap if we can
-      if(remoteIntro != m_NextIntro)
-      {
-        if(GetPathByRouter(m_NextIntro.router) != nullptr)
-        {
-          // we can safely set remoteIntro to the next one
-          SwapIntros();
-          LogInfo(Name(), " swapped intro");
-        }
-      }
-      // lookup router in intro if set and unknown
-      if(!remoteIntro.router.IsZero())
-        m_Endpoint->EnsureRouterIsKnown(remoteIntro.router);
-      // expire bad intros
-      auto itr = m_BadIntros.begin();
-      while(itr != m_BadIntros.end())
-      {
-        if(now - itr->second > path::default_lifetime)
-          itr = m_BadIntros.erase(itr);
-        else
-          ++itr;
-      }
-      // send control message if we look too quiet
-      if(lastGoodSend)
-      {
-        if(now - lastGoodSend > (sendTimeout / 2))
-        {
-          if(!GetNewestPathByRouter(remoteIntro.router))
-          {
-            BuildOneAlignedTo(remoteIntro.router);
-          }
-          Encrypted< 64 > tmp;
-          tmp.Randomize();
-          llarp_buffer_t buf(tmp.data(), tmp.size());
-          AsyncEncryptAndSendTo(buf, eProtocolControl);
-          SharedSecret k;
-          if(currentConvoTag.IsZero())
-            return false;
-          return !m_DataHandler->HasConvoTag(currentConvoTag);
-        }
-      }
-      // if we are dead return true so we are removed
-      return lastGoodSend
-          ? (now >= lastGoodSend && now - lastGoodSend > sendTimeout)
-          : (now >= createdAt && now - createdAt > connectTimeout);
-    }
-
     bool
     Endpoint::HasConvoTag(const ConvoTag& t) const
     {
       return m_Sessions.find(t) != m_Sessions.end();
-    }
-
-    bool
-    Endpoint::OutboundContext::SelectHop(llarp_nodedb* db,
-                                         const RouterContact& prev,
-                                         RouterContact& cur, size_t hop,
-                                         path::PathRole roles)
-    {
-      if(remoteIntro.router.IsZero())
-      {
-        SwapIntros();
-      }
-      if(hop == numHops - 1)
-      {
-        m_Endpoint->EnsureRouterIsKnown(remoteIntro.router);
-        if(db->Get(remoteIntro.router, cur))
-          return true;
-        ++m_BuildFails;
-        return false;
-      }
-      else if(hop == numHops - 2)
-      {
-        return db->select_random_hop_excluding(
-            cur, {prev.pubkey, remoteIntro.router});
-      }
-      return path::Builder::SelectHop(db, prev, cur, hop, roles);
     }
 
     uint64_t
@@ -1861,16 +1210,6 @@ namespace llarp
       if(itr == m_Sessions.end())
         return 0;
       return ++(itr->second.seqno);
-    }
-
-    bool
-    Endpoint::OutboundContext::ShouldBuildMore(llarp_time_t now) const
-    {
-      if(markedBad)
-        return false;
-      if(path::Builder::ShouldBuildMore(now))
-        return true;
-      return !ReadyToSend();
     }
 
     bool

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -39,7 +39,7 @@ namespace llarp
       if(k == "tag")
       {
         m_Tag = v;
-        llarp::LogInfo("Setting tag to ", v);
+        LogInfo("Setting tag to ", v);
       }
       if(k == "prefetch-tag")
       {
@@ -108,8 +108,8 @@ namespace llarp
                    && intro.expiresAt - now > (2 * 60 * 1000);
              }))
       {
-        llarp::LogWarn("could not publish descriptors for endpoint ", Name(),
-                       " because we couldn't get enough valid introductions");
+        LogWarn("could not publish descriptors for endpoint ", Name(),
+                " because we couldn't get enough valid introductions");
         if(ShouldBuildMore(now) || forceRebuild)
           ManualRebuild(1);
         return;
@@ -123,22 +123,22 @@ namespace llarp
       }
       if(m_IntroSet.I.size() == 0)
       {
-        llarp::LogWarn("not enough intros to publish introset for ", Name());
+        LogWarn("not enough intros to publish introset for ", Name());
         return;
       }
       m_IntroSet.topic = m_Tag;
       if(!m_Identity.SignIntroSet(m_IntroSet, m_Router->crypto(), now))
       {
-        llarp::LogWarn("failed to sign introset for endpoint ", Name());
+        LogWarn("failed to sign introset for endpoint ", Name());
         return;
       }
       if(PublishIntroSet(m_Router))
       {
-        llarp::LogInfo("(re)publishing introset for endpoint ", Name());
+        LogInfo("(re)publishing introset for endpoint ", Name());
       }
       else
       {
-        llarp::LogWarn("failed to publish intro set for endpoint ", Name());
+        LogWarn("failed to publish intro set for endpoint ", Name());
       }
     }
 
@@ -201,7 +201,7 @@ namespace llarp
       {
         RegenAndPublishIntroSet(now);
       }
-      else if(NumInStatus(llarp::path::ePathEstablished) < 3)
+      else if(NumInStatus(path::ePathEstablished) < 3)
       {
         if(m_IntroSet.HasExpiredIntros(now))
           ManualRebuild(1);
@@ -233,7 +233,7 @@ namespace llarp
           {
             std::unique_ptr< IServiceLookup > lookup = std::move(itr->second);
 
-            llarp::LogInfo(lookup->name, " timed out txid=", lookup->txid);
+            LogInfo(lookup->name, " timed out txid=", lookup->txid);
             lookup->HandleResponse({});
             itr = m_PendingLookups.erase(itr);
           }
@@ -248,7 +248,7 @@ namespace llarp
         {
           if(itr->second.IsExpired(now))
           {
-            llarp::LogInfo("lookup for ", itr->first, " timed out");
+            LogInfo("lookup for ", itr->first, " timed out");
             itr = m_PendingRouters.erase(itr);
           }
           else
@@ -267,7 +267,7 @@ namespace llarp
                     __attribute__((unused)) OutboundContext* ctx) {},
                  10000))
           {
-            llarp::LogWarn("failed to ensure path to ", addr);
+            LogWarn("failed to ensure path to ", addr);
           }
         }
       }
@@ -288,12 +288,12 @@ namespace llarp
           llarp_buffer_t buf(tmp);
           if(SendToServiceOrQueue(introset.A.Addr().data(), buf,
                                   eProtocolControl))
-            llarp::LogInfo(Name(), " send message to ", introset.A.Addr(),
-                           " for tag ", tag.ToString());
+            LogInfo(Name(), " send message to ", introset.A.Addr(), " for tag ",
+                    tag.ToString());
           else
 
-            llarp::LogWarn(Name(), " failed to send/queue data to ",
-                           introset.A.Addr(), " for tag ", tag.ToString());
+            LogWarn(Name(), " failed to send/queue data to ", introset.A.Addr(),
+                    " for tag ", tag.ToString());
         }
         itr->second.Expire(now);
         if(itr->second.ShouldRefresh(now))
@@ -303,11 +303,11 @@ namespace llarp
           {
             auto job = new TagLookupJob(this, &itr->second);
             if(!job->SendRequestViaPath(path, Router()))
-              llarp::LogError(Name(), " failed to send tag lookup");
+              LogError(Name(), " failed to send tag lookup");
           }
           else
           {
-            llarp::LogError(Name(), " has no paths for tag lookup");
+            LogError(Name(), " has no paths for tag lookup");
           }
         }
       }
@@ -356,7 +356,7 @@ namespace llarp
     Endpoint::OutboundContext::Stop()
     {
       markedBad = true;
-      return llarp::path::Builder::Stop();
+      return path::Builder::Stop();
     }
 
     bool
@@ -372,7 +372,7 @@ namespace llarp
       {
         item.second->Stop();
       }
-      return llarp::path::Builder::Stop();
+      return path::Builder::Stop();
     }
 
     bool
@@ -385,7 +385,7 @@ namespace llarp
     uint64_t
     Endpoint::GenTXID()
     {
-      uint64_t txid = llarp::randint();
+      uint64_t txid = randint();
       while(m_PendingLookups.find(txid) != m_PendingLookups.end())
         ++txid;
       return txid;
@@ -421,7 +421,7 @@ namespace llarp
     }
 
     bool
-    Endpoint::HandleGotIntroMessage(const llarp::dht::GotIntroMessage* msg)
+    Endpoint::HandleGotIntroMessage(const dht::GotIntroMessage* msg)
     {
       auto crypto = m_Router->crypto();
       std::set< IntroSet > remote;
@@ -435,7 +435,7 @@ namespace llarp
         }
         if(m_Identity.pub == introset.A && m_CurrentPublishTX == msg->T)
         {
-          llarp::LogInfo(
+          LogInfo(
               "got introset publish confirmation for hidden service endpoint ",
               Name());
           IntroSetPublished();
@@ -449,8 +449,8 @@ namespace llarp
       auto itr = m_PendingLookups.find(msg->T);
       if(itr == m_PendingLookups.end())
       {
-        llarp::LogWarn("invalid lookup response for hidden service endpoint ",
-                       Name(), " txid=", msg->T);
+        LogWarn("invalid lookup response for hidden service endpoint ", Name(),
+                " txid=", msg->T);
         return true;
       }
       std::unique_ptr< IServiceLookup > lookup = std::move(itr->second);
@@ -573,7 +573,7 @@ namespace llarp
       {
         if(!m_Identity.EnsureKeys(m_Keyfile, crypto))
         {
-          llarp::LogWarn("Can't ensure keyfile [", m_Keyfile, "]");
+          LogWarn("Can't ensure keyfile [", m_Keyfile, "]");
           return false;
         }
       }
@@ -600,7 +600,7 @@ namespace llarp
           m_OnInit.pop_front();
         else
         {
-          llarp::LogWarn("Can't call init of network isolation");
+          LogWarn("Can't call init of network isolation");
           return false;
         }
       }
@@ -620,10 +620,10 @@ namespace llarp
       for(const auto& introset : introsets)
         if(result.insert(introset).second)
           lastModified = now;
-      llarp::LogInfo("Tag result for ", tag.ToString(), " got ",
-                     introsets.size(), " results from lookup, have ",
-                     result.size(), " cached last modified at ", lastModified,
-                     " is ", now - lastModified, "ms old");
+      LogInfo("Tag result for ", tag.ToString(), " got ", introsets.size(),
+              " results from lookup, have ", result.size(),
+              " cached last modified at ", lastModified, " is ",
+              now - lastModified, "ms old");
       return true;
     }
 
@@ -635,7 +635,7 @@ namespace llarp
       {
         if(itr->HasExpiredIntros(now))
         {
-          llarp::LogInfo("Removing expired tag Entry ", itr->A.Name());
+          LogInfo("Removing expired tag Entry ", itr->A.Name());
           itr          = result.erase(itr);
           lastModified = now;
         }
@@ -646,11 +646,11 @@ namespace llarp
       }
     }
 
-    llarp::routing::IMessage*
+    routing::IMessage*
     Endpoint::CachedTagResult::BuildRequestMessage(uint64_t txid)
     {
-      llarp::routing::DHTMessage* msg = new llarp::routing::DHTMessage();
-      msg->M.emplace_back(new llarp::dht::FindIntroMessage(tag, txid));
+      routing::DHTMessage* msg = new routing::DHTMessage();
+      msg->M.emplace_back(new dht::FindIntroMessage(tag, txid));
       lastRequest = parent->Now();
       return msg;
     }
@@ -676,12 +676,11 @@ namespace llarp
       {
       }
 
-      llarp::routing::IMessage*
+      routing::IMessage*
       BuildRequestMessage()
       {
-        llarp::routing::DHTMessage* msg = new llarp::routing::DHTMessage();
-        msg->M.emplace_back(
-            new llarp::dht::PublishIntroMessage(m_IntroSet, txid, 1));
+        routing::DHTMessage* msg = new routing::DHTMessage();
+        msg->M.emplace_back(new dht::PublishIntroMessage(m_IntroSet, txid, 1));
         return msg;
       }
 
@@ -705,7 +704,7 @@ namespace llarp
       {
         RegenAndPublishIntroSet(now);
       }
-      else if(NumInStatus(llarp::path::ePathEstablished) < 3)
+      else if(NumInStatus(path::ePathEstablished) < 3)
       {
         if(m_IntroSet.HasExpiredIntros(now))
           ManualRebuild(1);
@@ -727,7 +726,7 @@ namespace llarp
     bool
     Endpoint::ShouldPublishDescriptors(llarp_time_t now) const
     {
-      if(NumInStatus(llarp::path::ePathEstablished) < 3)
+      if(NumInStatus(path::ePathEstablished) < 3)
         return false;
       // make sure we have all paths that are established
       // in our introset
@@ -751,7 +750,7 @@ namespace llarp
     Endpoint::IntroSetPublished()
     {
       m_LastPublish = Now();
-      llarp::LogInfo(Name(), " IntroSet publish confirmed");
+      LogInfo(Name(), " IntroSet publish confirmed");
     }
 
     struct HiddenServiceAddressLookup : public IServiceLookup
@@ -775,7 +774,7 @@ namespace llarp
       bool
       HandleResponse(const std::set< IntroSet >& results)
       {
-        llarp::LogInfo("found ", results.size(), " for ", remote.ToString());
+        LogInfo("found ", results.size(), " for ", remote.ToString());
         if(results.size() > 0)
         {
           IntroSet selected;
@@ -789,11 +788,11 @@ namespace llarp
         return handle(remote, nullptr, endpoint);
       }
 
-      llarp::routing::IMessage*
+      routing::IMessage*
       BuildRequestMessage()
       {
-        llarp::routing::DHTMessage* msg = new llarp::routing::DHTMessage();
-        msg->M.emplace_back(new llarp::dht::FindIntroMessage(txid, remote, 0));
+        routing::DHTMessage* msg = new routing::DHTMessage();
+        msg->M.emplace_back(new dht::FindIntroMessage(txid, remote, 0));
         return msg;
       }
     };
@@ -823,7 +822,7 @@ namespace llarp
     }
 
     void
-    Endpoint::PutNewOutboundContext(const llarp::service::IntroSet& introset)
+    Endpoint::PutNewOutboundContext(const service::IntroSet& introset)
     {
       Address addr;
       introset.A.CalculateAddress(addr.as_array());
@@ -845,7 +844,7 @@ namespace llarp
 
       OutboundContext* ctx = new OutboundContext(introset, this);
       m_RemoteSessions.emplace(addr, std::unique_ptr< OutboundContext >(ctx));
-      llarp::LogInfo("Created New outbound context for ", addr.ToString());
+      LogInfo("Created New outbound context for ", addr.ToString());
 
       // inform pending
       auto range = m_PendingServiceLookups.equal_range(addr);
@@ -859,7 +858,7 @@ namespace llarp
     }
 
     bool
-    Endpoint::HandleGotRouterMessage(const llarp::dht::GotRouterMessage* msg)
+    Endpoint::HandleGotRouterMessage(const dht::GotRouterMessage* msg)
     {
       if(msg->R.size() == 1)
       {
@@ -903,12 +902,12 @@ namespace llarp
 
         if(path && path->SendRoutingMessage(&msg, m_Router))
         {
-          llarp::LogInfo(Name(), " looking up ", router);
+          LogInfo(Name(), " looking up ", router);
           m_PendingRouters.emplace(router, RouterLookupJob(this));
           return true;
         }
         else
-          llarp::LogError("failed to send request for router lookup");
+          LogError("failed to send request for router lookup");
       }
       return false;
     }
@@ -931,8 +930,8 @@ namespace llarp
     bool
     Endpoint::HandleDataDrop(path::Path* p, const PathID_t& dst, uint64_t seq)
     {
-      llarp::LogWarn(Name(), " message ", seq, " dropped by endpoint ",
-                     p->Endpoint(), " via ", dst);
+      LogWarn(Name(), " message ", seq, " dropped by endpoint ", p->Endpoint(),
+              " via ", dst);
       return true;
     }
 
@@ -943,12 +942,12 @@ namespace llarp
       // pick another intro
       if(dst == remoteIntro.pathID && remoteIntro.router == p->Endpoint())
       {
-        llarp::LogWarn(Name(), " message ", seq, " dropped by endpoint ",
-                       p->Endpoint(), " via ", dst);
+        LogWarn(Name(), " message ", seq, " dropped by endpoint ",
+                p->Endpoint(), " via ", dst);
         if(MarkCurrentIntroBad(Now()))
         {
-          llarp::LogInfo(Name(), " switched intros to ", remoteIntro.router,
-                         " via ", remoteIntro.pathID);
+          LogInfo(Name(), " switched intros to ", remoteIntro.router, " via ",
+                  remoteIntro.pathID);
         }
         UpdateIntroSet(true);
       }
@@ -968,7 +967,7 @@ namespace llarp
     }
 
     bool
-    Endpoint::HasPathToSNode(const llarp::RouterID& ident) const
+    Endpoint::HasPathToSNode(const RouterID& ident) const
     {
       auto range = m_SNodeSessions.equal_range(ident);
       auto itr   = range.first;
@@ -1147,8 +1146,8 @@ namespace llarp
       auto now = Now();
       if(introset == nullptr || introset->IsExpired(now))
       {
-        llarp::LogError(Name(), " failed to lookup ", addr.ToString(), " from ",
-                        endpoint);
+        LogError(Name(), " failed to lookup ", addr.ToString(), " from ",
+                 endpoint);
         m_ServiceLookupFails[endpoint] = m_ServiceLookupFails[endpoint] + 1;
         // inform one
         auto itr = m_PendingServiceLookups.find(addr);
@@ -1177,11 +1176,11 @@ namespace llarp
         path = GetEstablishedPathClosestTo(remote.ToRouter());
       if(!path)
       {
-        llarp::LogWarn("No outbound path for lookup yet");
+        LogWarn("No outbound path for lookup yet");
         BuildOne();
         return false;
       }
-      llarp::LogInfo(Name(), " Ensure Path to ", remote.ToString());
+      LogInfo(Name(), " Ensure Path to ", remote.ToString());
       {
         auto itr = m_RemoteSessions.find(remote);
         if(itr != m_RemoteSessions.end())
@@ -1193,8 +1192,8 @@ namespace llarp
 
       if(m_PendingServiceLookups.count(remote) >= MaxConcurrentLookups)
       {
-        llarp::LogWarn(Name(), " has too many pending service lookups for ",
-                       remote.ToString());
+        LogWarn(Name(), " has too many pending service lookups for ",
+                remote.ToString());
         return false;
       }
 
@@ -1203,13 +1202,13 @@ namespace llarp
           std::bind(&Endpoint::OnLookup, this, std::placeholders::_1,
                     std::placeholders::_2, std::placeholders::_3),
           remote, GenTXID());
-      llarp::LogInfo("doing lookup for ", remote, " via ", path->Endpoint());
+      LogInfo("doing lookup for ", remote, " via ", path->Endpoint());
       if(job->SendRequestViaPath(path, Router()))
       {
         m_PendingServiceLookups.emplace(remote, hook);
         return true;
       }
-      llarp::LogError("send via path failed");
+      LogError("send via path failed");
       return false;
     }
 
@@ -1254,19 +1253,19 @@ namespace llarp
       {
         if(currentIntroSet.T >= i->T)
         {
-          llarp::LogInfo("introset is old, dropping");
+          LogInfo("introset is old, dropping");
           return true;
         }
         auto now = Now();
         if(i->IsExpired(now))
         {
-          llarp::LogError("got expired introset from lookup from ", endpoint);
+          LogError("got expired introset from lookup from ", endpoint);
           return true;
         }
         currentIntroSet = *i;
         if(!ShiftIntroduction())
         {
-          llarp::LogWarn("failed to pick new intro during introset update");
+          LogWarn("failed to pick new intro during introset update");
         }
         if(GetPathByRouter(m_NextIntro.router) == nullptr)
           BuildOneAlignedTo(m_NextIntro.router);
@@ -1316,7 +1315,7 @@ namespace llarp
     Endpoint::SendToSNodeOrQueue(const RouterID& addr,
                                  const llarp_buffer_t& buf)
     {
-      llarp::net::IPv4Packet pkt;
+      net::IPv4Packet pkt;
       if(!pkt.Load(buf))
         return false;
       auto range = m_SNodeSessions.equal_range(addr);
@@ -1325,8 +1324,7 @@ namespace llarp
       {
         if(itr->second->IsReady())
         {
-          if(itr->second->QueueUpstreamTraffic(pkt,
-                                               llarp::routing::ExitPadSize))
+          if(itr->second->QueueUpstreamTraffic(pkt, routing::ExitPadSize))
           {
             return true;
           }
@@ -1392,11 +1390,10 @@ namespace llarp
               transfer.P = remoteIntro.pathID;
               if(!f.EncryptAndSign(Router()->crypto(), m, K, m_Identity))
               {
-                llarp::LogError("failed to encrypt and sign");
+                LogError("failed to encrypt and sign");
                 return false;
               }
-              llarp::LogDebug(Name(), " send ", data.sz, " via ",
-                              remoteIntro.router);
+              LogDebug(Name(), " send ", data.sz, " via ", remoteIntro.router);
               return p->SendRoutingMessage(&transfer, Router());
             }
           }
@@ -1430,7 +1427,7 @@ namespace llarp
     bool
     Endpoint::OutboundContext::BuildOneAlignedTo(const RouterID& remote)
     {
-      llarp::LogInfo(Name(), " building path to ", remote);
+      LogInfo(Name(), " building path to ", remote);
       auto nodedb = m_Endpoint->Router()->nodedb();
       std::vector< RouterContact > hops;
       hops.resize(numHops);
@@ -1519,7 +1516,7 @@ namespace llarp
       }
       else
       {
-        llarp::LogInfo(Name(), " updating introset");
+        LogInfo(Name(), " updating introset");
         UpdateIntroSet(true);
       }
       return shiftedIntro;
@@ -1571,8 +1568,8 @@ namespace llarp
 
     struct AsyncKeyExchange
     {
-      llarp::Logic* logic;
-      llarp::Crypto* crypto;
+      Logic* logic;
+      Crypto* crypto;
       SharedSecret sharedKey;
       ServiceInfo remote;
       const Identity& m_LocalIdentity;
@@ -1585,7 +1582,7 @@ namespace llarp
       IDataHandler* handler;
       ConvoTag tag;
 
-      AsyncKeyExchange(llarp::Logic* l, llarp::Crypto* c, const ServiceInfo& r,
+      AsyncKeyExchange(Logic* l, Crypto* c, const ServiceInfo& r,
                        const Identity& localident,
                        const PQPubKey& introsetPubKey,
                        const Introduction& remote, IDataHandler* h,
@@ -1633,7 +1630,7 @@ namespace llarp
         if(!self->m_LocalIdentity.KeyExchange(dh_client, sharedSecret,
                                               self->remote, self->frame.N))
         {
-          llarp::LogError("failed to derive x25519 shared key component");
+          LogError("failed to derive x25519 shared key component");
         }
         std::array< byte_t, 64 > tmp = {{0}};
         // K
@@ -1655,7 +1652,7 @@ namespace llarp
           self->logic->queue_job({self, &Result});
         else
         {
-          llarp::LogError("failed to encrypt and sign");
+          LogError("failed to encrypt and sign");
           delete self;
         }
       }
@@ -1680,8 +1677,8 @@ namespace llarp
         if(path == nullptr)
         {
           BuildOneAlignedTo(remoteIntro.router);
-          llarp::LogWarn(Name(), " dropping intro frame, no path to ",
-                         remoteIntro.router);
+          LogWarn(Name(), " dropping intro frame, no path to ",
+                  remoteIntro.router);
           return;
         }
       }
@@ -1734,9 +1731,8 @@ namespace llarp
       }
       else
       {
-        llarp::LogWarn(
-            "Cannot update introset no path for outbound session to ",
-            currentIntroSet.A.Addr().ToString());
+        LogWarn("Cannot update introset no path for outbound session to ",
+                currentIntroSet.A.Addr().ToString());
       }
     }
 
@@ -1786,7 +1782,7 @@ namespace llarp
         {
           // we can safely set remoteIntro to the next one
           SwapIntros();
-          llarp::LogInfo(Name(), " swapped intro");
+          LogInfo(Name(), " swapped intro");
         }
       }
       // lookup router in intro if set and unknown
@@ -1836,7 +1832,7 @@ namespace llarp
     Endpoint::OutboundContext::SelectHop(llarp_nodedb* db,
                                          const RouterContact& prev,
                                          RouterContact& cur, size_t hop,
-                                         llarp::path::PathRole roles)
+                                         path::PathRole roles)
     {
       if(remoteIntro.router.IsZero())
       {
@@ -1896,19 +1892,19 @@ namespace llarp
                  && (dlt > buildIntervalLimit));
     }
 
-    llarp::Logic*
+    Logic*
     Endpoint::RouterLogic()
     {
       return m_Router->logic();
     }
 
-    llarp::Logic*
+    Logic*
     Endpoint::EndpointLogic()
     {
       return m_IsolatedLogic ? m_IsolatedLogic : m_Router->logic();
     }
 
-    llarp::Crypto*
+    Crypto*
     Endpoint::Crypto()
     {
       return m_Router->crypto();

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -600,50 +600,6 @@ namespace llarp
     }
 
     bool
-    Endpoint::CachedTagResult::HandleResponse(
-        const std::set< IntroSet >& introsets)
-    {
-      auto now = parent->Now();
-
-      for(const auto& introset : introsets)
-        if(result.insert(introset).second)
-          lastModified = now;
-      LogInfo("Tag result for ", tag.ToString(), " got ", introsets.size(),
-              " results from lookup, have ", result.size(),
-              " cached last modified at ", lastModified, " is ",
-              now - lastModified, "ms old");
-      return true;
-    }
-
-    void
-    Endpoint::CachedTagResult::Expire(llarp_time_t now)
-    {
-      auto itr = result.begin();
-      while(itr != result.end())
-      {
-        if(itr->HasExpiredIntros(now))
-        {
-          LogInfo("Removing expired tag Entry ", itr->A.Name());
-          itr          = result.erase(itr);
-          lastModified = now;
-        }
-        else
-        {
-          ++itr;
-        }
-      }
-    }
-
-    routing::IMessage*
-    Endpoint::CachedTagResult::BuildRequestMessage(uint64_t txid)
-    {
-      routing::DHTMessage* msg = new routing::DHTMessage();
-      msg->M.emplace_back(new dht::FindIntroMessage(tag, txid));
-      lastRequest = parent->Now();
-      return msg;
-    }
-
-    bool
     Endpoint::PublishIntroSet(AbstractRouter* r)
     {
       // publish via near router

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -22,10 +22,9 @@ namespace llarp
 {
   namespace service
   {
-    // forward declare
-    struct Context;
-    // forward declare
     struct AsyncKeyExchange;
+    struct Context;
+    struct OutboundContext;
 
     struct Endpoint : public path::Builder,
                       public ILookupHolder,
@@ -210,107 +209,6 @@ namespace llarp
       bool
       ShouldBuildMore(llarp_time_t now) const override;
 
-      /// context needed to initiate an outbound hidden service session
-      struct OutboundContext : public path::Builder, public SendContext
-      {
-        OutboundContext(const IntroSet& introSet, Endpoint* parent);
-        ~OutboundContext();
-
-        util::StatusObject
-        ExtractStatus() const;
-
-        bool
-        ShouldBundleRC() const override
-        {
-          return m_Endpoint->ShouldBundleRC();
-        }
-
-        bool
-        Stop() override;
-
-        bool
-        HandleDataDrop(path::Path* p, const PathID_t& dst, uint64_t s);
-
-        void
-        HandlePathDied(path::Path* p) override;
-
-        /// set to true if we are updating the remote introset right now
-        bool updatingIntroSet;
-
-        /// update the current selected intro to be a new best introduction
-        /// return true if we have changed intros
-        bool
-        ShiftIntroduction(bool rebuild = true) override;
-
-        /// mark the current remote intro as bad
-        bool
-        MarkCurrentIntroBad(llarp_time_t now) override;
-
-        /// return true if we are ready to send
-        bool
-        ReadyToSend() const;
-
-        bool
-        ShouldBuildMore(llarp_time_t now) const override;
-
-        /// tick internal state
-        /// return true to mark as dead
-        bool
-        Tick(llarp_time_t now);
-
-        /// return true if it's safe to remove ourselves
-        bool
-        IsDone(llarp_time_t now) const;
-
-        bool
-        CheckPathIsDead(path::Path* p, llarp_time_t dlt);
-
-        void
-        AsyncGenIntro(const llarp_buffer_t& payload, ProtocolType t) override;
-
-        /// issues a lookup to find the current intro set of the remote service
-        void
-        UpdateIntroSet(bool randomizePath) override;
-
-        bool
-        BuildOneAlignedTo(const RouterID& remote);
-
-        void
-        HandlePathBuilt(path::Path* path) override;
-
-        bool
-        SelectHop(llarp_nodedb* db, const RouterContact& prev,
-                  RouterContact& cur, size_t hop,
-                  llarp::path::PathRole roles) override;
-
-        bool
-        HandleHiddenServiceFrame(path::Path* p, const ProtocolFrame* frame);
-
-        std::string
-        Name() const override;
-
-       private:
-        /// swap remoteIntro with next intro
-        void
-        SwapIntros();
-
-        void
-        OnGeneratedIntroFrame(AsyncKeyExchange* k, PathID_t p);
-
-        bool
-        OnIntroSetUpdate(const Address& addr, const IntroSet* i,
-                         const RouterID& endpoint);
-
-        uint64_t m_UpdateIntrosetTX = 0;
-        IntroSet currentIntroSet;
-        Introduction m_NextIntro;
-        std::unordered_map< Introduction, llarp_time_t, Introduction::Hash >
-            m_BadIntros;
-        llarp_time_t lastShift = 0;
-        uint16_t m_LookupFails = 0;
-        uint16_t m_BuildFails  = 0;
-      };
-
       // passed a sendto context when we have a path established otherwise
       // nullptr if the path was not made before the timeout
       using PathEnsureHook = std::function< void(Address, OutboundContext*) >;
@@ -376,6 +274,9 @@ namespace llarp
       virtual void
       IntroSetPublished();
 
+      uint64_t
+      GenTXID();
+
      protected:
       /// parent context that owns this endpoint
       Context* const context;
@@ -422,9 +323,6 @@ namespace llarp
         // XXX: override me
         return false;
       }
-
-      uint64_t
-      GenTXID();
 
      protected:
       IDataHandler* m_DataHandler = nullptr;

--- a/llarp/service/hidden_service_address_lookup.cpp
+++ b/llarp/service/hidden_service_address_lookup.cpp
@@ -1,0 +1,45 @@
+#include <service/hidden_service_address_lookup.hpp>
+
+#include <dht/messages/findintro.hpp>
+#include <service/endpoint.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    HiddenServiceAddressLookup::HiddenServiceAddressLookup(Endpoint* p,
+                                                           HandlerFunc h,
+                                                           const Address& addr,
+                                                           uint64_t tx)
+        : IServiceLookup(p, tx, "HSLookup"), remote(addr), handle(h)
+    {
+    }
+
+    bool
+    HiddenServiceAddressLookup::HandleResponse(
+        const std::set< IntroSet >& results)
+    {
+      LogInfo("found ", results.size(), " for ", remote.ToString());
+      if(results.size() > 0)
+      {
+        IntroSet selected;
+        for(const auto& introset : results)
+        {
+          if(selected.OtherIsNewer(introset) && introset.A.Addr() == remote)
+            selected = introset;
+        }
+        return handle(remote, &selected, endpoint);
+      }
+      return handle(remote, nullptr, endpoint);
+    }
+
+    routing::IMessage*
+    HiddenServiceAddressLookup::BuildRequestMessage()
+    {
+      routing::DHTMessage* msg = new routing::DHTMessage();
+      msg->M.emplace_back(new dht::FindIntroMessage(txid, remote, 0));
+      return msg;
+    }
+
+  }  // namespace service
+}  // namespace llarp

--- a/llarp/service/hidden_service_address_lookup.hpp
+++ b/llarp/service/hidden_service_address_lookup.hpp
@@ -1,0 +1,36 @@
+#ifndef LLARP_SERVICE_HIDDEN_SERVICE_ADDRESS_LOOKUP_HPP
+#define LLARP_SERVICE_HIDDEN_SERVICE_ADDRESS_LOOKUP_HPP
+
+#include <messages/dht.hpp>
+#include <service/IntroSet.hpp>
+#include <service/lookup.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    struct Endpoint;
+    struct HiddenServiceAddressLookup : public IServiceLookup
+    {
+      Address remote;
+      using HandlerFunc = std::function< bool(const Address&, const IntroSet*,
+                                              const RouterID&) >;
+      HandlerFunc handle;
+
+      HiddenServiceAddressLookup(Endpoint* p, HandlerFunc h,
+                                 const Address& addr, uint64_t tx);
+
+      ~HiddenServiceAddressLookup()
+      {
+      }
+
+      bool
+      HandleResponse(const std::set< IntroSet >& results);
+
+      routing::IMessage*
+      BuildRequestMessage();
+    };
+  }  // namespace service
+}  // namespace llarp
+
+#endif

--- a/llarp/service/lookup.cpp
+++ b/llarp/service/lookup.cpp
@@ -1,7 +1,6 @@
 #include <service/lookup.hpp>
 
 #include <path/path.hpp>
-#include <service/endpoint.hpp>
 #include <util/time.hpp>
 
 namespace llarp

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -1,0 +1,545 @@
+#include <service/outbound_context.hpp>
+
+#include <router/abstractrouter.hpp>
+#include <service/async_key_exchange.hpp>
+#include <service/hidden_service_address_lookup.hpp>
+#include <service/endpoint.hpp>
+#include <nodedb.hpp>
+#include <profiling.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    bool
+    OutboundContext::Stop()
+    {
+      markedBad = true;
+      return path::Builder::Stop();
+    }
+
+    bool
+    OutboundContext::IsDone(llarp_time_t now) const
+    {
+      (void)now;
+      return AvailablePaths(path::ePathRoleAny) == 0 && ShouldRemove();
+    }
+
+    bool
+    OutboundContext::ShouldBundleRC() const
+    {
+      return m_Endpoint->ShouldBundleRC();
+    }
+
+    bool
+    OutboundContext::HandleDataDrop(path::Path* p, const PathID_t& dst,
+                                    uint64_t seq)
+    {
+      // pick another intro
+      if(dst == remoteIntro.pathID && remoteIntro.router == p->Endpoint())
+      {
+        LogWarn(Name(), " message ", seq, " dropped by endpoint ",
+                p->Endpoint(), " via ", dst);
+        if(MarkCurrentIntroBad(Now()))
+        {
+          LogInfo(Name(), " switched intros to ", remoteIntro.router, " via ",
+                  remoteIntro.pathID);
+        }
+        UpdateIntroSet(true);
+      }
+      return true;
+    }
+
+    OutboundContext::OutboundContext(const IntroSet& introset, Endpoint* parent)
+        : path::Builder(parent->Router(), parent->Router()->dht(), 3,
+                        path::default_len)
+        , SendContext(introset.A, {}, this, parent)
+        , currentIntroSet(introset)
+
+    {
+      updatingIntroSet = false;
+      for(const auto intro : introset.I)
+      {
+        if(intro.expiresAt > m_NextIntro.expiresAt)
+          m_NextIntro = intro;
+      }
+    }
+
+    OutboundContext::~OutboundContext()
+    {
+    }
+
+    /// actually swap intros
+    void
+    OutboundContext::SwapIntros()
+    {
+      remoteIntro = m_NextIntro;
+      m_DataHandler->PutIntroFor(currentConvoTag, remoteIntro);
+    }
+
+    bool
+    OutboundContext::OnIntroSetUpdate(__attribute__((unused))
+                                      const Address& addr,
+                                      const IntroSet* i,
+                                      const RouterID& endpoint)
+    {
+      if(markedBad)
+        return true;
+      updatingIntroSet = false;
+      if(i)
+      {
+        if(currentIntroSet.T >= i->T)
+        {
+          LogInfo("introset is old, dropping");
+          return true;
+        }
+        auto now = Now();
+        if(i->IsExpired(now))
+        {
+          LogError("got expired introset from lookup from ", endpoint);
+          return true;
+        }
+        currentIntroSet = *i;
+        if(!ShiftIntroduction())
+        {
+          LogWarn("failed to pick new intro during introset update");
+        }
+        if(GetPathByRouter(m_NextIntro.router) == nullptr)
+          BuildOneAlignedTo(m_NextIntro.router);
+        else
+          SwapIntros();
+      }
+      else
+        ++m_LookupFails;
+      return true;
+    }
+
+    bool
+    OutboundContext::ReadyToSend() const
+    {
+      return (!remoteIntro.router.IsZero())
+          && GetPathByRouter(remoteIntro.router) != nullptr;
+    }
+
+    void
+    OutboundContext::HandlePathBuilt(path::Path* p)
+    {
+      path::Builder::HandlePathBuilt(p);
+      /// don't use it if we are marked bad
+      if(markedBad)
+        return;
+      p->SetDataHandler(std::bind(&OutboundContext::HandleHiddenServiceFrame,
+                                  this, std::placeholders::_1,
+                                  std::placeholders::_2));
+      p->SetDropHandler(std::bind(&OutboundContext::HandleDataDrop, this,
+                                  std::placeholders::_1, std::placeholders::_2,
+                                  std::placeholders::_3));
+    }
+
+    bool
+    OutboundContext::BuildOneAlignedTo(const RouterID& remote)
+    {
+      LogInfo(Name(), " building path to ", remote);
+      auto nodedb = m_Endpoint->Router()->nodedb();
+      std::vector< RouterContact > hops;
+      hops.resize(numHops);
+      for(size_t hop = 0; hop < numHops; ++hop)
+      {
+        if(hop == 0)
+        {
+          if(!SelectHop(nodedb, hops[0], hops[0], 0, path::ePathRoleAny))
+            return false;
+        }
+        else if(hop == numHops - 1)
+        {
+          // last hop
+          if(!nodedb->Get(remote, hops[hop]))
+            return false;
+        }
+        // middle hop
+        else
+        {
+          size_t tries = 5;
+          do
+          {
+            nodedb->select_random_hop_excluding(hops[hop],
+                                                {hops[hop - 1].pubkey, remote});
+            --tries;
+          } while(m_Endpoint->Router()->routerProfiling().IsBadForPath(
+                      hops[hop].pubkey)
+                  && tries > 0);
+          return tries > 0;
+        }
+        return false;
+      }
+      Build(hops);
+      return true;
+    }
+
+    void
+    OutboundContext::AsyncGenIntro(const llarp_buffer_t& payload,
+                                   __attribute__((unused)) ProtocolType t)
+    {
+      auto path = m_PathSet->GetPathByRouter(remoteIntro.router);
+      if(path == nullptr)
+      {
+        // try parent as fallback
+        path = m_Endpoint->GetPathByRouter(remoteIntro.router);
+        if(path == nullptr)
+        {
+          BuildOneAlignedTo(remoteIntro.router);
+          LogWarn(Name(), " dropping intro frame, no path to ",
+                  remoteIntro.router);
+          return;
+        }
+      }
+      currentConvoTag.Randomize();
+      AsyncKeyExchange* ex = new AsyncKeyExchange(
+          m_Endpoint->RouterLogic(), m_Endpoint->Crypto(), remoteIdent,
+          m_Endpoint->GetIdentity(), currentIntroSet.K, remoteIntro,
+          m_DataHandler, currentConvoTag);
+
+      ex->hook = std::bind(&OutboundContext::Send, this, std::placeholders::_1);
+
+      ex->msg.PutBuffer(payload);
+      ex->msg.introReply = path->intro;
+      ex->frame.F        = ex->msg.introReply.pathID;
+      llarp_threadpool_queue_job(m_Endpoint->Worker(),
+                                 {ex, &AsyncKeyExchange::Encrypt});
+    }
+
+    std::string
+    OutboundContext::Name() const
+    {
+      return "OBContext:" + m_Endpoint->Name() + "-"
+          + currentIntroSet.A.Addr().ToString();
+    }
+
+    void
+    OutboundContext::UpdateIntroSet(bool randomizePath)
+    {
+      if(updatingIntroSet || markedBad)
+        return;
+      auto addr = currentIntroSet.A.Addr();
+
+      path::Path* path = nullptr;
+      if(randomizePath)
+        path = m_Endpoint->PickRandomEstablishedPath();
+      else
+        path = m_Endpoint->GetEstablishedPathClosestTo(addr.as_array());
+
+      if(path)
+      {
+        HiddenServiceAddressLookup* job = new HiddenServiceAddressLookup(
+            m_Endpoint,
+            std::bind(&OutboundContext::OnIntroSetUpdate, this,
+                      std::placeholders::_1, std::placeholders::_2,
+                      std::placeholders::_3),
+            addr, m_Endpoint->GenTXID());
+
+        updatingIntroSet = job->SendRequestViaPath(path, m_Endpoint->Router());
+      }
+      else
+      {
+        LogWarn("Cannot update introset no path for outbound session to ",
+                currentIntroSet.A.Addr().ToString());
+      }
+    }
+
+    util::StatusObject
+    OutboundContext::ExtractStatus() const
+    {
+      auto obj = path::Builder::ExtractStatus();
+      obj.Put("currentConvoTag", currentConvoTag.ToHex());
+      obj.Put("remoteIntro", remoteIntro.ExtractStatus());
+      obj.Put("sessionCreatedAt", createdAt);
+      obj.Put("lastGoodSend", lastGoodSend);
+      obj.Put("seqno", sequenceNo);
+      obj.Put("markedBad", markedBad);
+      obj.Put("lastShift", lastShift);
+      obj.Put("remoteIdentity", remoteIdent.Addr().ToString());
+      obj.Put("currentRemoteIntroset", currentIntroSet.ExtractStatus());
+      obj.Put("nextIntro", m_NextIntro.ExtractStatus());
+      std::vector< util::StatusObject > badIntrosObj;
+      std::transform(m_BadIntros.begin(), m_BadIntros.end(),
+                     std::back_inserter(badIntrosObj),
+                     [](const auto& item) -> util::StatusObject {
+                       util::StatusObject o{
+                           {"count", item.second},
+                           {"intro", item.first.ExtractStatus()}};
+                       return o;
+                     });
+      obj.Put("badIntros", badIntrosObj);
+      return obj;
+    }
+
+    bool
+    OutboundContext::Tick(llarp_time_t now)
+    {
+      // we are probably dead af
+      if(m_LookupFails > 16 || m_BuildFails > 10)
+        return true;
+      // check for expiration
+      if(remoteIntro.ExpiresSoon(now))
+      {
+        // shift intro if it expires "soon"
+        ShiftIntroduction();
+      }
+      // swap if we can
+      if(remoteIntro != m_NextIntro)
+      {
+        if(GetPathByRouter(m_NextIntro.router) != nullptr)
+        {
+          // we can safely set remoteIntro to the next one
+          SwapIntros();
+          LogInfo(Name(), " swapped intro");
+        }
+      }
+      // lookup router in intro if set and unknown
+      if(!remoteIntro.router.IsZero())
+        m_Endpoint->EnsureRouterIsKnown(remoteIntro.router);
+      // expire bad intros
+      auto itr = m_BadIntros.begin();
+      while(itr != m_BadIntros.end())
+      {
+        if(now - itr->second > path::default_lifetime)
+          itr = m_BadIntros.erase(itr);
+        else
+          ++itr;
+      }
+      // send control message if we look too quiet
+      if(lastGoodSend)
+      {
+        if(now - lastGoodSend > (sendTimeout / 2))
+        {
+          if(!GetNewestPathByRouter(remoteIntro.router))
+          {
+            BuildOneAlignedTo(remoteIntro.router);
+          }
+          Encrypted< 64 > tmp;
+          tmp.Randomize();
+          llarp_buffer_t buf(tmp.data(), tmp.size());
+          AsyncEncryptAndSendTo(buf, eProtocolControl);
+          SharedSecret k;
+          if(currentConvoTag.IsZero())
+            return false;
+          return !m_DataHandler->HasConvoTag(currentConvoTag);
+        }
+      }
+      // if we are dead return true so we are removed
+      return lastGoodSend
+          ? (now >= lastGoodSend && now - lastGoodSend > sendTimeout)
+          : (now >= createdAt && now - createdAt > connectTimeout);
+    }
+
+    bool
+    OutboundContext::SelectHop(llarp_nodedb* db, const RouterContact& prev,
+                               RouterContact& cur, size_t hop,
+                               path::PathRole roles)
+    {
+      if(remoteIntro.router.IsZero())
+      {
+        SwapIntros();
+      }
+      if(hop == numHops - 1)
+      {
+        m_Endpoint->EnsureRouterIsKnown(remoteIntro.router);
+        if(db->Get(remoteIntro.router, cur))
+          return true;
+        ++m_BuildFails;
+        return false;
+      }
+      else if(hop == numHops - 2)
+      {
+        return db->select_random_hop_excluding(
+            cur, {prev.pubkey, remoteIntro.router});
+      }
+      return path::Builder::SelectHop(db, prev, cur, hop, roles);
+    }
+
+    bool
+    OutboundContext::ShouldBuildMore(llarp_time_t now) const
+    {
+      if(markedBad)
+        return false;
+      if(path::Builder::ShouldBuildMore(now))
+        return true;
+      return !ReadyToSend();
+    }
+
+    bool
+    OutboundContext::MarkCurrentIntroBad(llarp_time_t now)
+    {
+      // insert bad intro
+      m_BadIntros[remoteIntro] = now;
+      // unconditional shift
+      bool shiftedRouter = false;
+      bool shiftedIntro  = false;
+      // try same router
+      for(const auto& intro : currentIntroSet.I)
+      {
+        if(intro.ExpiresSoon(now))
+          continue;
+        if(router->routerProfiling().IsBadForPath(intro.router))
+          continue;
+        auto itr = m_BadIntros.find(intro);
+        if(itr == m_BadIntros.end() && intro.router == m_NextIntro.router)
+        {
+          shiftedIntro = true;
+          m_NextIntro  = intro;
+          break;
+        }
+      }
+      if(!shiftedIntro)
+      {
+        // try any router
+        for(const auto& intro : currentIntroSet.I)
+        {
+          if(intro.ExpiresSoon(now))
+            continue;
+          auto itr = m_BadIntros.find(intro);
+          if(itr == m_BadIntros.end())
+          {
+            // TODO: this should always be true but idk if it really is
+            shiftedRouter = m_NextIntro.router != intro.router;
+            shiftedIntro  = true;
+            m_NextIntro   = intro;
+            break;
+          }
+        }
+      }
+      if(shiftedRouter)
+      {
+        lastShift = now;
+        BuildOneAlignedTo(m_NextIntro.router);
+      }
+      else if(shiftedIntro)
+      {
+        SwapIntros();
+      }
+      else
+      {
+        LogInfo(Name(), " updating introset");
+        UpdateIntroSet(true);
+      }
+      return shiftedIntro;
+    }
+
+    bool
+    OutboundContext::ShiftIntroduction(bool rebuild)
+    {
+      bool success = false;
+      auto now     = Now();
+      if(now - lastShift < MIN_SHIFT_INTERVAL)
+        return false;
+      bool shifted = false;
+      // to find a intro on the same router as before
+      for(const auto& intro : currentIntroSet.I)
+      {
+        if(intro.ExpiresSoon(now))
+          continue;
+        if(m_BadIntros.find(intro) == m_BadIntros.end()
+           && remoteIntro.router == intro.router)
+        {
+          m_NextIntro = intro;
+          return true;
+        }
+      }
+      for(const auto& intro : currentIntroSet.I)
+      {
+        m_Endpoint->EnsureRouterIsKnown(intro.router);
+        if(intro.ExpiresSoon(now))
+          continue;
+        if(m_BadIntros.find(intro) == m_BadIntros.end() && m_NextIntro != intro)
+        {
+          shifted = intro.router != m_NextIntro.router
+              || (now < intro.expiresAt
+                  && intro.expiresAt - now
+                      > 10 * 1000);  // TODO: hardcoded value
+          m_NextIntro = intro;
+          success     = true;
+          break;
+        }
+      }
+      if(shifted && rebuild)
+      {
+        lastShift = now;
+        BuildOneAlignedTo(m_NextIntro.router);
+      }
+      return success;
+    }
+
+    void
+    OutboundContext::HandlePathDied(path::Path* path)
+    {
+      // unconditionally update introset
+      UpdateIntroSet(true);
+      const RouterID endpoint(path->Endpoint());
+      // if a path to our current intro died...
+      if(endpoint == remoteIntro.router)
+      {
+        // figure out how many paths to this router we have
+        size_t num = 0;
+        ForEachPath([&](path::Path* p) {
+          if(p->Endpoint() == endpoint && p->IsReady())
+            ++num;
+        });
+        // if we have more than two then we are probably fine
+        if(num > 2)
+          return;
+        // if we have one working one ...
+        if(num == 1)
+        {
+          num = 0;
+          ForEachPath([&](path::Path* p) {
+            if(p->Endpoint() == endpoint)
+              ++num;
+          });
+          // if we have 2 or more established or pending don't do anything
+          if(num > 2)
+            return;
+          BuildOneAlignedTo(endpoint);
+        }
+        else if(num == 0)
+        {
+          // we have no paths to this router right now
+          // hop off it
+          Introduction picked;
+          // get the latest intro that isn't on that endpoint
+          for(const auto& intro : currentIntroSet.I)
+          {
+            if(intro.router == endpoint)
+              continue;
+            if(intro.expiresAt > picked.expiresAt)
+              picked = intro;
+          }
+          // we got nothing
+          if(picked.router.IsZero())
+          {
+            return;
+          }
+          m_NextIntro = picked;
+          // check if we have a path to this router
+          num = 0;
+          ForEachPath([&](path::Path* p) {
+            if(p->Endpoint() == m_NextIntro.router)
+              ++num;
+          });
+          // build a path if one isn't already pending build or established
+          if(num == 0)
+            BuildOneAlignedTo(m_NextIntro.router);
+          SwapIntros();
+        }
+      }
+    }
+
+    bool
+    OutboundContext::HandleHiddenServiceFrame(path::Path* p,
+                                              const ProtocolFrame* frame)
+    {
+      return m_Endpoint->HandleHiddenServiceFrame(p, frame);
+    }
+
+  }  // namespace service
+
+}  // namespace llarp

--- a/llarp/service/outbound_context.hpp
+++ b/llarp/service/outbound_context.hpp
@@ -1,0 +1,116 @@
+#ifndef LLARP_SERVICE_OUTBOUND_CONTEXT_HPP
+#define LLARP_SERVICE_OUTBOUND_CONTEXT_HPP
+
+#include <path/pathbuilder.hpp>
+#include <service/sendcontext.hpp>
+#include <util/status.hpp>
+
+#include <unordered_map>
+
+namespace llarp
+{
+  namespace service
+  {
+    struct AsyncKeyExchange;
+    struct Endpoint;
+
+    /// context needed to initiate an outbound hidden service session
+    struct OutboundContext : public path::Builder, public SendContext
+    {
+      OutboundContext(const IntroSet& introSet, Endpoint* parent);
+      ~OutboundContext();
+
+      util::StatusObject
+      ExtractStatus() const;
+
+      bool
+      ShouldBundleRC() const override;
+
+      bool
+      Stop() override;
+
+      bool
+      HandleDataDrop(path::Path* p, const PathID_t& dst, uint64_t s);
+
+      void
+      HandlePathDied(path::Path* p) override;
+
+      /// set to true if we are updating the remote introset right now
+      bool updatingIntroSet;
+
+      /// update the current selected intro to be a new best introduction
+      /// return true if we have changed intros
+      bool
+      ShiftIntroduction(bool rebuild = true) override;
+
+      /// mark the current remote intro as bad
+      bool
+      MarkCurrentIntroBad(llarp_time_t now) override;
+
+      /// return true if we are ready to send
+      bool
+      ReadyToSend() const;
+
+      bool
+      ShouldBuildMore(llarp_time_t now) const override;
+
+      /// tick internal state
+      /// return true to mark as dead
+      bool
+      Tick(llarp_time_t now);
+
+      /// return true if it's safe to remove ourselves
+      bool
+      IsDone(llarp_time_t now) const;
+
+      bool
+      CheckPathIsDead(path::Path* p, llarp_time_t dlt);
+
+      void
+      AsyncGenIntro(const llarp_buffer_t& payload, ProtocolType t) override;
+
+      /// issues a lookup to find the current intro set of the remote service
+      void
+      UpdateIntroSet(bool randomizePath) override;
+
+      bool
+      BuildOneAlignedTo(const RouterID& remote);
+
+      void
+      HandlePathBuilt(path::Path* path) override;
+
+      bool
+      SelectHop(llarp_nodedb* db, const RouterContact& prev, RouterContact& cur,
+                size_t hop, llarp::path::PathRole roles) override;
+
+      bool
+      HandleHiddenServiceFrame(path::Path* p, const ProtocolFrame* frame);
+
+      std::string
+      Name() const override;
+
+     private:
+      /// swap remoteIntro with next intro
+      void
+      SwapIntros();
+
+      void
+      OnGeneratedIntroFrame(AsyncKeyExchange* k, PathID_t p);
+
+      bool
+      OnIntroSetUpdate(const Address& addr, const IntroSet* i,
+                       const RouterID& endpoint);
+
+      uint64_t m_UpdateIntrosetTX = 0;
+      IntroSet currentIntroSet;
+      Introduction m_NextIntro;
+      std::unordered_map< Introduction, llarp_time_t, Introduction::Hash >
+          m_BadIntros;
+      llarp_time_t lastShift = 0;
+      uint16_t m_LookupFails = 0;
+      uint16_t m_BuildFails  = 0;
+    };
+  }  // namespace service
+
+}  // namespace llarp
+#endif

--- a/llarp/service/pendingbuffer.cpp
+++ b/llarp/service/pendingbuffer.cpp
@@ -1,0 +1,1 @@
+#include <service/pendingbuffer.hpp>

--- a/llarp/service/pendingbuffer.hpp
+++ b/llarp/service/pendingbuffer.hpp
@@ -1,0 +1,36 @@
+#ifndef LLARP_SERVICE_PENDINGBUFFER_HPP
+#define LLARP_SERVICE_PENDINGBUFFER_HPP
+
+#include <service/protocol.hpp>
+#include <util/buffer.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+namespace llarp
+{
+  namespace service
+  {
+    struct PendingBuffer
+    {
+      std::vector< byte_t > payload;
+      ProtocolType protocol;
+
+      PendingBuffer(const llarp_buffer_t& buf, ProtocolType t)
+          : payload(buf.sz), protocol(t)
+      {
+        std::copy(buf.base, buf.base + buf.sz, std::back_inserter(payload));
+      }
+
+      ManagedBuffer
+      Buffer()
+      {
+        return ManagedBuffer{llarp_buffer_t(payload)};
+      }
+    };
+  }  // namespace service
+
+}  // namespace llarp
+
+#endif

--- a/llarp/service/sendcontext.cpp
+++ b/llarp/service/sendcontext.cpp
@@ -1,0 +1,138 @@
+#include <service/sendcontext.hpp>
+
+#include <messages/path_transfer.hpp>
+#include <service/endpoint.hpp>
+#include <router/abstractrouter.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    SendContext::SendContext(const ServiceInfo& ident,
+                             const Introduction& intro, path::PathSet* send,
+                             Endpoint* ep)
+        : remoteIdent(ident)
+        , remoteIntro(intro)
+        , m_PathSet(send)
+        , m_DataHandler(ep)
+        , m_Endpoint(ep)
+    {
+      createdAt = ep->Now();
+      currentConvoTag.Zero();
+    }
+
+    bool
+    SendContext::Send(const ProtocolFrame& msg)
+    {
+      auto path = m_PathSet->GetByEndpointWithID(remoteIntro.router, msg.F);
+      if(path)
+      {
+        const routing::PathTransferMessage transfer(msg, remoteIntro.pathID);
+        if(path->SendRoutingMessage(&transfer, m_Endpoint->Router()))
+        {
+          llarp::LogInfo("sent intro to ", remoteIntro.pathID, " on ",
+                         remoteIntro.router, " seqno=", sequenceNo);
+          lastGoodSend = m_Endpoint->Now();
+          ++sequenceNo;
+          return true;
+        }
+        else
+          llarp::LogError("Failed to send frame on path");
+      }
+      else
+        llarp::LogError("cannot send because we have no path to ",
+                        remoteIntro.router);
+      return false;
+    }
+
+    /// send on an established convo tag
+    void
+    SendContext::EncryptAndSendTo(const llarp_buffer_t& payload, ProtocolType t)
+    {
+      auto crypto = m_Endpoint->Router()->crypto();
+      SharedSecret shared;
+      routing::PathTransferMessage msg;
+      ProtocolFrame& f = msg.T;
+      f.N.Randomize();
+      f.T = currentConvoTag;
+      f.S = m_Endpoint->GetSeqNoForConvo(f.T);
+
+      auto now = m_Endpoint->Now();
+      if(remoteIntro.ExpiresSoon(now))
+      {
+        // shift intro
+        if(MarkCurrentIntroBad(now))
+        {
+          llarp::LogInfo("intro shifted");
+        }
+      }
+      auto path = m_PathSet->GetNewestPathByRouter(remoteIntro.router);
+      if(!path)
+      {
+        llarp::LogError("cannot encrypt and send: no path for intro ",
+                        remoteIntro);
+        return;
+      }
+
+      if(m_DataHandler->GetCachedSessionKeyFor(f.T, shared))
+      {
+        ProtocolMessage m;
+        m_DataHandler->PutIntroFor(f.T, remoteIntro);
+        m_DataHandler->PutReplyIntroFor(f.T, path->intro);
+        m.proto      = t;
+        m.introReply = path->intro;
+        f.F          = m.introReply.pathID;
+        m.sender     = m_Endpoint->GetIdentity().pub;
+        m.tag        = f.T;
+        m.PutBuffer(payload);
+        if(!f.EncryptAndSign(crypto, m, shared, m_Endpoint->GetIdentity()))
+        {
+          llarp::LogError("failed to sign");
+          return;
+        }
+      }
+      else
+      {
+        llarp::LogError("No cached session key");
+        return;
+      }
+
+      msg.P = remoteIntro.pathID;
+      msg.Y.Randomize();
+      if(path->SendRoutingMessage(&msg, m_Endpoint->Router()))
+      {
+        llarp::LogDebug("sent message via ", remoteIntro.pathID, " on ",
+                        remoteIntro.router);
+        ++sequenceNo;
+        lastGoodSend = now;
+      }
+      else
+      {
+        llarp::LogWarn("Failed to send routing message for data");
+      }
+    }
+
+    void
+    SendContext::AsyncEncryptAndSendTo(const llarp_buffer_t& data,
+                                       ProtocolType protocol)
+    {
+      auto now = m_Endpoint->Now();
+      if(remoteIntro.ExpiresSoon(now))
+      {
+        if(!MarkCurrentIntroBad(now))
+        {
+          llarp::LogWarn("no good path yet, your message may drop");
+        }
+      }
+      if(sequenceNo)
+      {
+        EncryptAndSendTo(data, protocol);
+      }
+      else
+      {
+        AsyncGenIntro(data, protocol);
+      }
+    }
+  }  // namespace service
+
+}  // namespace llarp

--- a/llarp/service/sendcontext.hpp
+++ b/llarp/service/sendcontext.hpp
@@ -1,0 +1,68 @@
+#ifndef LLARP_SERVICE_SENDCONTEXT_HPP
+#define LLARP_SERVICE_SENDCONTEXT_HPP
+
+#include <path/pathset.hpp>
+#include <service/Intro.hpp>
+#include <service/protocol.hpp>
+#include <util/buffer.hpp>
+#include <util/types.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    struct ServiceInfo;
+    struct Endpoint;
+    struct Introduction;
+
+    struct SendContext
+    {
+      SendContext(const ServiceInfo& ident, const Introduction& intro,
+                  path::PathSet* send, Endpoint* ep);
+
+      void
+      AsyncEncryptAndSendTo(const llarp_buffer_t& payload, ProtocolType t);
+
+      /// send a fully encrypted hidden service frame
+      /// via a path on our pathset with path id p
+      bool
+      Send(const ProtocolFrame& f);
+
+      SharedSecret sharedKey;
+      ServiceInfo remoteIdent;
+      Introduction remoteIntro;
+      ConvoTag currentConvoTag;
+      path::PathSet* m_PathSet;
+      IDataHandler* m_DataHandler;
+      Endpoint* m_Endpoint;
+      uint64_t sequenceNo       = 0;
+      llarp_time_t lastGoodSend = 0;
+      llarp_time_t createdAt;
+      llarp_time_t sendTimeout    = 40 * 1000;
+      llarp_time_t connectTimeout = 60 * 1000;
+      bool markedBad              = false;
+
+      virtual bool
+      ShiftIntroduction(bool rebuild = true)
+      {
+        (void)rebuild;
+        return true;
+      };
+
+      virtual void
+      UpdateIntroSet(bool randomizePath = false) = 0;
+
+      virtual bool
+      MarkCurrentIntroBad(llarp_time_t now) = 0;
+
+     private:
+      void
+      EncryptAndSendTo(const llarp_buffer_t& payload, ProtocolType t);
+
+      virtual void
+      AsyncGenIntro(const llarp_buffer_t& payload, ProtocolType t) = 0;
+    };
+  }  // namespace service
+}  // namespace llarp
+
+#endif

--- a/llarp/service/session.cpp
+++ b/llarp/service/session.cpp
@@ -1,0 +1,18 @@
+#include <service/session.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    util::StatusObject
+    Session::ExtractStatus() const
+    {
+      util::StatusObject obj{{"lastUsed", lastUsed},
+                             {"replyIntro", replyIntro.ExtractStatus()},
+                             {"remote", remote.Addr().ToString()},
+                             {"seqno", seqno},
+                             {"intro", intro.ExtractStatus()}};
+      return obj;
+    };
+  }  // namespace service
+}  // namespace llarp

--- a/llarp/service/session.hpp
+++ b/llarp/service/session.hpp
@@ -1,0 +1,41 @@
+#ifndef LLARP_SERVICE_SESSION_HPP
+#define LLARP_SERVICE_SESSION_HPP
+
+#include <crypto/types.hpp>
+#include <path/path.hpp>
+#include <service/Info.hpp>
+#include <service/Intro.hpp>
+#include <util/status.hpp>
+#include <util/types.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    struct Session
+    {
+      Introduction replyIntro;
+      SharedSecret sharedKey;
+      ServiceInfo remote;
+      Introduction intro;
+      llarp_time_t lastUsed = 0;
+      uint64_t seqno        = 0;
+
+      util::StatusObject
+      ExtractStatus() const;
+
+      bool
+      IsExpired(llarp_time_t now,
+                llarp_time_t lifetime = (path::default_lifetime * 2)) const
+      {
+        if(now <= lastUsed)
+          return false;
+        return now - lastUsed > lifetime;
+      }
+    };
+
+  }  // namespace service
+
+}  // namespace llarp
+
+#endif

--- a/llarp/service/tag_lookup_job.cpp
+++ b/llarp/service/tag_lookup_job.cpp
@@ -1,0 +1,61 @@
+#include <service/tag_lookup_job.hpp>
+
+#include <dht/messages/findintro.hpp>
+#include <messages/dht.hpp>
+#include <service/endpoint.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    bool
+    CachedTagResult::HandleResponse(const std::set< IntroSet >& introsets)
+    {
+      auto now = parent->Now();
+
+      for(const auto& introset : introsets)
+        if(result.insert(introset).second)
+          lastModified = now;
+      LogInfo("Tag result for ", tag.ToString(), " got ", introsets.size(),
+              " results from lookup, have ", result.size(),
+              " cached last modified at ", lastModified, " is ",
+              now - lastModified, "ms old");
+      return true;
+    }
+
+    void
+    CachedTagResult::Expire(llarp_time_t now)
+    {
+      auto itr = result.begin();
+      while(itr != result.end())
+      {
+        if(itr->HasExpiredIntros(now))
+        {
+          LogInfo("Removing expired tag Entry ", itr->A.Name());
+          itr          = result.erase(itr);
+          lastModified = now;
+        }
+        else
+        {
+          ++itr;
+        }
+      }
+    }
+
+    routing::IMessage*
+    CachedTagResult::BuildRequestMessage(uint64_t txid)
+    {
+      routing::DHTMessage* msg = new routing::DHTMessage();
+      msg->M.emplace_back(new dht::FindIntroMessage(tag, txid));
+      lastRequest = parent->Now();
+      return msg;
+    }
+
+    TagLookupJob::TagLookupJob(Endpoint* parent, CachedTagResult* result)
+        : IServiceLookup(parent, parent->GenTXID(), "taglookup")
+        , m_result(result)
+    {
+    }
+  }  // namespace service
+
+}  // namespace llarp

--- a/llarp/service/tag_lookup_job.hpp
+++ b/llarp/service/tag_lookup_job.hpp
@@ -1,0 +1,79 @@
+#ifndef LLARP_SERVICE_TAG_LOOKUP_JOB_HPP
+#define LLARP_SERVICE_TAG_LOOKUP_JOB_HPP
+
+#include <routing/message.hpp>
+#include <service/IntroSet.hpp>
+#include <service/lookup.hpp>
+#include <service/tag.hpp>
+#include <util/types.hpp>
+
+#include <set>
+
+namespace llarp
+{
+  namespace service
+  {
+    struct Endpoint;
+
+    struct CachedTagResult
+    {
+      const static llarp_time_t TTL = 10000;
+      llarp_time_t lastRequest      = 0;
+      llarp_time_t lastModified     = 0;
+      std::set< IntroSet > result;
+      Tag tag;
+      Endpoint* parent;
+
+      CachedTagResult(const Tag& t, Endpoint* p) : tag(t), parent(p)
+      {
+      }
+
+      ~CachedTagResult()
+      {
+      }
+
+      void
+      Expire(llarp_time_t now);
+
+      bool
+      ShouldRefresh(llarp_time_t now) const
+      {
+        if(now <= lastRequest)
+          return false;
+        return (now - lastRequest) > TTL;
+      }
+
+      llarp::routing::IMessage*
+      BuildRequestMessage(uint64_t txid);
+
+      bool
+      HandleResponse(const std::set< IntroSet >& results);
+    };
+
+    struct TagLookupJob : public IServiceLookup
+    {
+      TagLookupJob(Endpoint* parent, CachedTagResult* result);
+
+      ~TagLookupJob()
+      {
+      }
+
+      llarp::routing::IMessage*
+      BuildRequestMessage() override
+      {
+        return m_result->BuildRequestMessage(txid);
+      }
+
+      bool
+      HandleResponse(const std::set< IntroSet >& results) override
+      {
+        return m_result->HandleResponse(results);
+      }
+
+      CachedTagResult* m_result;
+    };
+
+  }  // namespace service
+}  // namespace llarp
+
+#endif


### PR DESCRIPTION
This is mostly a mechanical refactoring, splitting private classes out into their own files. 

end result:

| file | lines before | lines after | %age |
| --- | ------------ | --------- | ---------------- |
| endpoint.cpp | 2050 | 1215 |  60% |
| endpoint.hpp | 680 | 422 | 62% |