### PR TITLE
Fix #911: Drop new inbound IWP sessions when the first packet can't be handled

### DIFF
--- a/llarp/iwp/linklayer.cpp
+++ b/llarp/iwp/linklayer.cpp
@@ -78,7 +78,8 @@ namespace llarp
     LinkLayer::RecvFrom(const Addr& from, ILinkSession::Packet_t pkt)
     {
       std::shared_ptr< ILinkSession > session;
-      auto itr = m_AuthedAddrs.find(from);
+      auto itr          = m_AuthedAddrs.find(from);
+      bool isNewSession = false;
       if(itr == m_AuthedAddrs.end())
       {
         ACQUIRE_LOCK(Lock_t lock, m_PendingMutex);
@@ -86,6 +87,7 @@ namespace llarp
         {
           if(not permitInbound)
             return;
+          isNewSession = true;
           m_Pending.insert({from, std::make_shared< Session >(this, from)});
         }
         session = m_Pending.find(from)->second;
@@ -98,7 +100,13 @@ namespace llarp
       }
       if(session)
       {
-        session->Recv_LL(std::move(pkt));
+        bool success = session->Recv_LL(std::move(pkt));
+        if(!success and isNewSession)
+        {
+          LogWarn(
+              "Brand new session failed; removing from pending sessions list");
+          m_Pending.erase(m_Pending.find(from));
+        }
       }
     }
 

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -805,7 +805,7 @@ namespace llarp
       return m_State == State::Ready;
     }
 
-    void
+    bool
     Session::Recv_LL(ILinkSession::Packet_t data)
     {
       switch(m_State)
@@ -816,9 +816,14 @@ namespace llarp
             // initial data
             // enter introduction phase
             if(DecryptMessageInPlace(data))
+            {
               HandleGotIntro(std::move(data));
+            }
             else
+            {
               LogError("bad intro from ", m_RemoteAddr);
+              return false;
+            }
           }
           else
           {
@@ -844,6 +849,7 @@ namespace llarp
           HandleSessionData(std::move(data));
           break;
       }
+      return true;
     }
   }  // namespace iwp
 }  // namespace llarp

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -821,7 +821,7 @@ namespace llarp
             }
             else
             {
-              LogError("bad intro from ", m_RemoteAddr);
+              LogWarn("bad intro from ", m_RemoteAddr);
               return false;
             }
           }

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -72,7 +72,7 @@ namespace llarp
       void
       Close() override;
 
-      void Recv_LL(ILinkSession::Packet_t) override;
+      bool Recv_LL(ILinkSession::Packet_t) override;
 
       bool
       SendKeepAlive() override;

--- a/llarp/link/session.hpp
+++ b/llarp/link/session.hpp
@@ -61,8 +61,9 @@ namespace llarp
 
     /// recv packet on low layer
     /// not used by utp
-    virtual void Recv_LL(Packet_t)
+    virtual bool Recv_LL(Packet_t)
     {
+      return true;
     }
 
     /// send a keepalive to the remote endpoint


### PR DESCRIPTION
This prevents any new inbound session from hanging around if it's already broken upon receiving the first packet. Strictly speaking, it doesn't fix the underlying problem (which is that broken sessions aren't being cleaned up properly), but it does prevent the most common use cases, and it's generally a good performance optimization as well.