### PR TITLE
macOS installer bump / Other windows fixes

### DIFF
--- a/llarp/ev/ev.cpp
+++ b/llarp/ev/ev.cpp
@@ -93,7 +93,6 @@ llarp_ev_udp_sendto(struct llarp_udp_io *udp, const sockaddr *to,
 bool
 llarp_ev_add_tun(struct llarp_ev_loop *loop, struct llarp_tun_io *tun)
 {
-#if !defined(_WIN32)
   if(tun->ifaddr[0] == 0 || strcmp(tun->ifaddr, "auto") == 0)
   {
     LogError("invalid ifaddr on tun: ", tun->ifaddr);
@@ -104,6 +103,7 @@ llarp_ev_add_tun(struct llarp_ev_loop *loop, struct llarp_tun_io *tun)
     LogError("invalid ifname on tun: ", tun->ifname);
     return false;
   }
+#if !defined(_WIN32)
   return loop->tun_listen(tun);
 #else
   UNREFERENCED_PARAMETER(loop);

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -356,7 +356,7 @@ namespace llarp
   Router::FromConfig(Config *conf)
   {
     // Set netid before anything else
-    if(!conf->router.netId().empty())
+    if(!conf->router.netId().empty() || (conf->router.netId() != Version::LLARP_NET_ID))
     {
       const auto &netid = conf->router.netId();
       llarp::LogWarn("!!!! you have manually set netid to be '", netid,

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -356,7 +356,7 @@ namespace llarp
   Router::FromConfig(Config *conf)
   {
     // Set netid before anything else
-    if(!conf->router.netId().empty() || (conf->router.netId() != Version::LLARP_NET_ID))
+    if(!conf->router.netId().empty() && strcmp(conf->router.netId().c_str(), Version::LLARP_NET_ID))
     {
       const auto &netid = conf->router.netId();
       llarp::LogWarn("!!!! you have manually set netid to be '", netid,

--- a/osx-setup/distribution.xml
+++ b/osx-setup/distribution.xml
@@ -10,7 +10,7 @@
   <conclusion file="conclusion.html" mime-type="text/html" />
   <!-- List all component packages -->
   <pkg-ref id="network.loki.lokinet"
-           version="0.6"
+           version="0.5"
            auth="root">lokinet.pkg</pkg-ref>
   <!-- List them again here. They can now be organized
        as a hierarchy if you want. -->

--- a/osx-setup/distribution.xml
+++ b/osx-setup/distribution.xml
@@ -10,7 +10,7 @@
   <conclusion file="conclusion.html" mime-type="text/html" />
   <!-- List all component packages -->
   <pkg-ref id="network.loki.lokinet"
-           version="0.4"
+           version="0.6"
            auth="root">lokinet.pkg</pkg-ref>
   <!-- List them again here. They can now be organized
        as a hierarchy if you want. -->
@@ -21,7 +21,7 @@
   <choice
       id="network.loki.lokinet"
       visible="false"
-      title="LokiNET"
+      title="Lokinet"
       description='Lokinet is a free, open source, private, decentralized, \"market based sybil resistant\" and IP based onion routing network'
       start_selected="true">
     <pkg-ref id="network.loki.lokinet"/>

--- a/osx-setup/resources/conclusion.html
+++ b/osx-setup/resources/conclusion.html
@@ -1,3 +1,3 @@
-IRC or Discord is likely the best place for help with Lokinet
+IRC, Discord, or Loki Messenger is likely the best place for help with Lokinet
 
-IRC: #llarp on irc.freenode.org
+IRC Address: #llarp on irc.freenode.org

--- a/osx-setup/resources/welcome.html
+++ b/osx-setup/resources/welcome.html
@@ -1,7 +1,7 @@
-Hi, welcome to Lokinet public alpha!
+Hi, welcome to Lokinet public beta!
 
 Lokinet is a private, decentralized and Market based, Sybil resistant overlay network for the internet.
 
 This package contains the reference implementation of LLARP.
 
-This software is in a very early stage where there's much work to be done.
+This software is in its early stages, please do not use it for anything mission critical, by default you are using the betanet which is mostly run by node operators from the Loki team.

--- a/osx-setup/scripts/postinstall
+++ b/osx-setup/scripts/postinstall
@@ -10,7 +10,7 @@ rm $HOME/.lokinet/*.key >> /tmp/lokinet_postinstall.log
 rm $HOME/.lokinet/*.private >> /tmp/lokinet_postinstall.log
 rm -fr $HOME/.lokinet/netdb >> /tmp/lokinet_postinstall.log
 
-url="https://i2p.rocks/i2procks.signed"
+url="https://seed.lokinet.org/bootstrap.signed"
 echo "downloading $url" >> /tmp/lokinet_postinstall.log
 echo "to $HOME/.lokinet/bootstrap.signed" >> /tmp/lokinet_postinstall.log
 


### PR DESCRIPTION
for @neuroscr 

also:
- don't warn when netid == default netid (some scripts set netid explicitly)
- windows error feedback for @KeeJef (instead of showing random network setup errors, tells the user to check their config file, just like all the other platforms were already doing)