### PR TITLE
Remove usage of raw new from service classes

### DIFF
--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -135,7 +135,7 @@ namespace llarp
       /// relay a dht message from a local path to the main network
       bool
       RelayRequestForPath(const llarp::PathID_t& localPath,
-                          const IMessage* msg) override;
+                          const IMessage& msg) override;
 
       /// send introset to peer from source with S counter and excluding peers
       void
@@ -540,15 +540,15 @@ namespace llarp
     }
 
     bool
-    Context::RelayRequestForPath(const llarp::PathID_t& id, const IMessage* msg)
+    Context::RelayRequestForPath(const llarp::PathID_t& id, const IMessage& msg)
     {
       llarp::routing::DHTMessage reply;
-      if(!msg->HandleMessage(router->dht(), reply.M))
+      if(!msg.HandleMessage(router->dht(), reply.M))
         return false;
       if(!reply.M.empty())
       {
         auto path = router->pathContext().GetByUpstream(router->pubkey(), id);
-        return path && path->SendRoutingMessage(&reply, router);
+        return path && path->SendRoutingMessage(reply, router);
       }
       return true;
     }

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -107,7 +107,7 @@ namespace llarp
           std::vector< std::unique_ptr< IMessage > >& replies) = 0;
 
       virtual bool
-      RelayRequestForPath(const PathID_t& localPath, const IMessage* msg) = 0;
+      RelayRequestForPath(const PathID_t& localPath, const IMessage& msg) = 0;
 
       /// send introset to peer from source with S counter and excluding peers
       virtual void

--- a/llarp/dht/localrouterlookup.cpp
+++ b/llarp/dht/localrouterlookup.cpp
@@ -47,7 +47,7 @@ namespace llarp
       routing::DHTMessage msg;
       msg.M.emplace_back(new GotRouterMessage(parent->OurKey(), whoasked.txid,
                                               valuesFound, true));
