### PR TITLE
Add function to set threadname, and use from threadpool impl

### DIFF
--- a/llarp/hook/shell.cpp
+++ b/llarp/hook/shell.cpp
@@ -34,7 +34,8 @@ namespace llarp
       std::vector< std::string > _args;
       std::vector< char * > args;
 
-      ExecShellHookBackend(std::string script) : m_ThreadPool(1, 1000)
+      ExecShellHookBackend(std::string script)
+          : m_ThreadPool(1, 1000, "exechook")
       {
         do
         {

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -214,7 +214,7 @@ namespace llarp
       , _logic(l)
       , paths(this)
       , _exitContext(this)
-      , disk(1, 1000)
+      , disk(1, 1000, "diskworker")
       , _dht(llarp_dht_context_new(this))
       , inbound_link_msg_parser(this)
       , _hiddenServiceContext(this)

--- a/llarp/util/thread_pool.cpp
+++ b/llarp/util/thread_pool.cpp
@@ -1,5 +1,7 @@
 #include <util/thread_pool.hpp>
 
+#include <util/threading.hpp>
+
 namespace llarp
 {
   namespace thread
@@ -93,6 +95,8 @@ namespace llarp
       // Lock will be valid until the end of the statement
       size_t gateCount = (absl::ReaderMutexLock(&m_gateMutex), m_gateCount);
 
+      util::SetThreadName(m_name);
+
       for(;;)
       {
         {
@@ -152,13 +156,14 @@ namespace llarp
       }
     }
 
-    ThreadPool::ThreadPool(size_t numThreads, size_t maxJobs)
+    ThreadPool::ThreadPool(size_t numThreads, size_t maxJobs, string_view name)
         : m_queue(maxJobs)
         , m_semaphore(0)
         , m_idleThreads(0)
         , m_status(Status::Stop)
         , m_gateCount(0)
         , m_numThreadsReady(0)
+        , m_name(name)
         , m_threads(numThreads)
         , m_createdThreads(0)
     {

--- a/llarp/util/thread_pool.hpp
+++ b/llarp/util/thread_pool.hpp
@@ -2,6 +2,7 @@
 #define LLARP_THREAD_POOL_HPP
 
 #include <util/queue.hpp>
+#include <util/string_view.hpp>
 #include <util/threading.hpp>
 
 #include <atomic>
@@ -47,6 +48,7 @@ namespace llarp
 
       util::Mutex m_gateMutex;
 
+      std::string m_name;
       std::vector< std::thread > m_threads;
       size_t m_createdThreads;
 
@@ -81,7 +83,7 @@ namespace llarp
       }
 
      public:
-      ThreadPool(size_t numThreads, size_t maxJobs);
+      ThreadPool(size_t numThreads, size_t maxJobs, string_view name);
 
       ~ThreadPool();
 

--- a/llarp/util/threading.cpp
+++ b/llarp/util/threading.cpp
@@ -1,1 +1,33 @@
 #include <util/threading.hpp>
+
+#include <util/logger.hpp>
+
+#ifdef POSIX
+#include <pthread.h>
+#endif
+
+namespace llarp
+{
+  namespace util
+  {
+    void
+    SetThreadName(const std::string& name)
+    {
+#ifdef POSIX
+#ifdef __MACH__
+      const int rc = pthread_setname_np(name.c_str());
+#else
+      const int rc = pthread_setname_np(pthread_self(), name.c_str());
+#endif
+      if(rc)
+      {
+        LogError("Failed to set thread name to ", name, " errno = ", rc,
+                 " errstr = ", strerror(rc));
+      }
+#else
+      LogInfo("Thread name setting not supported on this platform");
+      (void)name;
+#endif
+    }
+  }  // namespace util
+}  // namespace llarp

--- a/llarp/util/threading.hpp
+++ b/llarp/util/threading.hpp
@@ -82,6 +82,9 @@ namespace llarp
 
     using Barrier = absl::Barrier;
 
+    void
+    SetThreadName(const std::string& name);
+
   }  // namespace util
 }  // namespace llarp
 

--- a/llarp/util/threadpool.h
+++ b/llarp/util/threadpool.h
@@ -2,7 +2,9 @@
 #define LLARP_THREADPOOL_H
 
 #include <util/queue.hpp>
+#include <util/string_view.hpp>
 #include <util/thread_pool.hpp>
+
 #include <absl/base/thread_annotations.h>
 #include <memory>
 #include <queue>
@@ -13,13 +15,12 @@ struct llarp_threadpool
   std::unique_ptr< llarp::thread::Queue< std::function< void(void) > > > jobs;
   const pid_t callingPID;
 
-  llarp_threadpool(int workers, const char *name)
-      : impl(
-          std::make_unique< llarp::thread::ThreadPool >(workers, workers * 128))
+  llarp_threadpool(int workers, llarp::string_view name)
+      : impl(std::make_unique< llarp::thread::ThreadPool >(workers,
+                                                           workers * 128, name))
       , jobs(nullptr)
       , callingPID(0)
   {
-    (void)name;
   }
 
   llarp_threadpool()

--- a/test/util/test_llarp_util_thread_pool.cpp
+++ b/test/util/test_llarp_util_thread_pool.cpp
@@ -119,7 +119,7 @@ TEST(TestThreadPool, breathing)
   static constexpr size_t threads  = 10;
   static constexpr size_t capacity = 50;
 
-  ThreadPool pool(threads, capacity);
+  ThreadPool pool(threads, capacity, "breathing");
 
   ASSERT_EQ(0u, pool.startedThreadCount());
   ASSERT_EQ(capacity, pool.capacity());
@@ -151,11 +151,11 @@ class Accessors : public ::testing::TestWithParam< AccessorsData >
 {
 };
 
-TEST_P(Accessors, acessors)
+TEST_P(Accessors, accessors)
 {
   auto d = GetParam();
 
-  ThreadPool pool(d.threads, d.capacity);
+  ThreadPool pool(d.threads, d.capacity, "accessors");
 
   ASSERT_EQ(d.threads, pool.threadCount());
   ASSERT_EQ(d.capacity, pool.capacity());
@@ -195,7 +195,7 @@ TEST_P(Closing, drain)
 
   PoolArgs args{mutex, start, stop, 0, 0, 0};
 
-  ThreadPool pool(d.threads, d.capacity);
+  ThreadPool pool(d.threads, d.capacity, "drain");
 
   ASSERT_EQ(d.threads, pool.threadCount());
   ASSERT_EQ(d.capacity, pool.capacity());
@@ -235,7 +235,7 @@ TEST_P(Closing, stop)
 {
   auto d = GetParam();
 
-  ThreadPool pool(d.threads, d.capacity);
+  ThreadPool pool(d.threads, d.capacity, "stop");
 
   std::mutex mutex;
   std::condition_variable start;
@@ -286,7 +286,7 @@ TEST_P(Closing, shutdown)
 {
   auto d = GetParam();
 
-  ThreadPool pool(d.threads, d.capacity);
+  ThreadPool pool(d.threads, d.capacity, "shutdown");
 
   std::mutex mutex;
   std::condition_variable start;
@@ -370,7 +370,7 @@ TEST_P(TryAdd, noblocking)
   // Fill the queue, then verify `tryAddJob` does not block.
   auto d = GetParam();
 
-  ThreadPool pool(d.threads, d.capacity);
+  ThreadPool pool(d.threads, d.capacity, "noblocking");
 
   util::Barrier startBarrier(d.threads + 1);
   util::Barrier stopBarrier(d.threads + 1);
@@ -422,7 +422,7 @@ TEST(TestThreadPool, recurseJob)
   util::Barrier barrier(threads + 1);
   std::atomic_size_t counter{0};
 
-  ThreadPool pool(threads, capacity);
+  ThreadPool pool(threads, capacity, "recurse");
 
   pool.start();
 
@@ -441,7 +441,7 @@ TEST(TestThreadPool, destructors)
   static constexpr size_t threads  = 1;
   static constexpr size_t capacity = 100;
 
-  ThreadPool pool(threads, capacity);
+  ThreadPool pool(threads, capacity, "destructors");
 
   pool.start();
 


### PR DESCRIPTION
looks like:

```
(lldb) thread list
Process 17698 stopped
* thread #1: tid = 0x6d3a6, 0x00007fff6966c78e libsystem_kernel.dylib`kevent + 10, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  thread #2: tid = 0x6d45f, 0x00007fff6966986a libsystem_kernel.dylib`__psynch_cvwait + 10
  thread #3: tid = 0x6d462, 0x00007fff6966986a libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'llarp-worker'
  thread #4: tid = 0x6d463, 0x00007fff6966986a libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'llarp-worker'
  thread #5: tid = 0x6d464, 0x00007fff6966986a libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'diskworker'
```

makes debugging multithreaded issues/cores **soooooooooooo** much nicer.