### PR TITLE
Create CONTRIBUTING_es.md

### DIFF
--- a/CONTRIBUTING_es.md
+++ b/CONTRIBUTING_es.md
@@ -1,0 +1,28 @@
+[Ingles](CONTRIBUTING.md)
+# Lo que debe
+
+* Actuar como un adulto responsable.
+
+* CORRER `make format` SIEMPRE ANTES DEL COMMIT.
+
+# Lo que NO debe
+
+* Plantear asuntos fuera de lugar o que no son tecnicos en el registro de problemas.
+
+* Ser un contribuyente molestoso.
+
+# Lo que nosotros HAREMOS
+
+* Integrar correcciones de Ortografia (Yo tengo un monton porque la ortografia es COMPLICADA)
+
+* Integrar codigo en base a que tan correcto es, Incluyendo parches recibidos por correo electronico de contribuyentes (pseudo/completamente) anonimos.
+
+# Lo que nosotros NO HAREMOS
+
+* Aceptar parches con tabulaciones
+
+* Integrar cambios grandes sin sentido o pedantes, (por ejemplo codigo con cambios de formato)
+
+## notas adicionales
+
+github no parece aceptar este archivo como un codigo de conducta real.


### PR DESCRIPTION
Spanish version of "code of conduct" file, with a link to the english file.