-      if(!path->SendRoutingMessage(&msg, parent->GetRouter()))
+      if(!path->SendRoutingMessage(msg, parent->GetRouter()))
       {
         llarp::LogWarn(
             "failed to send routing message when informing result of dht "

--- a/llarp/dht/localserviceaddresslookup.cpp
+++ b/llarp/dht/localserviceaddresslookup.cpp
@@ -47,7 +47,7 @@ namespace llarp
       }
       routing::DHTMessage msg;
       msg.M.emplace_back(new GotIntroMessage(valuesFound, whoasked.txid));
-      if(!path->SendRoutingMessage(&msg, parent->GetRouter()))
+      if(!path->SendRoutingMessage(msg, parent->GetRouter()))
       {
         llarp::LogWarn(
             "failed to send routing message when informing result of dht "

--- a/llarp/dht/localtaglookup.cpp
+++ b/llarp/dht/localtaglookup.cpp
@@ -33,7 +33,7 @@ namespace llarp
       }
       routing::DHTMessage msg;
       msg.M.emplace_back(new GotIntroMessage(valuesFound, whoasked.txid));
-      if(!path->SendRoutingMessage(&msg, parent->GetRouter()))
+      if(!path->SendRoutingMessage(msg, parent->GetRouter()))
       {
         llarp::LogWarn(
             "failed to send routing message when informing result of dht "

--- a/llarp/exit/close_exit.cpp
+++ b/llarp/exit/close_exit.cpp
@@ -79,7 +79,7 @@ namespace llarp
     bool
     CloseExitMessage::HandleMessage(IMessageHandler* h, AbstractRouter* r) const
     {
-      return h->HandleCloseExitMessage(this, r);
+      return h->HandleCloseExitMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/exit/endpoint.cpp
+++ b/llarp/exit/endpoint.cpp
@@ -176,7 +176,7 @@ namespace llarp
           {
             auto& msg = queue.front();
             msg.S     = path->NextSeqNo();
-            if(path->SendRoutingMessage(&msg, m_Parent->GetRouter()))
+            if(path->SendRoutingMessage(msg, m_Parent->GetRouter()))
             {
               m_RxRate += msg.Size();
               sent = true;

--- a/llarp/exit/grant_exit.cpp
+++ b/llarp/exit/grant_exit.cpp
@@ -85,7 +85,7 @@ namespace llarp
     bool
     GrantExitMessage::HandleMessage(IMessageHandler* h, AbstractRouter* r) const
     {
-      return h->HandleGrantExitMessage(this, r);
+      return h->HandleGrantExitMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/exit/obtain_exit.cpp
+++ b/llarp/exit/obtain_exit.cpp
@@ -96,7 +96,7 @@ namespace llarp
     ObtainExitMessage::HandleMessage(IMessageHandler* h,
                                      AbstractRouter* r) const
     {
-      return h->HandleObtainExitMessage(this, r);
+      return h->HandleObtainExitMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/exit/reject_exit.cpp
+++ b/llarp/exit/reject_exit.cpp
@@ -96,7 +96,7 @@ namespace llarp
     RejectExitMessage::HandleMessage(IMessageHandler* h,
                                      AbstractRouter* r) const
     {
-      return h->HandleRejectExitMessage(this, r);
+      return h->HandleRejectExitMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/exit/session.cpp
+++ b/llarp/exit/session.cpp
@@ -113,7 +113,7 @@ namespace llarp
         llarp::LogError("Failed to sign exit request");
         return;
       }
-      if(p->SendExitRequest(&obtain, router))
+      if(p->SendExitRequest(obtain, router))
         llarp::LogInfo("asking ", m_ExitRouter, " for exit");
       else
         llarp::LogError("failed to send exit request");
@@ -162,7 +162,7 @@ namespace llarp
           llarp::LogInfo(p->Name(), " closing exit path");
           llarp::routing::CloseExitMessage msg;
           if(!(msg.Sign(router->crypto(), m_ExitIdentity)
-               && p->SendExitClose(&msg, router)))
+               && p->SendExitClose(msg, router)))
             llarp::LogWarn(p->Name(), " failed to send exit close message");
         }
       };
@@ -250,7 +250,7 @@ namespace llarp
           {
             auto& msg = queue.front();
             msg.S     = path->NextSeqNo();
-            if(path->SendRoutingMessage(&msg, router))
+            if(path->SendRoutingMessage(msg, router))
               m_LastUse = now;
             queue.pop_front();
           }

--- a/llarp/exit/transfer_traffic.cpp
+++ b/llarp/exit/transfer_traffic.cpp
@@ -66,7 +66,7 @@ namespace llarp
     TransferTrafficMessage::HandleMessage(IMessageHandler* h,
                                           AbstractRouter* r) const
     {
-      return h->HandleTransferTrafficMessage(this, r);
+      return h->HandleTransferTrafficMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/exit/update_exit.cpp
+++ b/llarp/exit/update_exit.cpp
@@ -87,7 +87,7 @@ namespace llarp
     UpdateExitMessage::HandleMessage(IMessageHandler* h,
                                      AbstractRouter* r) const
     {
-      return h->HandleUpdateExitMessage(this, r);
+      return h->HandleUpdateExitMessage(*this, r);
     }
 
     bool
@@ -124,7 +124,7 @@ namespace llarp
     UpdateExitVerifyMessage::HandleMessage(IMessageHandler* h,
                                            AbstractRouter* r) const
     {
-      return h->HandleUpdateExitVerifyMessage(this, r);
+      return h->HandleUpdateExitVerifyMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/messages/discard.hpp
+++ b/llarp/messages/discard.hpp
@@ -75,7 +75,7 @@ namespace llarp
       bool
       HandleMessage(IMessageHandler* h, AbstractRouter* r) const override
       {
-        return h->HandleDataDiscardMessage(this, r);
+        return h->HandleDataDiscardMessage(*this, r);
       }
 
       bool

--- a/llarp/messages/relay_commit.cpp
+++ b/llarp/messages/relay_commit.cpp
@@ -275,7 +275,7 @@ namespace llarp
       self->context->PutTransitHop(self->hop);
       // send path confirmation
       llarp::routing::PathConfirmMessage confirm(self->hop->lifetime);
-      if(!self->hop->SendRoutingMessage(&confirm, self->context->Router()))
+      if(!self->hop->SendRoutingMessage(confirm, self->context->Router()))
       {
         llarp::LogError("failed to send path confirmation for ",
                         self->hop->info);
@@ -329,7 +329,7 @@ namespace llarp
       using namespace std::placeholders;
       if(self->record.work
          && self->record.work->IsValid(
-                std::bind(&Crypto::shorthash, crypto, _1, _2), now))
+             std::bind(&Crypto::shorthash, crypto, _1, _2), now))
       {
         llarp::LogDebug("LRCM extended lifetime by ",
                         self->record.work->extendedLifetime, " seconds for ",

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -172,24 +172,26 @@ namespace llarp
     IHopHandler*
     PathContext::GetByUpstream(const RouterID& remote, const PathID_t& id)
     {
-      auto own = MapGet(m_OurPaths, id,
-                        [](__attribute__((unused)) const PathSet* s) -> bool {
-                          // TODO: is this right?
-                          return true;
-                        },
-                        [remote, id](PathSet* p) -> IHopHandler* {
-                          return p->GetByUpstream(remote, id);
-                        });
+      auto own = MapGet(
+          m_OurPaths, id,
+          [](ABSL_ATTRIBUTE_UNUSED const PathSet* s) -> bool {
+            // TODO: is this right?
+            return true;
+          },
+          [remote, id](PathSet* p) -> IHopHandler* {
+            return p->GetByUpstream(remote, id);
+          });
       if(own)
         return own;
 
-      return MapGet(m_TransitPaths, id,
-                    [remote](const std::shared_ptr< TransitHop >& hop) -> bool {
-                      return hop->info.upstream == remote;
-                    },
-                    [](const std::shared_ptr< TransitHop >& h) -> IHopHandler* {
-                      return h.get();
-                    });
+      return MapGet(
+          m_TransitPaths, id,
+          [remote](const std::shared_ptr< TransitHop >& hop) -> bool {
+            return hop->info.upstream == remote;
+          },
+          [](const std::shared_ptr< TransitHop >& h) -> IHopHandler* {
+            return h.get();
+          });
     }
 
     bool
@@ -206,13 +208,14 @@ namespace llarp
     IHopHandler*
     PathContext::GetByDownstream(const RouterID& remote, const PathID_t& id)
     {
-      return MapGet(m_TransitPaths, id,
-                    [remote](const std::shared_ptr< TransitHop >& hop) -> bool {
-                      return hop->info.downstream == remote;
-                    },
-                    [](const std::shared_ptr< TransitHop >& h) -> IHopHandler* {
-                      return h.get();
-                    });
+      return MapGet(
+          m_TransitPaths, id,
+          [remote](const std::shared_ptr< TransitHop >& hop) -> bool {
+            return hop->info.downstream == remote;
+          },
+          [](const std::shared_ptr< TransitHop >& h) -> IHopHandler* {
+            return h.get();
+          });
     }
 
     PathSet*
@@ -571,7 +574,7 @@ namespace llarp
           latency.T             = randint();
           m_LastLatencyTestID   = latency.T;
           m_LastLatencyTestTime = now;
-          SendRoutingMessage(&latency, r);
+          SendRoutingMessage(latency, r);
           return;
         }
         if(SupportsAnyRoles(ePathRoleExit | ePathRoleSVC))
@@ -675,15 +678,15 @@ namespace llarp
 
     bool
     Path::HandleUpdateExitVerifyMessage(
-        const routing::UpdateExitVerifyMessage* msg, AbstractRouter* r)
+        const routing::UpdateExitVerifyMessage& msg, AbstractRouter* r)
     {
       (void)r;
-      if(m_UpdateExitTX && msg->T == m_UpdateExitTX)
+      if(m_UpdateExitTX && msg.T == m_UpdateExitTX)
       {
         if(m_ExitUpdated)
           return m_ExitUpdated(this);
       }
-      if(m_CloseExitTX && msg->T == m_CloseExitTX)
+      if(m_CloseExitTX && msg.T == m_CloseExitTX)
       {
         if(m_ExitClosed)
           return m_ExitClosed(this);
@@ -692,15 +695,15 @@ namespace llarp
     }
 
     bool
-    Path::SendRoutingMessage(const routing::IMessage* msg, AbstractRouter* r)
+    Path::SendRoutingMessage(const routing::IMessage& msg, AbstractRouter* r)
     {
       std::array< byte_t, MAX_LINK_MSG_SIZE / 2 > tmp;
       llarp_buffer_t buf(tmp);
       // should help prevent bad paths with uninitialized members
       // FIXME: Why would we get uninitialized IMessages?
-      if(msg->version != LLARP_PROTO_VERSION)
+      if(msg.version != LLARP_PROTO_VERSION)
         return false;
-      if(!msg->BEncode(&buf))
+      if(!msg.BEncode(&buf))
       {
         LogError("Bencode failed");
         DumpBuffer(buf);
@@ -722,9 +725,9 @@ namespace llarp
     }
 
     bool
-    Path::HandlePathTransferMessage(__attribute__((unused))
-                                    const routing::PathTransferMessage* msg,
-                                    __attribute__((unused)) AbstractRouter* r)
+    Path::HandlePathTransferMessage(
+        ABSL_ATTRIBUTE_UNUSED const routing::PathTransferMessage& msg,
+        ABSL_ATTRIBUTE_UNUSED AbstractRouter* r)
     {
       LogWarn("unwarranted path transfer message on tx=", TXID(),
               " rx=", RXID());
@@ -732,19 +735,19 @@ namespace llarp
     }
 
     bool
-    Path::HandleDataDiscardMessage(const routing::DataDiscardMessage* msg,
+    Path::HandleDataDiscardMessage(const routing::DataDiscardMessage& msg,
                                    AbstractRouter* r)
     {
       MarkActive(r->Now());
       if(m_DropHandler)
-        return m_DropHandler(this, msg->P, msg->S);
+        return m_DropHandler(this, msg.P, msg.S);
       return true;
     }
 
     bool
-    Path::HandlePathConfirmMessage(__attribute__((unused))
-                                   const routing::PathConfirmMessage* msg,
-                                   AbstractRouter* r)
+    Path::HandlePathConfirmMessage(
+        ABSL_ATTRIBUTE_UNUSED const routing::PathConfirmMessage& msg,
+        AbstractRouter* r)
     {
       auto now = r->Now();
       if(_status == ePathBuilding)
@@ -762,7 +765,7 @@ namespace llarp
         latency.T             = randint();
         m_LastLatencyTestID   = latency.T;
         m_LastLatencyTestTime = now;
-        return SendRoutingMessage(&latency, r);
+        return SendRoutingMessage(latency, r);
       }
       LogWarn("got unwarranted path confirm message on tx=", RXID(),
               " rx=", RXID());
@@ -770,19 +773,19 @@ namespace llarp
     }
 
     bool
-    Path::HandleHiddenServiceFrame(const service::ProtocolFrame* frame)
+    Path::HandleHiddenServiceFrame(const service::ProtocolFrame& frame)
     {
       MarkActive(m_PathSet->Now());
       return m_DataHandler && m_DataHandler(this, frame);
     }
 
     bool
-    Path::HandlePathLatencyMessage(const routing::PathLatencyMessage* msg,
+    Path::HandlePathLatencyMessage(const routing::PathLatencyMessage& msg,
                                    AbstractRouter* r)
     {
       auto now = r->Now();
       MarkActive(now);
-      if(msg->L == m_LastLatencyTestID)
+      if(msg.L == m_LastLatencyTestID)
       {
         intro.latency       = now - m_LastLatencyTestTime;
         m_LastLatencyTestID = 0;
@@ -801,25 +804,25 @@ namespace llarp
     }
 
     bool
-    Path::HandleDHTMessage(const dht::IMessage* msg, AbstractRouter* r)
+    Path::HandleDHTMessage(const dht::IMessage& msg, AbstractRouter* r)
     {
       MarkActive(r->Now());
       routing::DHTMessage reply;
-      if(!msg->HandleMessage(r->dht(), reply.M))
+      if(!msg.HandleMessage(r->dht(), reply.M))
         return false;
       if(reply.M.size())
-        return SendRoutingMessage(&reply, r);
+        return SendRoutingMessage(reply, r);
       return true;
     }
 
     bool
-    Path::HandleCloseExitMessage(const routing::CloseExitMessage* msg,
+    Path::HandleCloseExitMessage(const routing::CloseExitMessage& msg,
                                  AbstractRouter* r)
     {
       /// allows exits to close from their end
       if(SupportsAnyRoles(ePathRoleExit | ePathRoleSVC))
       {
-        if(msg->Verify(r->crypto(), EndpointPubKey()))
+        if(msg.Verify(r->crypto(), EndpointPubKey()))
         {
           LogInfo(Name(), " had its exit closed");
           _role &= ~ePathRoleExit;
@@ -834,16 +837,16 @@ namespace llarp
     }
 
     bool
-    Path::SendExitRequest(const routing::ObtainExitMessage* msg,
+    Path::SendExitRequest(const routing::ObtainExitMessage& msg,
                           AbstractRouter* r)
     {
       LogInfo(Name(), " sending exit request to ", Endpoint());
-      m_ExitObtainTX = msg->T;
+      m_ExitObtainTX = msg.T;
       return SendRoutingMessage(msg, r);
     }
 
     bool
-    Path::SendExitClose(const routing::CloseExitMessage* msg, AbstractRouter* r)
+    Path::SendExitClose(const routing::CloseExitMessage& msg, AbstractRouter* r)
     {
       LogInfo(Name(), " closing exit to ", Endpoint());
       // mark as not exit anymore
@@ -852,7 +855,7 @@ namespace llarp
     }
 
     bool
-    Path::HandleObtainExitMessage(const routing::ObtainExitMessage* msg,
+    Path::HandleObtainExitMessage(const routing::ObtainExitMessage& msg,
                                   AbstractRouter* r)
     {
       (void)msg;
@@ -862,7 +865,7 @@ namespace llarp
     }
 
     bool
-    Path::HandleUpdateExitMessage(const routing::UpdateExitMessage* msg,
+    Path::HandleUpdateExitMessage(const routing::UpdateExitMessage& msg,
                                   AbstractRouter* r)
     {
       (void)msg;
@@ -872,31 +875,31 @@ namespace llarp
     }
 
     bool
-    Path::HandleRejectExitMessage(const routing::RejectExitMessage* msg,
+    Path::HandleRejectExitMessage(const routing::RejectExitMessage& msg,
                                   AbstractRouter* r)
     {
-      if(m_ExitObtainTX && msg->T == m_ExitObtainTX)
+      if(m_ExitObtainTX && msg.T == m_ExitObtainTX)
       {
-        if(!msg->Verify(r->crypto(), EndpointPubKey()))
+        if(!msg.Verify(r->crypto(), EndpointPubKey()))
         {
           LogError(Name(), "RXM invalid signature");
           return false;
         }
         LogInfo(Name(), " ", Endpoint(), " Rejected exit");
         MarkActive(r->Now());
-        return InformExitResult(msg->B);
+        return InformExitResult(msg.B);
       }
       LogError(Name(), " got unwarranted RXM");
       return false;
     }
 
     bool
-    Path::HandleGrantExitMessage(const routing::GrantExitMessage* msg,
+    Path::HandleGrantExitMessage(const routing::GrantExitMessage& msg,
                                  AbstractRouter* r)
     {
-      if(m_ExitObtainTX && msg->T == m_ExitObtainTX)
+      if(m_ExitObtainTX && msg.T == m_ExitObtainTX)
       {
-        if(!msg->Verify(r->crypto(), EndpointPubKey()))
+        if(!msg.Verify(r->crypto(), EndpointPubKey()))
         {
           LogError(Name(), " GXM signature failed");
           return false;
@@ -923,7 +926,7 @@ namespace llarp
 
     bool
     Path::HandleTransferTrafficMessage(
-        const routing::TransferTrafficMessage* msg, AbstractRouter* r)
+        const routing::TransferTrafficMessage& msg, AbstractRouter* r)
     {
       // check if we can handle exit data
       if(!SupportsAnyRoles(ePathRoleExit | ePathRoleSVC))
@@ -932,8 +935,8 @@ namespace llarp
       // handle traffic if we have a handler
       if(!m_ExitTrafficHandler)
         return false;
-      bool sent = msg->X.size() > 0;
-      for(const auto& pkt : msg->X)
+      bool sent = msg.X.size() > 0;
+      for(const auto& pkt : msg.X)
       {
         if(pkt.size() <= 8)
           return false;

--- a/llarp/path/path.hpp
+++ b/llarp/path/path.hpp
@@ -123,8 +123,7 @@ namespace llarp
 
       /// send routing message and increment sequence number
       virtual bool
-      SendRoutingMessage(const llarp::routing::IMessage* msg,
-                         llarp::AbstractRouter* r) = 0;
+      SendRoutingMessage(const routing::IMessage& msg, AbstractRouter* r) = 0;
 
       // handle data in upstream direction
       virtual bool
@@ -150,8 +149,7 @@ namespace llarp
       uint64_t m_SequenceNum = 0;
     };
 
-    struct TransitHop : public IHopHandler,
-                        public llarp::routing::IMessageHandler
+    struct TransitHop : public IHopHandler, public routing::IMessageHandler
     {
       TransitHop();
 
@@ -195,72 +193,68 @@ namespace llarp
 
       // send routing message when end of path
       bool
-      SendRoutingMessage(const llarp::routing::IMessage* msg,
+      SendRoutingMessage(const routing::IMessage& msg,
                          AbstractRouter* r) override;
 
       // handle routing message when end of path
       bool
-      HandleRoutingMessage(const llarp::routing::IMessage* msg,
-                           AbstractRouter* r);
+      HandleRoutingMessage(const routing::IMessage& msg, AbstractRouter* r);
 
       bool
-      HandleDataDiscardMessage(const llarp::routing::DataDiscardMessage* msg,
+      HandleDataDiscardMessage(const routing::DataDiscardMessage& msg,
                                AbstractRouter* r) override;
 
       bool
-      HandlePathConfirmMessage(const llarp::routing::PathConfirmMessage* msg,
+      HandlePathConfirmMessage(const routing::PathConfirmMessage& msg,
                                AbstractRouter* r) override;
       bool
-      HandlePathTransferMessage(const llarp::routing::PathTransferMessage* msg,
+      HandlePathTransferMessage(const routing::PathTransferMessage& msg,
                                 AbstractRouter* r) override;
       bool
-      HandlePathLatencyMessage(const llarp::routing::PathLatencyMessage* msg,
+      HandlePathLatencyMessage(const routing::PathLatencyMessage& msg,
                                AbstractRouter* r) override;
 
       bool
-      HandleObtainExitMessage(const llarp::routing::ObtainExitMessage* msg,
+      HandleObtainExitMessage(const routing::ObtainExitMessage& msg,
                               AbstractRouter* r) override;
 
       bool
-      HandleUpdateExitVerifyMessage(
-          const llarp::routing::UpdateExitVerifyMessage* msg,
-          AbstractRouter* r) override;
+      HandleUpdateExitVerifyMessage(const routing::UpdateExitVerifyMessage& msg,
+                                    AbstractRouter* r) override;
 
       bool
-      HandleTransferTrafficMessage(
-          const llarp::routing::TransferTrafficMessage* msg,
-          AbstractRouter* r) override;
+      HandleTransferTrafficMessage(const routing::TransferTrafficMessage& msg,
+                                   AbstractRouter* r) override;
 
       bool
-      HandleUpdateExitMessage(const llarp::routing::UpdateExitMessage* msg,
+      HandleUpdateExitMessage(const routing::UpdateExitMessage& msg,
                               AbstractRouter* r) override;
 
       bool
-      HandleGrantExitMessage(const llarp::routing::GrantExitMessage* msg,
+      HandleGrantExitMessage(const routing::GrantExitMessage& msg,
                              AbstractRouter* r) override;
       bool
-      HandleRejectExitMessage(const llarp::routing::RejectExitMessage* msg,
+      HandleRejectExitMessage(const routing::RejectExitMessage& msg,
                               AbstractRouter* r) override;
 
       bool
-      HandleCloseExitMessage(const llarp::routing::CloseExitMessage* msg,
+      HandleCloseExitMessage(const routing::CloseExitMessage& msg,
                              AbstractRouter* r) override;
 
       bool
-      HandleHiddenServiceFrame(__attribute__((
-          unused)) const llarp::service::ProtocolFrame* frame) override
+      HandleHiddenServiceFrame(
+          ABSL_ATTRIBUTE_UNUSED const service::ProtocolFrame& frame) override
       {
         /// TODO: implement me
-        llarp::LogWarn("Got hidden service data on transit hop");
+        LogWarn("Got hidden service data on transit hop");
         return false;
       }
 
       bool
-      HandleGotIntroMessage(const llarp::dht::GotIntroMessage* msg);
+      HandleGotIntroMessage(const dht::GotIntroMessage& msg);
 
       bool
-      HandleDHTMessage(const llarp::dht::IMessage* msg,
-                       AbstractRouter* r) override;
+      HandleDHTMessage(const dht::IMessage& msg, AbstractRouter* r) override;
 
       // handle data in upstream direction
       bool
@@ -307,7 +301,7 @@ namespace llarp
     };
 
     /// A path we made
-    struct Path : public IHopHandler, public llarp::routing::IMessageHandler
+    struct Path : public IHopHandler, public routing::IMessageHandler
     {
       using BuildResultHookFunc = std::function< void(Path*) >;
       using CheckForDeadFunc    = std::function< bool(Path*, llarp_time_t) >;
@@ -315,7 +309,7 @@ namespace llarp
           std::function< bool(Path*, const PathID_t&, uint64_t) >;
       using HopList = std::vector< PathHopConfig >;
       using DataHandlerFunc =
-          std::function< bool(Path*, const service::ProtocolFrame*) >;
+          std::function< bool(Path*, const service::ProtocolFrame&) >;
       using ExitUpdatedFunc = std::function< bool(Path*) >;
       using ExitClosedFunc  = std::function< bool(Path*) >;
       using ExitTrafficHandlerFunc =
@@ -327,7 +321,7 @@ namespace llarp
 
       PathSet* m_PathSet;
 
-      llarp::service::Introduction intro;
+      service::Introduction intro;
 
       llarp_time_t buildStarted;
 
@@ -439,63 +433,59 @@ namespace llarp
       Tick(llarp_time_t now, AbstractRouter* r);
 
       bool
-      SendRoutingMessage(const llarp::routing::IMessage* msg,
-                         llarp::AbstractRouter* r) override;
+      SendRoutingMessage(const routing::IMessage& msg,
+                         AbstractRouter* r) override;
 
       bool
-      HandleObtainExitMessage(const llarp::routing::ObtainExitMessage* msg,
+      HandleObtainExitMessage(const routing::ObtainExitMessage& msg,
                               AbstractRouter* r) override;
 
       bool
-      HandleUpdateExitVerifyMessage(
-          const llarp::routing::UpdateExitVerifyMessage* msg,
-          AbstractRouter* r) override;
+      HandleUpdateExitVerifyMessage(const routing::UpdateExitVerifyMessage& msg,
+                                    AbstractRouter* r) override;
 
       bool
-      HandleTransferTrafficMessage(
-          const llarp::routing::TransferTrafficMessage* msg,
-          AbstractRouter* r) override;
+      HandleTransferTrafficMessage(const routing::TransferTrafficMessage& msg,
+                                   AbstractRouter* r) override;
 
       bool
-      HandleUpdateExitMessage(const llarp::routing::UpdateExitMessage* msg,
+      HandleUpdateExitMessage(const routing::UpdateExitMessage& msg,
                               AbstractRouter* r) override;
 
       bool
-      HandleCloseExitMessage(const llarp::routing::CloseExitMessage* msg,
+      HandleCloseExitMessage(const routing::CloseExitMessage& msg,
                              AbstractRouter* r) override;
       bool
-      HandleGrantExitMessage(const llarp::routing::GrantExitMessage* msg,
+      HandleGrantExitMessage(const routing::GrantExitMessage& msg,
                              AbstractRouter* r) override;
       bool
-      HandleRejectExitMessage(const llarp::routing::RejectExitMessage* msg,
+      HandleRejectExitMessage(const routing::RejectExitMessage& msg,
                               AbstractRouter* r) override;
 
       bool
-      HandleDataDiscardMessage(const llarp::routing::DataDiscardMessage* msg,
+      HandleDataDiscardMessage(const routing::DataDiscardMessage& msg,
                                AbstractRouter* r) override;
 
       bool
-      HandlePathConfirmMessage(const llarp::routing::PathConfirmMessage* msg,
+      HandlePathConfirmMessage(const routing::PathConfirmMessage& msg,
                                AbstractRouter* r) override;
 
       bool
-      HandlePathLatencyMessage(const llarp::routing::PathLatencyMessage* msg,
+      HandlePathLatencyMessage(const routing::PathLatencyMessage& msg,
                                AbstractRouter* r) override;
 
       bool
-      HandlePathTransferMessage(const llarp::routing::PathTransferMessage* msg,
+      HandlePathTransferMessage(const routing::PathTransferMessage& msg,
                                 AbstractRouter* r) override;
 
       bool
-      HandleHiddenServiceFrame(
-          const llarp::service::ProtocolFrame* frame) override;
+      HandleHiddenServiceFrame(const service::ProtocolFrame& frame) override;
 
       bool
-      HandleGotIntroMessage(const llarp::dht::GotIntroMessage* msg);
+      HandleGotIntroMessage(const dht::GotIntroMessage& msg);
 
       bool
-      HandleDHTMessage(const llarp::dht::IMessage* msg,
-                       AbstractRouter* r) override;
+      HandleDHTMessage(const dht::IMessage& msg, AbstractRouter* r) override;
 
       bool
       HandleRoutingMessage(const llarp_buffer_t& buf, AbstractRouter* r);
@@ -543,12 +533,10 @@ namespace llarp
       }
 
       bool
-      SendExitRequest(const llarp::routing::ObtainExitMessage* msg,
-                      AbstractRouter* r);
+      SendExitRequest(const routing::ObtainExitMessage& msg, AbstractRouter* r);
 
       bool
-      SendExitClose(const llarp::routing::CloseExitMessage* msg,
-                    AbstractRouter* r);
+      SendExitClose(const routing::CloseExitMessage& msg, AbstractRouter* r);
 
      private:
       /// call obtained exit hooks
@@ -615,7 +603,7 @@ namespace llarp
       HasTransitHop(const TransitHopInfo& info);
 
       bool
-      HandleRelayCommit(const LR_CommitMessage* msg);
+      HandleRelayCommit(const LR_CommitMessage& msg);
 
       void
       PutTransitHop(std::shared_ptr< TransitHop > hop);
@@ -646,10 +634,10 @@ namespace llarp
       HopIsUs(const RouterID& k) const;
 
       bool
-      HandleLRUM(const RelayUpstreamMessage* msg);
+      HandleLRUM(const RelayUpstreamMessage& msg);
 
       bool
-      HandleLRDM(const RelayDownstreamMessage* msg);
+      HandleLRDM(const RelayDownstreamMessage& msg);
 
       void
       AddOwnPath(PathSet* set, Path* p);
@@ -684,13 +672,13 @@ namespace llarp
       llarp::Crypto*
       Crypto();
 
-      llarp::Logic*
+      Logic*
       Logic();
 
       AbstractRouter*
       Router();
 
-      const llarp::SecretKey&
+      const SecretKey&
       EncryptionSecretKey();
 
       const byte_t*

--- a/llarp/routing/dht_message.cpp
+++ b/llarp/routing/dht_message.cpp
@@ -58,7 +58,7 @@ namespace llarp
       {
         msg->From   = us;
         msg->pathID = from;
-        if(!h->HandleDHTMessage(msg.get(), r))
+        if(!h->HandleDHTMessage(*msg, r))
           return false;
       }
       return true;

--- a/llarp/routing/handler.hpp
+++ b/llarp/routing/handler.hpp
@@ -33,53 +33,53 @@ namespace llarp
     struct IMessageHandler
     {
       virtual bool
-      HandleObtainExitMessage(const ObtainExitMessage *msg,
+      HandleObtainExitMessage(const ObtainExitMessage& msg,
                               AbstractRouter *r) = 0;
 
       virtual bool
-      HandleGrantExitMessage(const GrantExitMessage *msg,
+      HandleGrantExitMessage(const GrantExitMessage& msg,
                              AbstractRouter *r) = 0;
 
       virtual bool
-      HandleRejectExitMessage(const RejectExitMessage *msg,
+      HandleRejectExitMessage(const RejectExitMessage& msg,
                               AbstractRouter *r) = 0;
 
       virtual bool
-      HandleTransferTrafficMessage(const TransferTrafficMessage *msg,
+      HandleTransferTrafficMessage(const TransferTrafficMessage& msg,
                                    AbstractRouter *r) = 0;
 
       virtual bool
-      HandleUpdateExitMessage(const UpdateExitMessage *msg,
+      HandleUpdateExitMessage(const UpdateExitMessage& msg,
                               AbstractRouter *r) = 0;
 
       virtual bool
-      HandleUpdateExitVerifyMessage(const UpdateExitVerifyMessage *msg,
+      HandleUpdateExitVerifyMessage(const UpdateExitVerifyMessage& msg,
                                     AbstractRouter *r) = 0;
 
       virtual bool
-      HandleCloseExitMessage(const CloseExitMessage *msg,
+      HandleCloseExitMessage(const CloseExitMessage& msg,
                              AbstractRouter *r) = 0;
 
       virtual bool
-      HandleDataDiscardMessage(const DataDiscardMessage *msg,
+      HandleDataDiscardMessage(const DataDiscardMessage& msg,
                                AbstractRouter *r) = 0;
 
       virtual bool
-      HandlePathTransferMessage(const PathTransferMessage *msg,
+      HandlePathTransferMessage(const PathTransferMessage& msg,
                                 AbstractRouter *r) = 0;
 
       virtual bool
-      HandleHiddenServiceFrame(const service::ProtocolFrame *msg) = 0;
+      HandleHiddenServiceFrame(const service::ProtocolFrame& msg) = 0;
 
       virtual bool
-      HandlePathConfirmMessage(const PathConfirmMessage *msg,
+      HandlePathConfirmMessage(const PathConfirmMessage& msg,
                                AbstractRouter *r) = 0;
 
       virtual bool
-      HandlePathLatencyMessage(const PathLatencyMessage *msg,
+      HandlePathLatencyMessage(const PathLatencyMessage& msg,
                                AbstractRouter *r) = 0;
       virtual bool
-      HandleDHTMessage(const dht::IMessage *msg, AbstractRouter *r) = 0;
+      HandleDHTMessage(const dht::IMessage& msg, AbstractRouter *r) = 0;
     };
   }  // namespace routing
 }  // namespace llarp

--- a/llarp/routing/path_confirm.cpp
+++ b/llarp/routing/path_confirm.cpp
@@ -55,7 +55,7 @@ namespace llarp
     PathConfirmMessage::HandleMessage(IMessageHandler* h,
                                       AbstractRouter* r) const
     {
-      return h && h->HandlePathConfirmMessage(this, r);
+      return h && h->HandlePathConfirmMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/routing/path_latency.cpp
+++ b/llarp/routing/path_latency.cpp
@@ -49,7 +49,7 @@ namespace llarp
     PathLatencyMessage::HandleMessage(IMessageHandler* h,
                                       AbstractRouter* r) const
     {
-      return h && h->HandlePathLatencyMessage(this, r);
+      return h && h->HandlePathLatencyMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/routing/path_transfer.cpp
+++ b/llarp/routing/path_transfer.cpp
@@ -61,7 +61,7 @@ namespace llarp
     PathTransferMessage::HandleMessage(IMessageHandler* h,
                                        AbstractRouter* r) const
     {
-      return h->HandlePathTransferMessage(this, r);
+      return h->HandlePathTransferMessage(*this, r);
     }
 
   }  // namespace routing

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -309,22 +309,24 @@ namespace llarp
         if(option.first == "keyfile")
           keyfile = option.second;
       }
-      std::unique_ptr< llarp::service::Endpoint > service;
 
-      static std::map< std::string,
-                       std::function< llarp::service::Endpoint *(
-                           const std::string &, AbstractRouter *,
-                           llarp::service::Context *) > >
+      std::unique_ptr< service::Endpoint > service;
+
+      static std::map<
+          std::string,
+          std::function< std::unique_ptr< service::Endpoint >(
+              const std::string &, AbstractRouter *, service::Context *) > >
           endpointConstructors = {
               {"tun",
                [](const std::string &nick, AbstractRouter *r,
-                  llarp::service::Context *c) -> llarp::service::Endpoint * {
-                 return new llarp::handlers::TunEndpoint(nick, r, c);
+                  llarp::service::Context *c)
+                   -> std::unique_ptr< service::Endpoint > {
+                 return std::make_unique< handlers::TunEndpoint >(nick, r, c);
                }},
               {"null",
                [](const std::string &nick, AbstractRouter *r,
-                  llarp::service::Context *c) -> llarp::service::Endpoint * {
-                 return new llarp::handlers::NullEndpoint(nick, r, c);
+                  service::Context *c) -> std::unique_ptr< service::Endpoint > {
+                 return std::make_unique< handlers::NullEndpoint >(nick, r, c);
                }}};
 
       {
@@ -337,7 +339,7 @@ namespace llarp
         }
 
         // construct
-        service.reset(itr->second(conf.first, m_Router, this));
+        service = itr->second(conf.first, m_Router, this);
 
         // if ephemeral, then we need to regen key
         // if privkey file, then set it and load it

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -620,11 +620,12 @@ namespace llarp
       {
       }
 
-      routing::IMessage*
+      std::unique_ptr< routing::IMessage >
       BuildRequestMessage()
       {
-        routing::DHTMessage* msg = new routing::DHTMessage();
-        msg->M.emplace_back(new dht::PublishIntroMessage(m_IntroSet, txid, 1));
+        auto msg = std::make_unique< routing::DHTMessage >();
+        msg->M.emplace_back(
+            std::make_unique< dht::PublishIntroMessage >(m_IntroSet, txid, 1));
         return msg;
       }
 
@@ -742,8 +743,8 @@ namespace llarp
         return;
       }
 
-      OutboundContext* ctx = new OutboundContext(introset, this);
-      m_RemoteSessions.emplace(addr, std::unique_ptr< OutboundContext >(ctx));
+      auto it = m_RemoteSessions.emplace(
+          addr, std::make_unique< OutboundContext >(introset, this));
       LogInfo("Created New outbound context for ", addr.ToString());
 
       // inform pending
@@ -751,7 +752,7 @@ namespace llarp
       auto itr   = range.first;
       if(itr != range.second)
       {
-        itr->second(addr, ctx);
+        itr->second(addr, it->second.get());
         ++itr;
       }
       m_PendingServiceLookups.erase(addr);
@@ -798,9 +799,10 @@ namespace llarp
         auto path = GetEstablishedPathClosestTo(router);
         routing::DHTMessage msg;
         auto txid = GenTXID();
-        msg.M.emplace_back(new dht::FindRouterMessage(txid, router));
+        msg.M.emplace_back(
+            std::make_unique< dht::FindRouterMessage >(txid, router));
 
-        if(path && path->SendRoutingMessage(&msg, m_Router))
+        if(path && path->SendRoutingMessage(msg, m_Router))
         {
           LogInfo(Name(), " looking up ", router);
           m_PendingRouters.emplace(router, RouterLookupJob(this));
@@ -815,15 +817,11 @@ namespace llarp
     void
     Endpoint::HandlePathBuilt(path::Path* p)
     {
-      p->SetDataHandler(std::bind(&Endpoint::HandleHiddenServiceFrame, this,
-                                  std::placeholders::_1,
-                                  std::placeholders::_2));
-      p->SetDropHandler(std::bind(&Endpoint::HandleDataDrop, this,
-                                  std::placeholders::_1, std::placeholders::_2,
-                                  std::placeholders::_3));
-      p->SetDeadChecker(std::bind(&Endpoint::CheckPathIsDead, this,
-                                  std::placeholders::_1,
-                                  std::placeholders::_2));
+      using namespace std::placeholders;
+      p->SetDataHandler(
+          std::bind(&Endpoint::HandleHiddenServiceFrame, this, _1, _2));
+      p->SetDropHandler(std::bind(&Endpoint::HandleDataDrop, this, _1, _2, _3));
+      p->SetDeadChecker(std::bind(&Endpoint::CheckPathIsDead, this, _1, _2));
       path::Builder::HandlePathBuilt(p);
     }
 
@@ -890,34 +888,34 @@ namespace llarp
 
     bool
     Endpoint::HandleHiddenServiceFrame(path::Path* p,
-                                       const ProtocolFrame* frame)
+                                       const ProtocolFrame& frame)
     {
-      if(frame->R)
+      if(frame.R)
       {
         // handle discard
         ServiceInfo si;
-        if(!GetSenderFor(frame->T, si))
+        if(!GetSenderFor(frame.T, si))
           return false;
         // verify source
-        if(!frame->Verify(Crypto(), si))
+        if(!frame.Verify(Crypto(), si))
           return false;
         // remove convotag it doesn't exist
-        LogWarn("remove convotag T=", frame->T);
-        RemoveConvoTag(frame->T);
+        LogWarn("remove convotag T=", frame.T);
+        RemoveConvoTag(frame.T);
         return true;
       }
-      if(!frame->AsyncDecryptAndVerify(EndpointLogic(), Crypto(), p, Worker(),
-                                       m_Identity, m_DataHandler))
+      if(!frame.AsyncDecryptAndVerify(EndpointLogic(), Crypto(), p, Worker(),
+                                      m_Identity, m_DataHandler))
       {
         // send discard
         ProtocolFrame f;
         f.R = 1;
-        f.T = frame->T;
+        f.T = frame.T;
         f.F = p->intro.pathID;
         if(!f.Sign(Crypto(), m_Identity))
           return false;
-        const routing::PathTransferMessage d(f, frame->F);
-        return p->SendRoutingMessage(&d, router);
+        const routing::PathTransferMessage d(f, frame.F);
+        return p->SendRoutingMessage(d, router);
       }
       return true;
     }
@@ -992,11 +990,10 @@ namespace llarp
         return false;
       }
 
+      using namespace std::placeholders;
       HiddenServiceAddressLookup* job = new HiddenServiceAddressLookup(
-          this,
-          std::bind(&Endpoint::OnLookup, this, std::placeholders::_1,
-                    std::placeholders::_2, std::placeholders::_3),
-          remote, GenTXID());
+          this, std::bind(&Endpoint::OnLookup, this, _1, _2, _3), remote,
+          GenTXID());
       LogInfo("doing lookup for ", remote, " via ", path->Endpoint());
       if(job->SendRequestViaPath(path, Router()))
       {
@@ -1010,6 +1007,7 @@ namespace llarp
     void
     Endpoint::EnsurePathToSNode(const RouterID& snode, SNodeEnsureHook h)
     {
+      using namespace std::placeholders;
       if(m_SNodeSessions.count(snode) == 0)
       {
         auto themIP = ObtainIPForAddr(snode, true);
@@ -1017,8 +1015,7 @@ namespace llarp
             snode,
             std::make_unique< exit::SNodeSession >(
                 snode,
-                std::bind(&Endpoint::HandleWriteIPPacket, this,
-                          std::placeholders::_1,
+                std::bind(&Endpoint::HandleWriteIPPacket, this, _1,
                           [themIP]() -> huint32_t { return themIP; }),
                 m_Router, 2, numHops));
       }
@@ -1029,7 +1026,7 @@ namespace llarp
         if(itr->second->IsReady())
           h(snode, itr->second.get());
         else
-          itr->second->AddReadyHook(std::bind(h, snode, std::placeholders::_1));
+          itr->second->AddReadyHook(std::bind(h, snode, _1));
         ++itr;
       }
     }
@@ -1117,7 +1114,7 @@ namespace llarp
                 return false;
               }
               LogDebug(Name(), " send ", data.sz, " via ", remoteIntro.router);
-              return p->SendRoutingMessage(&transfer, Router());
+              return p->SendRoutingMessage(transfer, Router());
             }
           }
         }

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -125,7 +125,7 @@ namespace llarp
 
       bool
       HandleHiddenServiceFrame(path::Path* p,
-                               const service::ProtocolFrame* msg);
+                               const service::ProtocolFrame& msg);
 
       /// return true if we have an established path to a hidden service
       bool

--- a/llarp/service/hidden_service_address_lookup.cpp
+++ b/llarp/service/hidden_service_address_lookup.cpp
@@ -33,11 +33,12 @@ namespace llarp
       return handle(remote, nullptr, endpoint);
     }
 
-    routing::IMessage*
+    std::unique_ptr< routing::IMessage >
     HiddenServiceAddressLookup::BuildRequestMessage()
     {
-      routing::DHTMessage* msg = new routing::DHTMessage();
-      msg->M.emplace_back(new dht::FindIntroMessage(txid, remote, 0));
+      auto msg = std::make_unique< routing::DHTMessage >();
+      msg->M.emplace_back(
+          std::make_unique< dht::FindIntroMessage >(txid, remote, 0));
       return msg;
     }
 

--- a/llarp/service/hidden_service_address_lookup.hpp
+++ b/llarp/service/hidden_service_address_lookup.hpp
@@ -27,7 +27,7 @@ namespace llarp
       bool
       HandleResponse(const std::set< IntroSet >& results);
 
-      routing::IMessage*
+      std::unique_ptr< routing::IMessage >
       BuildRequestMessage();
     };
   }  // namespace service

--- a/llarp/service/lookup.cpp
+++ b/llarp/service/lookup.cpp
@@ -23,9 +23,8 @@ namespace llarp
       auto msg = BuildRequestMessage();
       if(!msg)
         return false;
-      auto result = path->SendRoutingMessage(msg, r);
+      auto result = path->SendRoutingMessage(*msg, r);
       endpoint    = path->Endpoint();
-      delete msg;
       return result;
     }
   }  // namespace service

--- a/llarp/service/lookup.hpp
+++ b/llarp/service/lookup.hpp
@@ -43,10 +43,10 @@ namespace llarp
       }
 
       /// build request message for service lookup
-      virtual llarp::routing::IMessage*
+      virtual std::unique_ptr< routing::IMessage >
       BuildRequestMessage() = 0;
 
-      /// build a new requset message and send it via a path
+      /// build a new request message and send it via a path
       bool
       SendRequestViaPath(llarp::path::Path* p, AbstractRouter* r);
 

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -535,7 +535,7 @@ namespace llarp
 
     bool
     OutboundContext::HandleHiddenServiceFrame(path::Path* p,
-                                              const ProtocolFrame* frame)
+                                              const ProtocolFrame& frame)
     {
       return m_Endpoint->HandleHiddenServiceFrame(p, frame);
     }

--- a/llarp/service/outbound_context.hpp
+++ b/llarp/service/outbound_context.hpp
@@ -84,7 +84,7 @@ namespace llarp
                 size_t hop, llarp::path::PathRole roles) override;
 
       bool
-      HandleHiddenServiceFrame(path::Path* p, const ProtocolFrame* frame);
+      HandleHiddenServiceFrame(path::Path* p, const ProtocolFrame& frame);
 
       std::string
       Name() const override;

--- a/llarp/service/protocol.cpp
+++ b/llarp/service/protocol.cpp
@@ -443,10 +443,9 @@ namespace llarp
 
     bool
     ProtocolFrame::HandleMessage(llarp::routing::IMessageHandler* h,
-                                 __attribute__((unused))
-                                 AbstractRouter* r) const
+                                 ABSL_ATTRIBUTE_UNUSED AbstractRouter* r) const
     {
-      return h->HandleHiddenServiceFrame(this);
+      return h->HandleHiddenServiceFrame(*this);
     }
 
   }  // namespace service

--- a/llarp/service/sendcontext.cpp
+++ b/llarp/service/sendcontext.cpp
@@ -28,7 +28,7 @@ namespace llarp
       if(path)
       {
         const routing::PathTransferMessage transfer(msg, remoteIntro.pathID);
-        if(path->SendRoutingMessage(&transfer, m_Endpoint->Router()))
+        if(path->SendRoutingMessage(transfer, m_Endpoint->Router()))
         {
           llarp::LogInfo("sent intro to ", remoteIntro.pathID, " on ",
                          remoteIntro.router, " seqno=", sequenceNo);
@@ -99,7 +99,7 @@ namespace llarp
 
       msg.P = remoteIntro.pathID;
       msg.Y.Randomize();
-      if(path->SendRoutingMessage(&msg, m_Endpoint->Router()))
+      if(path->SendRoutingMessage(msg, m_Endpoint->Router()))
       {
         llarp::LogDebug("sent message via ", remoteIntro.pathID, " on ",
                         remoteIntro.router);

--- a/llarp/service/tag_lookup_job.cpp
+++ b/llarp/service/tag_lookup_job.cpp
@@ -42,11 +42,11 @@ namespace llarp
       }
     }
 
-    routing::IMessage*
+    std::unique_ptr< routing::IMessage >
     CachedTagResult::BuildRequestMessage(uint64_t txid)
     {
-      routing::DHTMessage* msg = new routing::DHTMessage();
-      msg->M.emplace_back(new dht::FindIntroMessage(tag, txid));
+      auto msg = std::make_unique< routing::DHTMessage >();
+      msg->M.emplace_back(std::make_unique< dht::FindIntroMessage >(tag, txid));
       lastRequest = parent->Now();
       return msg;
     }

--- a/llarp/service/tag_lookup_job.hpp
+++ b/llarp/service/tag_lookup_job.hpp
@@ -43,7 +43,7 @@ namespace llarp
         return (now - lastRequest) > TTL;
       }
 
-      llarp::routing::IMessage*
+      std::unique_ptr< routing::IMessage >
       BuildRequestMessage(uint64_t txid);
 
       bool
@@ -58,7 +58,7 @@ namespace llarp
       {
       }
 
-      llarp::routing::IMessage*
+      std::unique_ptr< routing::IMessage >
       BuildRequestMessage() override
       {
         return m_result->BuildRequestMessage(txid);

--- a/test/dht/mock_context.hpp
+++ b/test/dht/mock_context.hpp
@@ -64,7 +64,7 @@ namespace llarp
                std::vector< std::unique_ptr< dht::IMessage > >& replies));
 
       MOCK_METHOD2(RelayRequestForPath,
-                   bool(const PathID_t& localPath, const dht::IMessage* msg));
+                   bool(const PathID_t& localPath, const dht::IMessage& msg));
 
       MOCK_CONST_METHOD2(GetRCFromNodeDB,
                          bool(const dht::Key_t& k, RouterContact& rc));


### PR DESCRIPTION
Mostly replacing pointers with `unique_ptr`. the larger part of the change (maybe unnecessary) is changing message handlers to take `const Msg& msg` versus `const Msg * msg`.