### PR TITLE
correct function behavior

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1848,7 +1848,13 @@ namespace llarp
   bool
   Router::HasSessionTo(const RouterID &remote) const
   {
-    return validRouters.find(remote) != validRouters.end();
+    for(const auto & link : outboundLinks)
+      if(link->HasSessionTo(remote))
+        return true;
+    for(const auto & link : inboundLinks)
+      if(link->HasSessionTo(remote))
+        return true;
+    return false;
   }
 
   void


### PR DESCRIPTION
i dont know why i didn't see this before but this was not the correct behavior `._.`