### PR TITLE
Dump more info from router contact

### DIFF
--- a/docker/compose/compose-base.Dockerfile
+++ b/docker/compose/compose-base.Dockerfile
@@ -13,3 +13,4 @@ RUN make NINJA=ninja STATIC_LINK=ON BUILD_TYPE=Release
 FROM alpine:latest
 
 COPY --from=builder /src/build/lokinet /
+COPY --from=builder /src/build/lokinet-rcutil /

--- a/llarp/net/address_info.cpp
+++ b/llarp/net/address_info.cpp
@@ -160,4 +160,17 @@ namespace llarp
 
     return stream;
   }
+
+  void
+  to_json(nlohmann::json &j, const AddressInfo &a)
+  {
+    char tmp[128] = {0};
+    inet_ntop(AF_INET6, (void *)&a.ip, tmp, sizeof(tmp));
+
+    j = nlohmann::json{{"rank", a.rank},
+                       {"dialect", a.dialect},
+                       {"pubkey", a.pubkey.ToString()},
+                       {"in6_addr", tmp},
+                       {"port", a.port}};
+  }
 }  // namespace llarp

--- a/llarp/net/address_info.hpp
+++ b/llarp/net/address_info.hpp
@@ -52,6 +52,9 @@ namespace llarp
     };
   };
 
+  void
+  to_json(nlohmann::json& j, const AddressInfo& a);
+
   inline std::ostream&
   operator<<(std::ostream& out, const AddressInfo& a)
   {

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -163,9 +163,12 @@ namespace llarp
     util::StatusObject obj{{"lastUpdated", last_updated},
                            {"exit", IsExit()},
                            {"publicRouter", IsPublicRouter()},
-                           {"identity", pubkey.ToString()}};
+                           {"identity", pubkey.ToString()},
+                           {"addresses", addrs}};
+
     if(HasNick())
       obj["nickname"] = Nick();
+
     return obj;
   }
 


### PR DESCRIPTION
```json
./lokinet-rcutil --dump ~/.lokinet/bootstrap.signed --json | jq . 
{
  "/Users/foo/.lokinet/bootstrap.signed": {
    "addresses": [
      {
        "dialect": "utp",
        "in6_addr": "::ffff:51.79.57.235",
        "port": 1090,
        "pubkey": "632d43917c5f5e45a079690d906f825b20c3931d32b1c26115d529a48d710a11",
        "rank": 1
      }
    ],
    "exit": false,
    "identity": "e883ba38963ada84dbf88a3223727d123a75b07b20cb4fd7ce8ce3983a76e625",
    "lastUpdated": 1565820374503,
    "publicRouter": true
  }
}
```