### PR TITLE
[WIP] Path build status messages

### DIFF
--- a/docs/proto_v0.txt
+++ b/docs/proto_v0.txt
@@ -344,11 +344,11 @@ request a commit to relay traffic to another node.
 
 {
   a: "c",
-  c: [ list, of, encrypted, frames ],
+  c: [ list, of, encrypted, LRCR frames ],
   v: 0
 }
 
-c and r MUST contain dummy records if the hop length is less than the maximum
+c MUST contain dummy records if the hop length is less than the maximum
 hop length.
 
 link relay commit record (LRCR)
@@ -365,7 +365,7 @@ the path is extended by w.y seconds
 
 {
   c: "<32 byte public encryption key used for upstream>",
-  d: uint_optional_ms_delay,
+  d: uint_optional_ms_delay,  // TODO
   i: "<32 byte RC.k of next hop>",
   l: uint_optional_lifespan,
   n: "<32 bytes nounce for key exchange>",
@@ -395,6 +395,39 @@ this proof of work requirement is subject to change
 
 if i is equal to RC.k then any LRDM.x values are decrypted and interpreted as
 routing layer messages. This indicates that we are the farthest hop in the path.
+
+link relay status message (LRSM)
+
+response to path creator about build status
+
+{
+  a: "s",
+  c: [ list, of, encrypted, LRSR frames],
+  p: "<16 bytes rx path id>",
+  s: uint_status_flags, // for now, only set (or don't) success bit
+  v: 0
+}
+
+the creator of the LRSM MUST include dummy LRSR records
+to pad out to the maximum path length
+
+link relay status record (LRSR)
+
+record indicating status of path build
+
+{
+  s: uint_status_flags,
+  v: 0
+}
+
+uint_status_flags (bitwise booleans):
+  [0] = success
+  [1] = fail, hop timeout
+  [2] = fail, congestion
+  [3] = fail, refusal, next hop is not known to be a snode
+  [4] = fail, used by hop creator when decrypting frames if decryption fails
+  [5] = fail, used by hop creator when record decode fails
+  [4-63] reserved
 
 link relay upstream message (LRUM)
 

--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -182,6 +182,7 @@ set(LIB_SRC
   messages/link_message.cpp
   messages/relay.cpp
   messages/relay_commit.cpp
+  messages/relay_status.cpp
   net/address_info.cpp
   net/exit_info.cpp
   net/ip.cpp

--- a/llarp/crypto/encrypted_frame.cpp
+++ b/llarp/crypto/encrypted_frame.cpp
@@ -7,41 +7,30 @@
 namespace llarp
 {
   bool
-  EncryptedFrame::EncryptInPlace(const SecretKey& ourSecretKey,
-                                 const PubKey& otherPubkey)
+  EncryptedFrame::DoEncrypt(const SharedSecret& shared, bool noDH)
   {
-    // format of frame is
-    // <32 bytes keyed hash of following data>
-    // <32 bytes nonce>
-    // <32 bytes pubkey>
-    // <N bytes encrypted payload>
-    //
     byte_t* hash     = data();
     byte_t* noncePtr = hash + SHORTHASHSIZE;
     byte_t* pubkey   = noncePtr + TUNNONCESIZE;
     byte_t* body     = pubkey + PUBKEYSIZE;
 
-    SharedSecret shared;
+    auto crypto = CryptoManager::instance();
+
+    // if noDH flag, means key exchange has already taken place
+    // in this case, set pubkey to random noise and choose a
+    // random nonce here
+    if (noDH)
+    {
+      crypto->randbytes(noncePtr, TUNNONCESIZE);
+      crypto->randbytes(pubkey, PUBKEYSIZE);
+    }
+
+    TunnelNonce nonce(noncePtr);
 
     llarp_buffer_t buf;
     buf.base = body;
     buf.cur  = buf.base;
     buf.sz   = size() - EncryptedFrameOverheadSize;
-
-    auto crypto = CryptoManager::instance();
-
-    // set our pubkey
-    memcpy(pubkey, ourSecretKey.toPublic().data(), PUBKEYSIZE);
-    // randomize nonce
-    crypto->randbytes(noncePtr, TUNNONCESIZE);
-    TunnelNonce nonce(noncePtr);
-
-    // derive shared key
-    if(!crypto->dh_client(shared, otherPubkey, ourSecretKey, nonce))
-    {
-      llarp::LogError("DH failed");
-      return false;
-    }
 
     // encrypt body
     if(!crypto->xchacha20(buf, shared, nonce))
@@ -60,11 +49,13 @@ namespace llarp
       llarp::LogError("Failed to generate message auth");
       return false;
     }
+
     return true;
   }
 
   bool
-  EncryptedFrame::DecryptInPlace(const SecretKey& ourSecretKey)
+  EncryptedFrame::EncryptInPlace(const SecretKey& ourSecretKey,
+                                 const PubKey& otherPubkey)
   {
     // format of frame is
     // <32 bytes keyed hash of following data>
@@ -72,22 +63,39 @@ namespace llarp
     // <32 bytes pubkey>
     // <N bytes encrypted payload>
     //
-    ShortHash hash(data());
-    byte_t* noncePtr = data() + SHORTHASHSIZE;
-    byte_t* body     = data() + EncryptedFrameOverheadSize;
-    TunnelNonce nonce(noncePtr);
-    PubKey otherPubkey(noncePtr + TUNNONCESIZE);
+    byte_t* hash     = data();
+    byte_t* noncePtr = hash + SHORTHASHSIZE;
+    byte_t* pubkey   = noncePtr + TUNNONCESIZE;
 
     SharedSecret shared;
 
     auto crypto = CryptoManager::instance();
 
-    // use dh_server because we are not the creator of this message
-    if(!crypto->dh_server(shared, otherPubkey, ourSecretKey, nonce))
+    // set our pubkey
+    memcpy(pubkey, ourSecretKey.toPublic().data(), PUBKEYSIZE);
+    // randomize nonce
+    crypto->randbytes(noncePtr, TUNNONCESIZE);
+    TunnelNonce nonce(noncePtr);
+
+    // derive shared key
+    if(!crypto->dh_client(shared, otherPubkey, ourSecretKey, nonce))
     {
       llarp::LogError("DH failed");
       return false;
     }
+
+    return DoEncrypt(shared, false);
+  }
+
+  bool
+  EncryptedFrame::DoDecrypt(const SharedSecret& shared)
+  {
+    ShortHash hash(data());
+    byte_t* noncePtr = data() + SHORTHASHSIZE;
+    byte_t* body     = data() + EncryptedFrameOverheadSize;
+    TunnelNonce nonce(noncePtr);
+
+    auto crypto = CryptoManager::instance();
 
     llarp_buffer_t buf;
     buf.base = noncePtr;
@@ -116,6 +124,34 @@ namespace llarp
       llarp::LogError("decrypt failed");
       return false;
     }
+
     return true;
+  }
+
+  bool
+  EncryptedFrame::DecryptInPlace(const SecretKey& ourSecretKey)
+  {
+    // format of frame is
+    // <32 bytes keyed hash of following data>
+    // <32 bytes nonce>
+    // <32 bytes pubkey>
+    // <N bytes encrypted payload>
+    //
+    byte_t* noncePtr = data() + SHORTHASHSIZE;
+    TunnelNonce nonce(noncePtr);
+    PubKey otherPubkey(noncePtr + TUNNONCESIZE);
+
+    SharedSecret shared;
+
+    auto crypto = CryptoManager::instance();
+
+    // use dh_server because we are not the creator of this message
+    if(!crypto->dh_server(shared, otherPubkey, ourSecretKey, nonce))
+    {
+      llarp::LogError("DH failed");
+      return false;
+    }
+
+    return DoDecrypt(shared);
   }
 }  // namespace llarp

