### PR TITLE
Add numNodesKnown to llarp.admin.dumpstate RPC endpoint

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -114,6 +114,7 @@ namespace llarp
     {
       return util::StatusObject{
           {"running", true},
+          {"numNodesKnown", _nodedb->num_loaded()},
           {"dht", _dht->impl->ExtractStatus()},
           {"services", _hiddenServiceContext.ExtractStatus()},
           {"exit", _exitContext.ExtractStatus()},


### PR DESCRIPTION
This adds the number of nodes in the `nodedb` to the `llarp.admin.dumpstate` endpoint. 

It might be better / more consistent to add an `ExtractStatus()` method to `nodedb`, though there doesn't seem to be much else in `nodedb` we might want to know.

Also note that `num_loaded()` is going to acquire the `nodedb`'s `access mutex`; would this be problematic?