### PR TITLE
Tidy up more parts of the service/ directory

### DIFF
--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -221,19 +221,18 @@ set(LIB_SRC
   service/endpoint.cpp
   service/handler.cpp
   service/hidden_service_address_lookup.cpp
-  service/Identity.cpp
+  service/identity.cpp
   service/info.cpp
-  service/Intro.cpp
-  service/IntroSet.cpp
+  service/intro_set.cpp
+  service/intro.cpp
   service/lookup.cpp
   service/outbound_context.cpp
   service/pendingbuffer.cpp
   service/protocol.cpp
   service/sendcontext.cpp
   service/session.cpp
-  service/tag.cpp
   service/tag_lookup_job.cpp
-  service/types.cpp
+  service/tag.cpp
   service/vanity.cpp
   utp/inbound_message.cpp
   utp/linklayer.cpp

--- a/llarp/dht/context.hpp
+++ b/llarp/dht/context.hpp
@@ -10,7 +10,7 @@
 #include <dht/tx.hpp>
 #include <dht/txholder.hpp>
 #include <dht/txowner.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <util/time.hpp>
 #include <util/status.hpp>
 

--- a/llarp/dht/messages/gotintro.hpp
+++ b/llarp/dht/messages/gotintro.hpp
@@ -2,7 +2,7 @@
 #define LLARP_DHT_MESSAGES_GOT_INTRO_HPP
 
 #include <dht/message.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 
 #include <vector>
 

--- a/llarp/dht/messages/pubintro.hpp
+++ b/llarp/dht/messages/pubintro.hpp
@@ -1,7 +1,7 @@
 #ifndef LLARP_DHT_MESSAGES_PUB_INTRO_HPP
 #define LLARP_DHT_MESSAGES_PUB_INTRO_HPP
 #include <dht/message.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 
 #include <vector>
 

--- a/llarp/dht/node.hpp
+++ b/llarp/dht/node.hpp
@@ -3,7 +3,7 @@
 
 #include <dht/key.hpp>
 #include <router_contact.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 
 namespace llarp
 {

--- a/llarp/dht/publishservicejob.hpp
+++ b/llarp/dht/publishservicejob.hpp
@@ -4,7 +4,7 @@
 #include <dht/tx.hpp>
 #include <dht/txowner.hpp>
 #include <service/address.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 
 #include <set>
 

--- a/llarp/dht/serviceaddresslookup.hpp
+++ b/llarp/dht/serviceaddresslookup.hpp
@@ -4,7 +4,7 @@
 #include <dht/key.hpp>
 #include <dht/tx.hpp>
 #include <service/address.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 
 namespace llarp
 {

--- a/llarp/dht/taglookup.hpp
+++ b/llarp/dht/taglookup.hpp
@@ -2,7 +2,7 @@
 #define LLARP_DHT_TAGLOOKUP
 
 #include <dht/tx.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <service/tag.hpp>
 
 namespace llarp

--- a/llarp/path/path.hpp
+++ b/llarp/path/path.hpp
@@ -10,7 +10,7 @@
 #include <router_id.hpp>
 #include <routing/handler.hpp>
 #include <routing/message.hpp>
-#include <service/Intro.hpp>
+#include <service/intro.hpp>
 #include <util/aligned.hpp>
 #include <util/threading.hpp>
 #include <util/time.hpp>

--- a/llarp/path/pathset.hpp
+++ b/llarp/path/pathset.hpp
@@ -4,7 +4,7 @@
 #include <path/path_types.hpp>
 #include <router_id.hpp>
 #include <routing/message.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <service/lookup.hpp>
 #include <util/status.hpp>
 #include <util/threading.hpp>

--- a/llarp/service/Identity.cpp
+++ b/llarp/service/Identity.cpp
@@ -1,4 +1,4 @@
-#include <service/Identity.hpp>
+#include <service/identity.hpp>
 
 #include <util/fs.hpp>
 
@@ -57,12 +57,11 @@ namespace llarp
     }
 
     void
-    Identity::RegenerateKeys(llarp::Crypto* crypto)
+    Identity::RegenerateKeys(Crypto* crypto)
     {
       crypto->encryption_keygen(enckey);
       crypto->identity_keygen(signkey);
-      pub.Update(llarp::seckey_topublic(enckey),
-                 llarp::seckey_topublic(signkey));
+      pub.Update(seckey_topublic(enckey), seckey_topublic(signkey));
       crypto->pqe_keygen(pq);
     }
 
@@ -81,7 +80,7 @@ namespace llarp
     }
 
     bool
-    Identity::EnsureKeys(const std::string& fname, llarp::Crypto* c)
+    Identity::EnsureKeys(const std::string& fname, Crypto* c)
     {
       std::array< byte_t, 4096 > tmp;
       llarp_buffer_t buf(tmp);
@@ -91,7 +90,7 @@ namespace llarp
       {
         if(ec)
         {
-          llarp::LogError(ec);
+          LogError(ec);
           return false;
         }
         // regen and encode
@@ -125,14 +124,12 @@ namespace llarp
       if(!vanity.IsZero())
         van = vanity;
       // update pubkeys
-      pub.Update(llarp::seckey_topublic(enckey),
-                 llarp::seckey_topublic(signkey), van);
+      pub.Update(seckey_topublic(enckey), seckey_topublic(signkey), van);
       return true;
     }
 
     bool
-    Identity::SignIntroSet(IntroSet& i, llarp::Crypto* crypto,
-                           llarp_time_t now) const
+    Identity::SignIntroSet(IntroSet& i, Crypto* crypto, llarp_time_t now) const
     {
       if(i.I.size() == 0)
         return false;

--- a/llarp/service/Identity.hpp
+++ b/llarp/service/Identity.hpp
@@ -2,9 +2,9 @@
 #define LLARP_SERVICE_IDENTITY_HPP
 
 #include <crypto/types.hpp>
-#include <service/Info.hpp>
-#include <service/IntroSet.hpp>
-#include <service/types.hpp>
+#include <service/info.hpp>
+#include <service/intro_set.hpp>
+#include <service/vanity.hpp>
 #include <util/bencode.hpp>
 
 namespace llarp
@@ -14,11 +14,11 @@ namespace llarp
   namespace service
   {
     // private keys
-    struct Identity final : public llarp::IBEncodeMessage
+    struct Identity final : public IBEncodeMessage
     {
-      llarp::SecretKey enckey;
-      llarp::SecretKey signkey;
-      llarp::PQKeyPair pq;
+      SecretKey enckey;
+      SecretKey signkey;
+      PQKeyPair pq;
       uint64_t version = 0;
       VanityNonce vanity;
 
@@ -29,7 +29,7 @@ namespace llarp
 
       // regenerate secret keys
       void
-      RegenerateKeys(llarp::Crypto* c);
+      RegenerateKeys(Crypto* c);
 
       // load from file
       bool
@@ -39,20 +39,20 @@ namespace llarp
       BEncode(llarp_buffer_t* buf) const override;
 
       bool
-      EnsureKeys(const std::string& fpath, llarp::Crypto* c);
+      EnsureKeys(const std::string& fpath, Crypto* c);
 
       bool
-      KeyExchange(llarp::path_dh_func dh, SharedSecret& sharedkey,
+      KeyExchange(path_dh_func dh, SharedSecret& sharedkey,
                   const ServiceInfo& other, const KeyExchangeNonce& N) const;
 
       bool
       DecodeKey(const llarp_buffer_t& key, llarp_buffer_t* buf) override;
 
       bool
-      SignIntroSet(IntroSet& i, llarp::Crypto* c, llarp_time_t now) const;
+      SignIntroSet(IntroSet& i, Crypto* c, llarp_time_t now) const;
 
       bool
-      Sign(llarp::Crypto*, Signature& sig, const llarp_buffer_t& buf) const;
+      Sign(Crypto*, Signature& sig, const llarp_buffer_t& buf) const;
     };
   }  // namespace service
 }  // namespace llarp

--- a/llarp/service/Info.hpp
+++ b/llarp/service/Info.hpp
@@ -2,7 +2,8 @@
 #define LLARP_SERVICE_INFO_HPP
 
 #include <crypto/types.hpp>
-#include <service/types.hpp>
+#include <service/address.hpp>
+#include <service/vanity.hpp>
 #include <util/bencode.hpp>
 
 #include <absl/types/optional.h>
@@ -13,11 +14,11 @@ namespace llarp
 
   namespace service
   {
-    struct ServiceInfo final : public llarp::IBEncodeMessage
+    struct ServiceInfo final : public IBEncodeMessage
     {
      private:
-      llarp::PubKey enckey;
-      llarp::PubKey signkey;
+      PubKey enckey;
+      PubKey signkey;
 
      public:
       VanityNonce vanity;
@@ -52,7 +53,7 @@ namespace llarp
       }
 
       bool
-      Verify(llarp::Crypto* crypto, const llarp_buffer_t& payload,
+      Verify(Crypto* crypto, const llarp_buffer_t& payload,
              const Signature& sig) const;
 
       const PubKey&

--- a/llarp/service/Intro.cpp
+++ b/llarp/service/Intro.cpp
@@ -1,4 +1,4 @@
-#include <service/Intro.hpp>
+#include <service/intro.hpp>
 
 namespace llarp
 {

--- a/llarp/service/async_key_exchange.hpp
+++ b/llarp/service/async_key_exchange.hpp
@@ -2,7 +2,7 @@
 #define LLARP_SERVICE_ASYNC_KEY_EXCHANGE_HPP
 
 #include <crypto/types.hpp>
-#include <service/Identity.hpp>
+#include <service/identity.hpp>
 #include <service/protocol.hpp>
 
 namespace llarp

--- a/llarp/service/config.cpp
+++ b/llarp/service/config.cpp
@@ -9,12 +9,12 @@ namespace llarp
     bool
     Config::Load(const std::string& fname)
     {
-      llarp::ConfigParser parser;
+      ConfigParser parser;
       if(!parser.LoadFile(fname.c_str()))
         return false;
-      parser.IterAll([&](const llarp::ConfigParser::String_t& name,
-                         const llarp::ConfigParser::Section_t& section) {
-        llarp::service::Config::section_t values;
+      parser.IterAll([&](const ConfigParser::String_t& name,
+                         const ConfigParser::Section_t& section) {
+        Config::section_t values;
         values.first.assign(name.begin(), name.end());
         for(const auto& item : section)
           values.second.emplace_back(string_view_string(item.first),

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -118,12 +118,12 @@ namespace llarp
       return m_Endpoints.size() ? true : false;
     }
 
-    llarp::service::Endpoint *
+    service::Endpoint *
     Context::getFirstEndpoint()
     {
       if(!m_Endpoints.size())
       {
-        llarp::LogError("No endpoints found");
+        LogError("No endpoints found");
         return nullptr;
       }
       auto itr = m_Endpoints.begin();
@@ -137,11 +137,11 @@ namespace llarp
     {
       if(!m_Endpoints.size())
       {
-        llarp::LogError("No endpoints found");
+        LogError("No endpoints found");
         return false;
       }
       i.index = 0;
-      // llarp::util::Lock lock(access);
+      // util::Lock lock(access);
       auto itr = m_Endpoints.begin();
       while(itr != m_Endpoints.end())
       {
@@ -155,34 +155,34 @@ namespace llarp
       return true;
     }
 
-    llarp::handlers::TunEndpoint *
+    handlers::TunEndpoint *
     Context::getFirstTun()
     {
-      llarp::service::Endpoint *endpointer = this->getFirstEndpoint();
+      service::Endpoint *endpointer = this->getFirstEndpoint();
       if(!endpointer)
       {
         return nullptr;
       }
-      llarp::handlers::TunEndpoint *tunEndpoint =
-          static_cast< llarp::handlers::TunEndpoint * >(endpointer);
+      handlers::TunEndpoint *tunEndpoint =
+          static_cast< handlers::TunEndpoint * >(endpointer);
       return tunEndpoint;
     }
 
     llarp_tun_io *
     Context::getRange()
     {
-      llarp::handlers::TunEndpoint *tunEndpoint = this->getFirstTun();
+      handlers::TunEndpoint *tunEndpoint = this->getFirstTun();
       if(!tunEndpoint)
       {
-        llarp::LogError("No tunnel endpoint found");
+        LogError("No tunnel endpoint found");
         return nullptr;
       }
       return &tunEndpoint->tunif;
     }
 
     bool
-    Context::FindBestAddressFor(const llarp::AlignedBuffer< 32 > &addr,
-                                bool isSNode, huint32_t &ip)
+    Context::FindBestAddressFor(const AlignedBuffer< 32 > &addr, bool isSNode,
+                                huint32_t &ip)
     {
       auto itr = m_Endpoints.begin();
       while(itr != m_Endpoints.end())
@@ -204,12 +204,12 @@ namespace llarp
     }
 
     bool
-    Context::Prefetch(const llarp::service::Address &addr)
+    Context::Prefetch(const service::Address &addr)
     {
-      llarp::handlers::TunEndpoint *tunEndpoint = this->getFirstTun();
+      handlers::TunEndpoint *tunEndpoint = this->getFirstTun();
       if(!tunEndpoint)
       {
-        llarp::LogError("No tunnel endpoint found");
+        LogError("No tunnel endpoint found");
         return false;
       }
       // HiddenServiceAddresslookup *lookup = new
@@ -227,11 +227,11 @@ namespace llarp
     {
       Context::mapAddressAll_context *context =
           (Context::mapAddressAll_context *)endpointCfg->user;
-      llarp::handlers::TunEndpoint *tunEndpoint =
-          (llarp::handlers::TunEndpoint *)endpointCfg->endpoint;
+      handlers::TunEndpoint *tunEndpoint =
+          (handlers::TunEndpoint *)endpointCfg->endpoint;
       if(!tunEndpoint)
       {
-        llarp::LogError("No tunnel endpoint found");
+        LogError("No tunnel endpoint found");
         return true;  // still continue
       }
       return tunEndpoint->MapAddress(
@@ -239,8 +239,8 @@ namespace llarp
     }
 
     bool
-    Context::MapAddressAll(const llarp::service::Address &addr,
-                           llarp::Addr &localPrivateIpAddr)
+    Context::MapAddressAll(const service::Address &addr,
+                           Addr &localPrivateIpAddr)
     {
       struct Context::mapAddressAll_context context;
       context.serviceAddr        = addr;
@@ -278,10 +278,10 @@ namespace llarp
       {
         if(!itr->second->Start())
         {
-          llarp::LogError(itr->first, " failed to start");
+          LogError(itr->first, " failed to start");
           return false;
         }
-        llarp::LogInfo(itr->first, " started");
+        LogInfo(itr->first, " started");
         ++itr;
       }
       return true;
@@ -294,8 +294,8 @@ namespace llarp
         auto itr = m_Endpoints.find(conf.first);
         if(itr != m_Endpoints.end())
         {
-          llarp::LogError("cannot add hidden service with duplicate name: ",
-                          conf.first);
+          LogError("cannot add hidden service with duplicate name: ",
+                   conf.first);
           return false;
         }
       }
@@ -319,8 +319,7 @@ namespace llarp
           endpointConstructors = {
               {"tun",
                [](const std::string &nick, AbstractRouter *r,
-                  llarp::service::Context *c)
-                   -> std::unique_ptr< service::Endpoint > {
+                  service::Context *c) -> std::unique_ptr< service::Endpoint > {
                  return std::make_unique< handlers::TunEndpoint >(nick, r, c);
                }},
               {"null",
@@ -334,7 +333,7 @@ namespace llarp
         auto itr = endpointConstructors.find(endpointType);
         if(itr == endpointConstructors.end())
         {
-          llarp::LogError("no such endpoint type: ", endpointType);
+          LogError("no such endpoint type: ", endpointType);
           return false;
         }
 
@@ -348,7 +347,7 @@ namespace llarp
           service->SetOption("keyfile", keyfile);
           // load keyfile, so we have the correct name for logging
         }
-        llarp::LogInfo("Establishing endpoint identity");
+        LogInfo("Establishing endpoint identity");
         service->LoadKeyFile();  // only start endpoint not tun
         // now Name() will be correct
       }
@@ -361,8 +360,8 @@ namespace llarp
         auto &v = option.second;
         if(!service->SetOption(k, v))
         {
-          llarp::LogError("failed to set ", k, "=", v,
-                          " for hidden service endpoint ", conf.first);
+          LogError("failed to set ", k, "=", v, " for hidden service endpoint ",
+                   conf.first);
           return false;
         }
       }
@@ -371,17 +370,16 @@ namespace llarp
         // start
         if(service->Start())
         {
-          llarp::LogInfo("autostarting hidden service endpoint ",
-                         service->Name());
+          LogInfo("autostarting hidden service endpoint ", service->Name());
           m_Endpoints.emplace(conf.first, std::move(service));
           return true;
         }
-        llarp::LogError("failed to start hidden service endpoint ", conf.first);
+        LogError("failed to start hidden service endpoint ", conf.first);
         return false;
       }
       else
       {
-        llarp::LogInfo("added hidden service endpoint ", service->Name());
+        LogInfo("added hidden service endpoint ", service->Name());
         m_Endpoints.emplace(conf.first, std::move(service));
         return true;
       }

--- a/llarp/service/context.hpp
+++ b/llarp/service/context.hpp
@@ -15,7 +15,7 @@ namespace llarp
     /// holds all the hidden service endpoints we own
     struct Context
     {
-      Context(AbstractRouter *r);
+      explicit Context(AbstractRouter *r);
       ~Context();
 
       void
@@ -32,15 +32,15 @@ namespace llarp
       hasEndpoints();
 
       /// DRY refactor
-      llarp::service::Endpoint *
+      service::Endpoint *
       getFirstEndpoint();
 
       bool
-      FindBestAddressFor(const llarp::AlignedBuffer< 32 > &addr, bool isSNode,
+      FindBestAddressFor(const AlignedBuffer< 32 > &addr, bool isSNode,
                          huint32_t &);
 
       /// DRY refactor
-      llarp::handlers::TunEndpoint *
+      handlers::TunEndpoint *
       getFirstTun();
 
       /// punch a hole to get ip range from first tun endpoint
@@ -49,14 +49,14 @@ namespace llarp
 
       struct mapAddressAll_context
       {
-        llarp::service::Address serviceAddr;
-        llarp::Addr localPrivateIpAddr;
+        service::Address serviceAddr;
+        Addr localPrivateIpAddr;
       };
 
       struct endpoint_iter
       {
         void *user;
-        llarp::service::Endpoint *endpoint;
+        service::Endpoint *endpoint;
         size_t index;
         bool (*visit)(struct endpoint_iter *);
       };
@@ -72,11 +72,10 @@ namespace llarp
 
       /// hint at possible path usage and trigger building early
       bool
-      Prefetch(const llarp::service::Address &addr);
+      Prefetch(const service::Address &addr);
 
       bool
-      MapAddressAll(const llarp::service::Address &addr,
-                    llarp::Addr &localPrivateIpAddr);
+      MapAddressAll(const service::Address &addr, Addr &localPrivateIpAddr);
 
       /// add default endpoint with options
       bool

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -8,7 +8,7 @@
 #include <path/pathbuilder.hpp>
 #include <service/address.hpp>
 #include <service/handler.hpp>
-#include <service/Identity.hpp>
+#include <service/identity.hpp>
 #include <service/pendingbuffer.hpp>
 #include <service/protocol.hpp>
 #include <service/sendcontext.hpp>

--- a/llarp/service/handler.hpp
+++ b/llarp/service/handler.hpp
@@ -3,14 +3,14 @@
 
 #include <crypto/types.hpp>
 #include <path/path_types.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <util/aligned.hpp>
 
 namespace llarp
 {
   namespace service
   {
-    using ConvoTag = llarp::AlignedBuffer< 16 >;
+    using ConvoTag = AlignedBuffer< 16 >;
 
     struct ProtocolMessage;
     struct IDataHandler

--- a/llarp/service/hidden_service_address_lookup.hpp
+++ b/llarp/service/hidden_service_address_lookup.hpp
@@ -2,7 +2,7 @@
 #define LLARP_SERVICE_HIDDEN_SERVICE_ADDRESS_LOOKUP_HPP
 
 #include <messages/dht.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <service/lookup.hpp>
 
 namespace llarp

--- a/llarp/service/info.cpp
+++ b/llarp/service/info.cpp
@@ -1,4 +1,4 @@
-#include <service/Info.hpp>
+#include <service/info.hpp>
 
 #include <crypto/crypto.hpp>
 #include <service/address.hpp>
@@ -13,7 +13,7 @@ namespace llarp
   namespace service
   {
     bool
-    ServiceInfo::Verify(llarp::Crypto* crypto, const llarp_buffer_t& payload,
+    ServiceInfo::Verify(Crypto* crypto, const llarp_buffer_t& payload,
                         const Signature& sig) const
     {
       return crypto->verify(signkey, payload, sig);

--- a/llarp/service/intro_set.cpp
+++ b/llarp/service/intro_set.cpp
@@ -1,4 +1,4 @@
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 
 #include <path/path.hpp>
 
@@ -114,7 +114,7 @@ namespace llarp
     }
 
     bool
-    IntroSet::Verify(llarp::Crypto* crypto, llarp_time_t now) const
+    IntroSet::Verify(Crypto* crypto, llarp_time_t now) const
     {
       std::array< byte_t, MAX_INTROSET_SIZE > tmp;
       llarp_buffer_t buf(tmp);
@@ -153,14 +153,14 @@ namespace llarp
           }
           else if(W == nullptr)
           {
-            llarp::LogWarn("intro has too high expire time");
+            LogWarn("intro has too high expire time");
             return false;
           }
         }
       }
       if(IsExpired(now))
       {
-        llarp::LogWarn("introset expired: ", *this);
+        LogWarn("introset expired: ", *this);
         return false;
       }
       return true;

--- a/llarp/service/intro_set.hpp
+++ b/llarp/service/intro_set.hpp
@@ -1,10 +1,10 @@
-#ifndef LLARP_SERVICE_INTROSET_HPP
-#define LLARP_SERVICE_INTROSET_HPP
+#ifndef LLARP_SERVICE_INTRO_SET_HPP
+#define LLARP_SERVICE_INTRO_SET_HPP
 
 #include <crypto/types.hpp>
 #include <pow.hpp>
-#include <service/Info.hpp>
-#include <service/Intro.hpp>
+#include <service/info.hpp>
+#include <service/intro.hpp>
 #include <service/tag.hpp>
 #include <util/bencode.hpp>
 #include <util/time.hpp>

--- a/llarp/service/lookup.hpp
+++ b/llarp/service/lookup.hpp
@@ -2,7 +2,7 @@
 #define LLARP_SERVICE_LOOKUP_HPP
 
 #include <routing/message.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 
 #include <set>
 
@@ -48,7 +48,7 @@ namespace llarp
 
       /// build a new request message and send it via a path
       bool
-      SendRequestViaPath(llarp::path::Path* p, AbstractRouter* r);
+      SendRequestViaPath(path::Path* p, AbstractRouter* r);
 
       ILookupHolder* parent;
       uint64_t txid;
@@ -58,7 +58,7 @@ namespace llarp
       util::StatusObject
       ExtractStatus() const
       {
-        auto now = llarp::time_now_ms();
+        auto now = time_now_ms();
         util::StatusObject obj{{"txid", txid},
                                {"endpoint", endpoint.ToHex()},
                                {"name", name},

--- a/llarp/service/outbound_context.hpp
+++ b/llarp/service/outbound_context.hpp
@@ -81,7 +81,7 @@ namespace llarp
 
       bool
       SelectHop(llarp_nodedb* db, const RouterContact& prev, RouterContact& cur,
-                size_t hop, llarp::path::PathRole roles) override;
+                size_t hop, path::PathRole roles) override;
 
       bool
       HandleHiddenServiceFrame(path::Path* p, const ProtocolFrame& frame);

--- a/llarp/service/protocol.hpp
+++ b/llarp/service/protocol.hpp
@@ -5,9 +5,9 @@
 #include <crypto/types.hpp>
 #include <dht/message.hpp>
 #include <routing/message.hpp>
-#include <service/Identity.hpp>
-#include <service/Info.hpp>
-#include <service/Intro.hpp>
+#include <service/identity.hpp>
+#include <service/info.hpp>
+#include <service/intro.hpp>
 #include <service/handler.hpp>
 #include <util/bencode.hpp>
 #include <util/time.hpp>

--- a/llarp/service/sendcontext.cpp
+++ b/llarp/service/sendcontext.cpp
@@ -30,18 +30,17 @@ namespace llarp
         const routing::PathTransferMessage transfer(msg, remoteIntro.pathID);
         if(path->SendRoutingMessage(transfer, m_Endpoint->Router()))
         {
-          llarp::LogInfo("sent intro to ", remoteIntro.pathID, " on ",
-                         remoteIntro.router, " seqno=", sequenceNo);
+          LogInfo("sent intro to ", remoteIntro.pathID, " on ",
+                  remoteIntro.router, " seqno=", sequenceNo);
           lastGoodSend = m_Endpoint->Now();
           ++sequenceNo;
           return true;
         }
         else
-          llarp::LogError("Failed to send frame on path");
+          LogError("Failed to send frame on path");
       }
       else
-        llarp::LogError("cannot send because we have no path to ",
-                        remoteIntro.router);
+        LogError("cannot send because we have no path to ", remoteIntro.router);
       return false;
     }
 
@@ -63,14 +62,13 @@ namespace llarp
         // shift intro
         if(MarkCurrentIntroBad(now))
         {
-          llarp::LogInfo("intro shifted");
+          LogInfo("intro shifted");
         }
       }
       auto path = m_PathSet->GetNewestPathByRouter(remoteIntro.router);
       if(!path)
       {
-        llarp::LogError("cannot encrypt and send: no path for intro ",
-                        remoteIntro);
+        LogError("cannot encrypt and send: no path for intro ", remoteIntro);
         return;
       }
 
@@ -87,13 +85,13 @@ namespace llarp
         m.PutBuffer(payload);
         if(!f.EncryptAndSign(crypto, m, shared, m_Endpoint->GetIdentity()))
         {
-          llarp::LogError("failed to sign");
+          LogError("failed to sign");
           return;
         }
       }
       else
       {
-        llarp::LogError("No cached session key");
+        LogError("No cached session key");
         return;
       }
 
@@ -101,14 +99,14 @@ namespace llarp
       msg.Y.Randomize();
       if(path->SendRoutingMessage(msg, m_Endpoint->Router()))
       {
-        llarp::LogDebug("sent message via ", remoteIntro.pathID, " on ",
-                        remoteIntro.router);
+        LogDebug("sent message via ", remoteIntro.pathID, " on ",
+                 remoteIntro.router);
         ++sequenceNo;
         lastGoodSend = now;
       }
       else
       {
-        llarp::LogWarn("Failed to send routing message for data");
+        LogWarn("Failed to send routing message for data");
       }
     }
 
@@ -121,7 +119,7 @@ namespace llarp
       {
         if(!MarkCurrentIntroBad(now))
         {
-          llarp::LogWarn("no good path yet, your message may drop");
+          LogWarn("no good path yet, your message may drop");
         }
       }
       if(sequenceNo)

--- a/llarp/service/sendcontext.hpp
+++ b/llarp/service/sendcontext.hpp
@@ -2,7 +2,7 @@
 #define LLARP_SERVICE_SENDCONTEXT_HPP
 
 #include <path/pathset.hpp>
-#include <service/Intro.hpp>
+#include <service/intro.hpp>
 #include <service/protocol.hpp>
 #include <util/buffer.hpp>
 #include <util/types.hpp>

--- a/llarp/service/session.hpp
+++ b/llarp/service/session.hpp
@@ -3,8 +3,8 @@
 
 #include <crypto/types.hpp>
 #include <path/path.hpp>
-#include <service/Info.hpp>
-#include <service/Intro.hpp>
+#include <service/info.hpp>
+#include <service/intro.hpp>
 #include <util/status.hpp>
 #include <util/types.hpp>
 

--- a/llarp/service/tag.hpp
+++ b/llarp/service/tag.hpp
@@ -15,13 +15,13 @@ namespace llarp
 {
   namespace service
   {
-    struct Tag : public llarp::AlignedBuffer< 16 >
+    struct Tag : public AlignedBuffer< 16 >
     {
-      Tag() : llarp::AlignedBuffer< SIZE >()
+      Tag() : AlignedBuffer< SIZE >()
       {
       }
 
-      Tag(const byte_t* d) : llarp::AlignedBuffer< SIZE >(d)
+      Tag(const byte_t* d) : AlignedBuffer< SIZE >(d)
       {
       }
 

--- a/llarp/service/tag_lookup_job.hpp
+++ b/llarp/service/tag_lookup_job.hpp
@@ -2,7 +2,7 @@
 #define LLARP_SERVICE_TAG_LOOKUP_JOB_HPP
 
 #include <routing/message.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <service/lookup.hpp>
 #include <service/tag.hpp>
 #include <util/types.hpp>

--- a/llarp/service/types.cpp
+++ b/llarp/service/types.cpp
@@ -1,1 +1,0 @@
-#include <service/types.hpp>

--- a/llarp/service/types.hpp
+++ b/llarp/service/types.hpp
@@ -1,6 +1,0 @@
-#ifndef LLARP_SERVICE_TYPES_HPP
-#define LLARP_SERVICE_TYPES_HPP
-#include <service/address.hpp>
-#include <service/vanity.hpp>
-
-#endif

--- a/llarp/service/vanity.hpp
+++ b/llarp/service/vanity.hpp
@@ -10,7 +10,7 @@ namespace llarp
   {
     /// hidden service address
 
-    using VanityNonce = llarp::AlignedBuffer< 16 >;
+    using VanityNonce = AlignedBuffer< 16 >;
   }  // namespace service
 }  // namespace llarp
 #endif

--- a/test/dht/test_llarp_dht_serviceaddresslookup.cpp
+++ b/test/dht/test_llarp_dht_serviceaddresslookup.cpp
@@ -3,7 +3,7 @@
 #include <crypto/mock_crypto.hpp>
 #include <dht/mock_context.hpp>
 #include <dht/messages/gotintro.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <test_util.hpp>
 
 #include <gtest/gtest.h>

--- a/test/dht/test_llarp_dht_taglookup.cpp
+++ b/test/dht/test_llarp_dht_taglookup.cpp
@@ -3,7 +3,7 @@
 #include <crypto/mock_crypto.hpp>
 #include <dht/mock_context.hpp>
 #include <dht/messages/gotintro.hpp>
-#include <service/IntroSet.hpp>
+#include <service/intro_set.hpp>
 #include <test_util.hpp>
 
 #include <gtest/gtest.h>

--- a/test/service/test_llarp_service_identity.cpp
+++ b/test/service/test_llarp_service_identity.cpp
@@ -2,8 +2,8 @@
 #include <crypto/crypto_libsodium.hpp>
 #include <path/path.hpp>
 #include <service/address.hpp>
-#include <service/Identity.hpp>
-#include <service/IntroSet.hpp>
+#include <service/identity.hpp>
+#include <service/intro_set.hpp>
 #include <util/time.hpp>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
this is mostly a few minor tweaks to fix up stuff.

- remove the `llarp/service/types` component
- remove unrequired `llarp::` bits
- removing casing from headers. this caused weirdness for me previously when i moved to a case insensitive FS (boo 🍏)