--- a/llarp/crypto/encrypted_frame.hpp
+++ b/llarp/crypto/encrypted_frame.hpp
@@ -38,7 +38,13 @@ namespace llarp
     }
 
     bool
+    DoEncrypt(const SharedSecret& shared, bool noDH = false);
+
+    bool
     DecryptInPlace(const SecretKey& seckey);
+
+    bool
+    DoDecrypt(const SharedSecret& shared);
 
     bool
     EncryptInPlace(const SecretKey& seckey, const PubKey& other);

--- a/llarp/messages/link_message_parser.cpp
+++ b/llarp/messages/link_message_parser.cpp
@@ -5,6 +5,7 @@
 #include <messages/link_intro.hpp>
 #include <messages/link_message.hpp>
 #include <messages/relay_commit.hpp>
+#include <messages/relay_status.hpp>
 #include <messages/relay.hpp>
 #include <router_contact.hpp>
 #include <util/buffer.hpp>
@@ -22,6 +23,7 @@ namespace llarp
     RelayUpstreamMessage u;
     DHTImmediateMessage m;
     LR_CommitMessage c;
+    LR_StatusMessage s;
     DiscardMessage x;
 
     msg_holder_t() = default;
@@ -87,6 +89,9 @@ namespace llarp
           break;
         case 'c':
           msg = &holder->c;
