### PR TITLE
disable link layer locking

### DIFF
--- a/llarp/iwp/linklayer.cpp
+++ b/llarp/iwp/linklayer.cpp
@@ -79,7 +79,7 @@ namespace llarp
       auto itr = m_AuthedAddrs.find(from);
       if(itr == m_AuthedAddrs.end())
       {
-        util::Lock lock(&m_PendingMutex);
+        Lock lock(&m_PendingMutex);
         if(m_Pending.count(from) == 0)
         {
           if(not permitInbound)

--- a/llarp/link/server.hpp
+++ b/llarp/link/server.hpp
@@ -237,8 +237,8 @@ namespace llarp
     const SecretKey& m_RouterEncSecret;
 
    protected:
-    using Lock  = util::Lock;
-    using Mutex = util::Mutex;
+    using Lock  = util::NullLock;
+    using Mutex = util::NullMutex;
 
     bool
     PutSession(const std::shared_ptr< ILinkSession >& s);


### PR DESCRIPTION
i found no lock contention on the link layer mutexes with tracy so we should revert these into Null{Lock,Mutex} like they were before.