### PR TITLE
make path builds work

### DIFF
--- a/llarp/iwp/message_buffer.cpp
+++ b/llarp/iwp/message_buffer.cpp
@@ -163,7 +163,8 @@ namespace llarp
     bool
     InboundMessage::ShouldSendACKS(llarp_time_t now) const
     {
-      return (now > m_LastACKSent && now - m_LastACKSent > 1000);
+      return (now > m_LastACKSent
+              && now - m_LastACKSent > (Session::DeliveryTimeout / 4));
     }
 
     bool

--- a/llarp/iwp/message_buffer.cpp
+++ b/llarp/iwp/message_buffer.cpp
@@ -163,8 +163,7 @@ namespace llarp
     bool
     InboundMessage::ShouldSendACKS(llarp_time_t now) const
     {
-      return (now > m_LastACKSent
-              && now - m_LastACKSent > (Session::DeliveryTimeout / 4));
+      return now > m_LastACKSent + (Session::DeliveryTimeout / 4);
     }
 
     bool

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -596,6 +596,14 @@ namespace llarp
         }
       }
       SendMACK();
+      if(m_EncryptNext && !m_EncryptNext->empty())
+      {
+        auto self = shared_from_this();
+        m_Parent->QueueWork([self, data = std::move(m_EncryptNext)] {
+          self->EncryptWorker(data);
+        });
+        m_EncryptNext = nullptr;
+      }
     }
 
     void

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -598,10 +598,10 @@ namespace llarp
       SendMACK();
       if(m_EncryptNext && !m_EncryptNext->empty())
       {
-        auto self = shared_from_this();
-        m_Parent->QueueWork([self, data = std::move(m_EncryptNext)] {
-          self->EncryptWorker(data);
-        });
+        m_Parent->QueueWork(
+            [self = shared_from_this(), data = std::move(m_EncryptNext)] {
+              self->EncryptWorker(data);
+            });
         m_EncryptNext = nullptr;
       }
     }

--- a/llarp/messages/relay.cpp
+++ b/llarp/messages/relay.cpp
@@ -113,7 +113,7 @@ namespace llarp
     {
       return path->HandleDownstream(llarp_buffer_t(X), Y, r);
     }
-    llarp::LogWarn("unhandled downstream message");
+    llarp::LogWarn("unhandled downstream message id=", pathid);
     return false;
   }
 }  // namespace llarp

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -619,7 +619,7 @@ namespace llarp
     Path::HandlePathLatencyMessage(const routing::PathLatencyMessage& msg,
                                    AbstractRouter* r)
     {
-      auto now = r->Now();
+      const auto now = r->Now();
       MarkActive(now);
       if(msg.L == m_LastLatencyTestID)
       {

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -584,12 +584,6 @@ namespace llarp
 
         // persist session with upstream router until the path is done
         r->PersistSessionUntil(Upstream(), intro.expiresAt);
-
-        EnterState(ePathEstablished, now);
-        if(m_BuiltHook)
-          m_BuiltHook(shared_from_this());
-        m_BuiltHook = nullptr;
-
         MarkActive(now);
         // send path latency test
         routing::PathLatencyMessage latency;
@@ -631,6 +625,10 @@ namespace llarp
       {
         intro.latency       = now - m_LastLatencyTestTime;
         m_LastLatencyTestID = 0;
+        EnterState(ePathEstablished, now);
+        if(m_BuiltHook)
+          m_BuiltHook(shared_from_this());
+        m_BuiltHook = nullptr;
         LogDebug("path latency is now ", intro.latency, " for ", Name());
         return true;
       }

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -584,6 +584,12 @@ namespace llarp
 
         // persist session with upstream router until the path is done
         r->PersistSessionUntil(Upstream(), intro.expiresAt);
+
+        EnterState(ePathEstablished, now);
+        if(m_BuiltHook)
+          m_BuiltHook(shared_from_this());
+        m_BuiltHook = nullptr;
+
         MarkActive(now);
         // send path latency test
         routing::PathLatencyMessage latency;
@@ -625,10 +631,6 @@ namespace llarp
       {
         intro.latency       = now - m_LastLatencyTestTime;
         m_LastLatencyTestID = 0;
-        EnterState(ePathEstablished, now);
-        if(m_BuiltHook)
-          m_BuiltHook(shared_from_this());
-        m_BuiltHook = nullptr;
         LogDebug("path latency is now ", intro.latency, " for ", Name());
         return true;
       }


### PR DESCRIPTION
bigger link messages like those for path builds are not delivered fast enough because we wait to flush the encrypt packet buffer after handling decrypted packets until we get more packets from the network.

this should fix that