+          break;
+        case 's':
+          msg = &holder->s;
           break;
         case 'x':
           msg = &holder->x;

--- a/llarp/messages/relay_commit.cpp
+++ b/llarp/messages/relay_commit.cpp
@@ -1,4 +1,5 @@
 #include <messages/relay_commit.hpp>
+#include <messages/relay_status.hpp>
 
 #include <crypto/crypto.hpp>
 #include <nodedb.hpp>
@@ -257,9 +258,17 @@ namespace llarp
           self->hop->info.downstream, self->hop->ExpireTime() + 10000);
       // put hop
       self->context->PutTransitHop(self->hop);
+
       // send path confirmation
-      const llarp::routing::PathConfirmMessage confirm(self->hop->lifetime);
-      if(!self->hop->SendRoutingMessage(confirm, self->context->Router()))
+      //TODO: other status flags?
+      uint64_t status = LR_StatusRecord::SUCCESS;
+
+      if (!LR_StatusMessage::CreateAndSend(self->context->Router(),
+                                           self->hop->info.rxID,
+                                           self->hop->info.downstream,
+                                           self->hop->pathKey,
+                                           status)
+         )
       {
         llarp::LogError("failed to send path confirmation for ",
                         self->hop->info);

--- a/llarp/messages/relay_status.cpp
+++ b/llarp/messages/relay_status.cpp
@@ -1,0 +1,295 @@
+#include <messages/relay_status.hpp>
+
+#include <crypto/crypto.hpp>
+#include <path/path_context.hpp>
+#include <path/ihophandler.hpp>
+#include <router/abstractrouter.hpp>
+#include <routing/path_confirm_message.hpp>
+#include <util/bencode.hpp>
+#include <util/buffer.hpp>
+#include <util/logger.hpp>
+#include <util/logic.hpp>
+
+#include <functional>
+
+namespace llarp
+{
+  struct LRSM_AsyncHandler : public std::enable_shared_from_this< LRSM_AsyncHandler >
+  {
+    using HopHandler_ptr = std::shared_ptr< llarp::path::IHopHandler >;
+
+    std::array< EncryptedFrame, 8 > frames;
+    PathID_t pathid;
+    uint64_t status = 0;
+    HopHandler_ptr path;
+    AbstractRouter *router;
+
+    LRSM_AsyncHandler(const std::array< EncryptedFrame, 8> &_frames,
+                      const PathID_t& _pathid, uint64_t _status,
+                      HopHandler_ptr _path, AbstractRouter *_router)
+        : frames(_frames), pathid(_pathid), status(_status), path(_path), router(_router)
+    {
+    }
+
+    ~LRSM_AsyncHandler()
+    {
+    }
+
+    void handle()
+    {
+      path->HandleLRSM(status, frames, router);
+    }
+
+    void queue_handle()
+    {
+      auto func = std::bind(&llarp::LRSM_AsyncHandler::handle, shared_from_this());
+      llarp_threadpool_queue_job(router->pathContext().Worker(), func);
+    }
+
+  };
+
+
+  LR_StatusMessage::~LR_StatusMessage()
+  {
+  }
+
+  bool
+  LR_StatusMessage::DecodeKey(const llarp_buffer_t& key, llarp_buffer_t* buf)
+  {
+    bool read = false;
+    if(key == "c")
+    {
+      return BEncodeReadArray(frames, buf);
+    }
+    else if(key == "p")
+    {
+      if (!BEncodeMaybeReadDictEntry("p", pathid, read, key, buf))
+      {
+        return false;
+      }
+    }
+    else if(key == "s")
+    {
+      if (!BEncodeMaybeReadDictInt("s", status, read, key, buf))
+      {
+        return false;
+      }
+    }
+    else if(key == "v")
+    {
+      if(!BEncodeMaybeReadVersion("v", version, LLARP_PROTO_VERSION, read, key,
+                                  buf))
+      {
+        return false;
+      }
+    }
+
+    return read;
+  }
+
+  void
+  LR_StatusMessage::Clear()
+  {
+    frames[0].Clear();
+    frames[1].Clear();
+    frames[2].Clear();
+    frames[3].Clear();
+    frames[4].Clear();
+    frames[5].Clear();
+    frames[6].Clear();
+    frames[7].Clear();
+  }
+
+  bool
+  LR_StatusMessage::BEncode(llarp_buffer_t* buf) const
+  {
+    if(!bencode_start_dict(buf))
+      return false;
+    // msg type
+    if(!BEncodeWriteDictMsgType(buf, "a", "s"))
+      return false;
+    // frames
+    if(!BEncodeWriteDictArray("c", frames, buf))
+      return false;
+    // path id
+    if(!BEncodeWriteDictEntry("p", pathid, buf))
+      return false;
+    // status (for now, only success bit is relevant)
+    if(!BEncodeWriteDictInt("s", status, buf))
+      return false;
+    // version
+    if(!bencode_write_version_entry(buf))
+      return false;
+
+    return bencode_end(buf);
+  }
+
+  bool
+  LR_StatusMessage::HandleMessage(AbstractRouter* router) const
+  {
+    llarp::LogDebug("Received LR_Status message from (", session->GetPubKey(), ")");
+    if(frames.size() != path::max_len)
+    {
+      llarp::LogError("LRSM invalid number of records, ", frames.size(),
+                      "!=", path::max_len);
+      return false;
+    }
+
+    auto path = router->pathContext().GetByUpstream(session->GetPubKey(), pathid);
+    if (!path)
+    {
+      llarp::LogWarn("unhandled LR_Status message: no associated IHopHandler found");
+      return false;
+    }
+
+    auto handler = std::make_shared< LRSM_AsyncHandler >(
+        frames, pathid, status, path, router);
+
+    handler->queue_handle();
+
+    return true;
+  }
+
+  void LR_StatusMessage::SetDummyFrames()
+  {
+    //TODO
+    return;
+  }
+
+  // call this from a worker thread
+  bool
+  LR_StatusMessage::CreateAndSend(AbstractRouter *router, const PathID_t pathid,
+                                  const RouterID nextHop, const SharedSecret pathKey,
+                                  uint64_t status)
+  {
+    typedef std::shared_ptr< LR_StatusMessage > LRSM_ptr;
+    LRSM_ptr message = std::make_shared< LR_StatusMessage >();
+
+    message->status = status & LR_StatusRecord::SUCCESS;
+    message->pathid = pathid;
+
+    message->SetDummyFrames();
+
+    if(!message->AddFrame(pathKey, status))
+    {
+      return false;
+    }
+
+    QueueSendMessage(router, nextHop, message);
+    return true; // can't guarantee delivery here, as far as we know it's fine
+  }
+
+  bool
+  LR_StatusMessage::AddFrame(const SharedSecret& pathKey, uint64_t status)
+  {
+    frames[7] = frames[6];
+    frames[6] = frames[5];
+    frames[5] = frames[4];
+    frames[4] = frames[3];
+    frames[3] = frames[2];
+    frames[2] = frames[1];
+    frames[1] = frames[0];
+
+    auto& frame = frames[0];
+
+    frame.Randomize();
+
+    LR_StatusRecord record;
+
+    record.status    = status;
+    record.version     = LLARP_PROTO_VERSION;
+
+    llarp_buffer_t buf(frame.data(), frame.size());
+    buf.cur = buf.base + EncryptedFrameOverheadSize;
+    // encode record
+    if(!record.BEncode(&buf))
+    {
+      // failed to encode?
+      LogError(Name(), " Failed to generate Status Record");
+      DumpBuffer(buf);
+      return false;
+    }
+    // use ephemeral keypair for frame
+    if(!frame.DoEncrypt(pathKey, true))
+    {
+      LogError(Name(), " Failed to encrypt LRSR");
+      DumpBuffer(buf);
+      return false;
+    }
+
+    return true;
+  }
+
+  void
+  LR_StatusMessage::QueueSendMessage(AbstractRouter *router, const RouterID nextHop,
+                   std::shared_ptr< LR_StatusMessage > msg)
+  {
+    auto func = std::bind(&LR_StatusMessage::SendMessage, router, nextHop, msg); 
+    router->pathContext().logic()->queue_func(func);
+  }
+
+  void
+  LR_StatusMessage::SendMessage(AbstractRouter *router, const RouterID nextHop,
+                                std::shared_ptr< LR_StatusMessage > msg)
+  {
+    llarp::LogDebug("Attempting to send LR_Status message to (", nextHop, ")");
+    if(router->HasSessionTo(nextHop))
+    {
+      if (router->SendToOrQueue(nextHop, msg.get()))
+      {
+        return;
+      }
+      llarp::LogError("Sending LR_Status message, SendToOrQueue to ", nextHop, " failed");
+      return;
+    }
+    llarp::LogError("Sending LR_Status message, but no connection to previous hop (", nextHop, ")");
+    return;
+  }
+
+  bool
+  LR_StatusRecord::BEncode(llarp_buffer_t* buf) const
+  {
+    if(!bencode_start_dict(buf))
+      return false;
+
+    if(!BEncodeWriteDictInt("s", status, buf))
+      return false;
+    if(!bencode_write_version_entry(buf))
+      return false;
+
+    return bencode_end(buf);
+  }
+
+  bool
+  LR_StatusRecord::OnKey(llarp_buffer_t* buffer, llarp_buffer_t* key)
+  {
+    if(!key)
+      return true;
+
+    bool read = false;
+
+    if(!BEncodeMaybeReadDictInt("s", status, read, *key, buffer))
+      return false;
+    if(!BEncodeMaybeReadVersion("v", version, LLARP_PROTO_VERSION, read, *key,
+                                buffer))
+      return false;
+
+    return read;
+  }
+
+  bool
+  LR_StatusRecord::BDecode(llarp_buffer_t* buf)
+  {
+    using namespace std::placeholders;
+    return bencode_read_dict(std::bind(&LR_StatusRecord::OnKey, this, _1, _2),
+                             buf);
+  }
+
+  bool
+  LR_StatusRecord::operator==(const LR_StatusRecord& other) const
+  {
+    return status == other.status;
+  }
+
+
+}  // namespace llarp

--- a/llarp/messages/relay_status.hpp
+++ b/llarp/messages/relay_status.hpp
@@ -59,11 +59,9 @@ namespace llarp
     {
     }
 
-    LR_StatusMessage() : ILinkMessage()
-    {
-    }
+    LR_StatusMessage() = default;
 
-    ~LR_StatusMessage();
+    ~LR_StatusMessage() = default;
 
     void
     Clear() override;

--- a/llarp/messages/relay_status.hpp
+++ b/llarp/messages/relay_status.hpp
@@ -1,0 +1,107 @@
+#ifndef LLARP_RELAY_STATUS_HPP
+#define LLARP_RELAY_STATUS_HPP
+
+#include <crypto/encrypted_frame.hpp>
+#include <crypto/types.hpp>
+#include <messages/link_message.hpp>
+#include <path/path_types.hpp>
+#include <pow.hpp>
+
+#include <array>
+#include <memory>
+
+namespace llarp
+{
+  // forward declare
+  struct AbstractRouter;
+  namespace path
+  {
+    struct PathContext;
+    struct IHopHandler;
+  }
+
+  struct LR_StatusRecord
+  {
+    static constexpr uint64_t SUCCESS = 1;
+    static constexpr uint64_t FAIL_TIMEOUT = 1 << 1;
+    static constexpr uint64_t FAIL_CONGESTION = 1 << 2;
+    static constexpr uint64_t FAIL_DEST_UNKNOWN = 1 << 3;
+    static constexpr uint64_t FAIL_DECRYPT_ERROR = 1 << 4;
+    static constexpr uint64_t FAIL_MALFORMED_RECORD = 1 << 5;
+
+    uint64_t status = 0;
+    uint64_t version  = 0;
+
+    bool
+    BDecode(llarp_buffer_t *buf);
+
+    bool
+    BEncode(llarp_buffer_t *buf) const;
+
+    bool
+    operator==(const LR_StatusRecord &other) const;
+
+   private:
+    bool
+    OnKey(llarp_buffer_t *buffer, llarp_buffer_t *key);
+  };
+
+  struct LR_StatusMessage : public ILinkMessage
+  {
+    std::array< EncryptedFrame, 8 > frames;
+
+    PathID_t pathid;
+
+    uint64_t status = 0;
+
+    LR_StatusMessage(const std::array< EncryptedFrame, 8 > &_frames)
+        : ILinkMessage(), frames(_frames)
+    {
+    }
+
+    LR_StatusMessage() : ILinkMessage()
+    {
+    }
+
+    ~LR_StatusMessage();
+
+    void
+    Clear() override;
+
+    bool
+    DecodeKey(const llarp_buffer_t &key, llarp_buffer_t *buf) override;
+
+    bool
+    BEncode(llarp_buffer_t *buf) const override;
+
+    bool
+    HandleMessage(AbstractRouter *router) const override;
+
+    void
+    SetDummyFrames();
+
+    static bool
+    CreateAndSend(AbstractRouter *router, const PathID_t pathid,
+                  const RouterID nextHop, const SharedSecret pathKey,
+                  uint64_t status);
+
+    bool
+    AddFrame(const SharedSecret& pathKey, uint64_t status);
+
+    static void
+    QueueSendMessage(AbstractRouter *router, const RouterID nextHop,
+                     std::shared_ptr< LR_StatusMessage > msg);
+
+    static void
+    SendMessage(AbstractRouter *router, const RouterID nextHop,
+                std::shared_ptr< LR_StatusMessage > msg);
+
+    const char *
+    Name() const override
+    {
+      return "RelayStatus";
+    }
+  };
+}  // namespace llarp
+
+#endif

--- a/llarp/path/ihophandler.hpp
+++ b/llarp/path/ihophandler.hpp
@@ -3,6 +3,7 @@
 
 #include <crypto/types.hpp>
 #include <util/types.hpp>
+#include <crypto/encrypted_frame.hpp>
 
 #include <memory>
 
@@ -48,6 +49,10 @@ namespace llarp
       /// return timestamp last remote activity happened at
       virtual llarp_time_t
       LastRemoteActivityAt() const = 0;
+
+      virtual bool
+      HandleLRSM(uint64_t status, std::array< EncryptedFrame, 8 >& frames,
+                 AbstractRouter* r) = 0;
 
       uint64_t
       NextSeqNo()

--- a/llarp/path/path.hpp
+++ b/llarp/path/path.hpp
@@ -156,6 +156,10 @@ namespace llarp
         return m_LastRecvMessage;
       }
 
