### PR TITLE
Refactor well named functionality in service::Endpoint into new struct

### DIFF
--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -217,6 +217,7 @@ set(LIB_SRC
   service/async_key_exchange.cpp
   service/config.cpp
   service/context.cpp
+  service/endpoint_util.cpp
   service/endpoint.cpp
   service/handler.cpp
   service/hidden_service_address_lookup.cpp

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -332,6 +332,8 @@ namespace llarp
       std::unique_ptr< exit::BaseSession > m_Exit;
 
      private:
+      friend struct EndpointUtil;
+
       AbstractRouter* m_Router;
       llarp_threadpool* m_IsolatedWorker  = nullptr;
       Logic* m_IsolatedLogic              = nullptr;
@@ -387,8 +389,9 @@ namespace llarp
         }
       };
 
-      std::unordered_map< RouterID, RouterLookupJob, RouterID::Hash >
-          m_PendingRouters;
+      using PendingRouters =
+          std::unordered_map< RouterID, RouterLookupJob, RouterID::Hash >;
+      PendingRouters m_PendingRouters;
 
       uint64_t m_CurrentPublishTX       = 0;
       llarp_time_t m_LastPublish        = 0;
@@ -397,8 +400,10 @@ namespace llarp
       /// our introset
       service::IntroSet m_IntroSet;
       /// pending remote service lookups by id
-      std::unordered_map< uint64_t, std::unique_ptr< service::IServiceLookup > >
-          m_PendingLookups;
+      using PendingLookups =
+          std::unordered_map< uint64_t,
+                              std::unique_ptr< service::IServiceLookup > >;
+      PendingLookups m_PendingLookups;
       /// prefetch remote address list
       std::set< Address > m_PrefetchAddrs;
       /// hidden service tag
@@ -409,10 +414,9 @@ namespace llarp
       std::list< std::function< bool(void) > > m_OnInit;
 
       /// conversations
-      using ConvoMap_t =
-          std::unordered_map< ConvoTag, Session, ConvoTag::Hash >;
+      using ConvoMap = std::unordered_map< ConvoTag, Session, ConvoTag::Hash >;
 
-      ConvoMap_t m_Sessions;
+      ConvoMap m_Sessions;
 
       std::unordered_map< Tag, CachedTagResult, Tag::Hash > m_PrefetchedTags;
     };

