### PR TITLE
Statically link releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(AMD_RYZEN_HACK "hack for AMD Ryzen FPU bug (support FMA3 and FMA4 in FPU,
 option(NATIVE_BUILD "optimise for host system and FPU, may not be portable" )
 option(EMBEDDED_CFG "optimise for older hardware or embedded systems")
 if (NOT MSVC)
+option(STATIC_LINK "link statically against dependencies" OFF)
 option(STATIC_LINK_RUNTIME "link statically against compiler runtime, standard library and pthreads")
 endif()
 option(NON_PC_TARGET "non-pc target build: iphone, andriod, embedded non-i386 SBC, etc" )
@@ -33,6 +34,10 @@ include(cmake/target_link_libraries_system.cmake)
 include(cmake/add_import_library.cmake)
 include(cmake/add_log_tag.cmake)
 include(cmake/libatomic.cmake)
+
+if (STATIC_LINK AND STATIC_LINK_RUNTIME)
+  message(FATAL "Cannot set both STATIC_LINK and STATIC_LINK_RUNTIME")
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
@@ -183,6 +188,7 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
+include(cmake/static_link_runtime.cmake)
 include(cmake/static_link.cmake)
 
 if(USE_NETNS)

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,10 @@ TOOLCHAIN ?=
 AVX2 ?= OFF
 # non x86 target
 NON_PC_TARGET ?= OFF
-# statically link
+# statically link everything
 STATIC_LINK ?= OFF
+# statically link dependencies
+STATIC ?= OFF
 # enable network namespace isolation
 NETNS ?= OFF
 # enable shell hooks callbacks
@@ -139,7 +141,7 @@ debug-configure:
 
 release-configure: clean
 	mkdir -p '$(BUILD_ROOT)'
-	$(CONFIG_CMD) -DCMAKE_BUILD_TYPE=Release -DRELEASE_MOTTO="$(shell cat motto.txt)" -DCMAKE_C_FLAGS='$(CFLAGS)' -DCMAKE_CXX_FLAGS='$(CXXFLAGS)'
+	$(CONFIG_CMD) -DCMAKE_BUILD_TYPE=Release -DSTATIC_LINK=ON -DRELEASE_MOTTO="$(shell cat motto.txt)" -DCMAKE_C_FLAGS='$(CFLAGS)' -DCMAKE_CXX_FLAGS='$(CXXFLAGS)'
 
 debug: debug-configure
 	$(MAKE) -C $(BUILD_ROOT)

--- a/cmake/static_link.cmake
+++ b/cmake/static_link.cmake
@@ -1,11 +1,4 @@
-if(NOT STATIC_LINK_RUNTIME)
-  return()
-endif()
-
-# not supported on Solaris - system libraries are not available as archives
-# LTO is supported only for native builds
-if(SOLARIS)
-  link_libraries( -static-libstdc++ -static-libgcc )
+if(NOT STATIC_LINK)
   return()
 endif()
 
@@ -16,25 +9,5 @@ else()
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if(APPLE)
-    link_libraries( -flto)
-  else()
-    link_libraries( -static -static-libstdc++ -pthread -flto )
-  endif()
-
-  return()
-endif()
-
-if(NOT CMAKE_CROSSCOMPILING)
-  # this is messing with release builds
-  add_compile_options(-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0)
-  set(CMAKE_AR "gcc-ar")
-  set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-  set(CMAKE_C_ARCHIVE_FINISH "true")
-  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-  set(CMAKE_CXX_ARCHIVE_FINISH "true")
-  link_libraries( -flto -static-libstdc++ -static-libgcc -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive )
-else()
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive" )
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+  link_libraries( -flto)
 endif()

--- a/cmake/static_link_runtime.cmake
+++ b/cmake/static_link_runtime.cmake
@@ -1,0 +1,40 @@
+if(NOT STATIC_LINK_RUNTIME)
+  return()
+endif()
+
+# not supported on Solaris - system libraries are not available as archives
+# LTO is supported only for native builds
+if(SOLARIS)
+  link_libraries( -static-libstdc++ -static-libgcc )
+  return()
+endif()
+
+if(NOT CMAKE_CROSSCOMPILING)
+  add_compile_options(-static -flto)
+else()
+  add_compile_options(-static)
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(APPLE)
+    link_libraries( -flto)
+  else()
+    link_libraries( -static -static-libstdc++ -pthread -flto )
+  endif()
+
+  return()
+endif()
+
+if(NOT CMAKE_CROSSCOMPILING)
+  # this is messing with release builds
+  add_compile_options(-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0)
+  set(CMAKE_AR "gcc-ar")
+  set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+  set(CMAKE_C_ARCHIVE_FINISH "true")
+  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+  set(CMAKE_CXX_ARCHIVE_FINISH "true")
+  link_libraries( -flto -static-libstdc++ -static-libgcc -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive )
+else()
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive" )
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+endif()

--- a/cmake/unix.cmake
+++ b/cmake/unix.cmake
@@ -8,7 +8,7 @@ include(CheckLibraryExists)
 add_definitions(-DUNIX)
 add_definitions(-DPOSIX)
 
-if (STATIC_LINK_RUNTIME)
+if (STATIC_LINK_RUNTIME OR STATIC_LINK)
   set(LIBUV_USE_STATIC ON)
 endif()
 


### PR DESCRIPTION
fixes #823 

```
$ otool -L lokinet
lokinet:
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.6.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```