+      bool
+      HandleLRSM(uint64_t status, std::array< EncryptedFrame, 8 >& frames,
+                 AbstractRouter* r) override;
+
       void
       SetBuildResultHook(BuildResultHookFunc func);
 
@@ -254,6 +258,9 @@ namespace llarp
       bool
       HandleDataDiscardMessage(const routing::DataDiscardMessage& msg,
                                AbstractRouter* r) override;
+
+      bool
+      HandlePathConfirmMessage(AbstractRouter* r);
 
       bool
       HandlePathConfirmMessage(const routing::PathConfirmMessage& msg,

--- a/llarp/path/transit_hop.cpp
+++ b/llarp/path/transit_hop.cpp
@@ -5,6 +5,7 @@
 #include <exit/exit_messages.hpp>
 #include <messages/discard.hpp>
 #include <messages/relay_commit.hpp>
+#include <messages/relay_status.hpp>
 #include <path/path_context.hpp>
 #include <path/transit_hop.hpp>
 #include <router/abstractrouter.hpp>
@@ -44,6 +45,26 @@ namespace llarp
     TransitHop::ExpireTime() const
     {
       return started + lifetime;
+    }
+
+    bool
+    TransitHop::HandleLRSM(uint64_t status, std::array< EncryptedFrame, 8 >& frames,
+                           AbstractRouter* r)
+    {
+      auto msg = std::make_shared< LR_StatusMessage >(frames);
+      msg->status = status;
+      msg->pathid = info.rxID;
+
+      //TODO: add to IHopHandler some notion of "path status"
+
+      if(!msg->AddFrame(pathKey, status))
+      {
+        return false;
+      }
+
+      LR_StatusMessage::QueueSendMessage(r, info.downstream, msg);
+
+      return true;
     }
 
     TransitHopInfo::TransitHopInfo(const RouterID& down,

--- a/llarp/path/transit_hop.hpp
+++ b/llarp/path/transit_hop.hpp
@@ -107,6 +107,10 @@ namespace llarp
         return m_LastActivity;
       }
 
+      bool
+      HandleLRSM(uint64_t status, std::array< EncryptedFrame, 8 >& frames,
+                 AbstractRouter* r) override;
+
       std::ostream&
       print(std::ostream& stream, int level, int spaces) const;
 
@@ -131,6 +135,9 @@ namespace llarp
       bool
       HandleDataDiscardMessage(const routing::DataDiscardMessage& msg,
                                AbstractRouter* r) override;
+
+      bool
+      HandlePathConfirmMessage(AbstractRouter* r);
 
       bool
       HandlePathConfirmMessage(const routing::PathConfirmMessage& msg,

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -280,7 +280,7 @@ namespace llarp
             continue;
           std::array< byte_t, 128 > tmp = {0};
           llarp_buffer_t buf(tmp);
-          if(SendToServiceOrQueue(introset.A.Addr().data(), buf,
+          if(SendToServiceOrQueue(introset.A.Addr(), buf,
                                   eProtocolControl))
             LogInfo(Name(), " send message to ", introset.A.Addr(), " for tag ",
                     tag.ToString());

--- a/llarp/util/threadpool.h
+++ b/llarp/util/threadpool.h
@@ -86,6 +86,15 @@ llarp_threadpool_tick(struct llarp_threadpool *tp);
 void
 llarp_threadpool_queue_job(struct llarp_threadpool *tp,
                            struct llarp_thread_job j);
+
+#ifdef __cplusplus
+
+void
+llarp_threadpool_queue_job(struct llarp_threadpool *tp,
+                           std::function<void()> func);
+
+#endif
+
 void
 llarp_threadpool_start(struct llarp_threadpool *tp);
 


### PR DESCRIPTION
Adds LR_StatusMessage as a Link Message.  This message type is sent back to a path creator in a manner which mirrors the LR_CommitMessage(s) sent to create a path, such that the hops of the path can inform the path creator of the path creation status (success or fail with reason).

It compiles and there are no meaningful warnings added!

LR_StatusMessage is now used in place of PathConfirmMessage