--- a/llarp/service/endpoint_util.cpp
+++ b/llarp/service/endpoint_util.cpp
@@ -1,0 +1,153 @@
+#include <service/endpoint_util.hpp>
+
+#include <service/outbound_context.hpp>
+#include <util/logger.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    void
+    EndpointUtil::ExpireSNodeSessions(llarp_time_t now,
+                                      Endpoint::SNodeSessions& sessions)
+    {
+      auto itr = sessions.begin();
+      while(itr != sessions.end())
+      {
+        if(itr->second->ShouldRemove() && itr->second->IsStopped())
+        {
+          itr = sessions.erase(itr);
+          continue;
+        }
+        // expunge next tick
+        if(itr->second->IsExpired(now))
+        {
+          itr->second->Stop();
+        }
+
+        ++itr;
+      }
+    }
+
+    void
+    EndpointUtil::ExpirePendingTx(llarp_time_t now,
+                                  Endpoint::PendingLookups& lookups)
+    {
+      for(auto itr = lookups.begin(); itr != lookups.end();)
+      {
+        if(!itr->second->IsTimedOut(now))
+        {
+          ++itr;
+          continue;
+        }
+        std::unique_ptr< IServiceLookup > lookup = std::move(itr->second);
+
+        LogInfo(lookup->name, " timed out txid=", lookup->txid);
+        lookup->HandleResponse({});
+        itr = lookups.erase(itr);
+      }
+    }
+
+    void
+    EndpointUtil::ExpirePendingRouterLookups(llarp_time_t now,
+                                             Endpoint::PendingRouters& routers)
+    {
+      for(auto itr = routers.begin(); itr != routers.end();)
+      {
+        if(!itr->second.IsExpired(now))
+        {
+          ++itr;
+          continue;
+        }
+        LogInfo("lookup for ", itr->first, " timed out");
+        itr = routers.erase(itr);
+      }
+    }
+
+    void
+    EndpointUtil::DeregisterDeadSessions(llarp_time_t now,
+                                         Endpoint::Sessions& sessions)
+    {
+      auto itr = sessions.begin();
+      while(itr != sessions.end())
+      {
+        if(itr->second->IsDone(now))
+        {
+          itr = sessions.erase(itr);
+        }
+        else
+        {
+          ++itr;
+        }
+      }
+    }
+
+    void
+    EndpointUtil::TickRemoteSessions(llarp_time_t now,
+                                     Endpoint::Sessions& remoteSessions,
+                                     Endpoint::Sessions& deadSessions)
+    {
+      auto itr = remoteSessions.begin();
+      while(itr != remoteSessions.end())
+      {
+        if(itr->second->Tick(now))
+        {
+          itr->second->Stop();
+          deadSessions.emplace(std::move(*itr));
+          itr = remoteSessions.erase(itr);
+        }
+        else
+        {
+          ++itr;
+        }
+      }
+    }
+
+    void
+    EndpointUtil::ExpireConvoSessions(llarp_time_t now,
+                                      Endpoint::ConvoMap& sessions)
+    {
+      auto itr = sessions.begin();
+      while(itr != sessions.end())
+      {
+        if(itr->second.IsExpired(now))
+          itr = sessions.erase(itr);
+        else
+          ++itr;
+      }
+    }
+
+    void
+    EndpointUtil::StopRemoteSessions(Endpoint::Sessions& remoteSessions)
+    {
+      for(auto& item : remoteSessions)
+      {
+        item.second->Stop();
+      }
+    }
+
+    void
+    EndpointUtil::StopSnodeSessions(Endpoint::SNodeSessions& sessions)
+    {
+      for(auto& item : sessions)
+      {
+        item.second->Stop();
+      }
+    }
+
+    bool
+    EndpointUtil::HasPathToService(const Address& addr,
+                                   const Endpoint::Sessions& remoteSessions)
+    {
+      auto range = remoteSessions.equal_range(addr);
+      auto itr   = range.first;
+      while(itr != range.second)
+      {
+        if(itr->second->ReadyToSend())
+          return true;
+        ++itr;
+      }
+      return false;
+    }
+  }  // namespace service
+}  // namespace llarp

--- a/llarp/service/endpoint_util.hpp
+++ b/llarp/service/endpoint_util.hpp
@@ -1,0 +1,46 @@
+#ifndef LLARP_SERVICE_ENDPOINT_UTIL_HPP
+#define LLARP_SERVICE_ENDPOINT_UTIL_HPP
+
+#include <service/endpoint.hpp>
+
+namespace llarp
+{
+  namespace service
+  {
+    struct EndpointUtil
+    {
+      static void
+      ExpireSNodeSessions(llarp_time_t now, Endpoint::SNodeSessions& sessions);
+
+      static void
+      ExpirePendingTx(llarp_time_t now, Endpoint::PendingLookups& lookups);
+
+      static void
+      ExpirePendingRouterLookups(llarp_time_t now,
+                                 Endpoint::PendingRouters& routers);
+
+      static void
+      DeregisterDeadSessions(llarp_time_t now, Endpoint::Sessions& sessions);
+
+      static void
+      TickRemoteSessions(llarp_time_t now, Endpoint::Sessions& remoteSessions,
+                         Endpoint::Sessions& deadSessions);
+
+      static void
+      ExpireConvoSessions(llarp_time_t now, Endpoint::ConvoMap& sessions);
+
+      static void
+      StopRemoteSessions(Endpoint::Sessions& remoteSessions);
+
+      static void
+      StopSnodeSessions(Endpoint::SNodeSessions& sessions);
+
+      static bool
+      HasPathToService(const Address& addr,
+                       const Endpoint::Sessions& remoteSessions);
+    };
+  }  // namespace service
+
+}  // namespace llarp
+
+#endif


### PR DESCRIPTION
Does two things:
- simplifies logic in the main class
- makes these things more testable/composable