### PR TITLE
Fix build on xenial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Lowest version - android ndk 3.6.0
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.5.1)  # xenial's cmake version
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)

--- a/llarp/net/net.cpp
+++ b/llarp/net/net.cpp
@@ -9,7 +9,20 @@
 #ifndef ANDROID
 #include <ifaddrs.h>
 #endif
-#include <net/if.h>
+
+// Work around for broken glibc/linux header definitions in xenial that makes
+// including both net/if.h (which we need for if_nametoindex) and linux/if.h
+// (which tuntap.h includes) impossible.  When we stop supporting xenial we can
+// remove this mess and just include net/if.h here.
+#if defined(Linux) && __GLIBC__ == 2 && __GLIBC_MINOR__ == 23
+# include <linux/version.h>
+# if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0) && LINUX_VERSION_CODE < KERNEL_VERSION(4,5,0)
+#  define _NET_IF_H 1
+#  include <linux/if.h>
+extern "C" unsigned int if_nametoindex (const char *__ifname) __THROW;
+# endif
+#else
+# include <net/if.h>
 #endif
 
 #include <net/net_addr.hpp>


### PR DESCRIPTION
- xenial's cmake version (3.5.1) builds everything fine and test suite
  passes, so lower the minimum to that.

- add a hack for xenial's kernel header & glibc version breaking if both
  net/if.h and linux/if.h get included.  The only thing we actually need
  from net/if.h that linux/if.h doesn't have is `if_nametoindex`, so
  just hack that definition in for xenial's specific glibc/kernel header
  versions.

This travis-ci build doesn't hit either of these issues because it isn't fully xenial - it's xenial plus updated headers and cmake versions because WTF travis.