### PR TITLE
Remove shell globbing of path

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -215,7 +215,7 @@ main(int argc, char *argv[])
     if(genconfigOnly)
     {
       if(!llarp_ensure_config(conffname.c_str(), basedir.string().c_str(),
-            overWrite, asRouter))
+                              overWrite, asRouter))
         return 1;
     }
     else

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -7,10 +7,6 @@
 
 #include <csignal>
 
-#if !defined(_WIN32) && !defined(__OpenBSD__)
-#include <wordexp.h>
-#endif
-
 #include <cxxopts.hpp>
 #include <string>
 #include <iostream>
@@ -58,31 +54,6 @@ handle_signal_win32(DWORD fdwCtrlType)
   return TRUE;  // probably unreachable
 }
 #endif
-
-/// resolve ~ and symlinks into actual paths (so we know the real path on disk,
-/// to remove assumptions and confusion with permissions)
-std::string
-resolvePath(std::string conffname)
-{
-  // implemented in netbsd, removed downstream for security reasons
-  // even though it is defined by POSIX.1-2001+
-#if !defined(_WIN32) && !defined(__OpenBSD__)
-  wordexp_t exp_result;
-  wordexp(conffname.c_str(), &exp_result, 0);
-  char *resolvedPath = realpath(exp_result.we_wordv[0], NULL);
-  if(!resolvedPath)
-  {
-    // relative paths don't need to be resolved
-    // llarp::LogWarn("Can't resolve path: ", exp_result.we_wordv[0]);
-    return conffname;
-  }
-  return resolvedPath;
-#else
-  // TODO(despair): dig through LLVM local patch set
-  // one of these exists deep in the bowels of LLVMSupport
-  return conffname;  // eww, easier said than done outside of cygwin
-#endif
-}
 
 /// this sets up, configures and runs the main context
 static void
@@ -152,7 +123,7 @@ main(int argc, char *argv[])
   bool genconfigOnly = false;
   bool asRouter      = false;
   bool overWrite     = false;
-  std::string conffname;  // suggestions: confFName? conf_fname?
+  std::string conffname;
   try
   {
     auto result = options.parse(argc, argv);
@@ -226,33 +197,10 @@ main(int argc, char *argv[])
     fs::path fname   = fs::path(conffname);
     fs::path basedir = fname.parent_path();
     conffname        = fname.string();
-    conffname        = resolvePath(conffname);
-    std::error_code ec;
 
-    // llarp::LogDebug("Basedir: ", basedir);
-    if(basedir.string().empty())
+    if(!basedir.empty())
     {
-      // relative path to config
-
-      // does this file exist?
-      if(genconfigOnly)
-      {
-        if(!llarp_ensure_config(conffname.c_str(), basedir.string().c_str(),
-                                overWrite, asRouter))
-          return 1;
-      }
-      else
-      {
-        if(!fs::exists(fname, ec))
-        {
-          llarp::LogError("Config file not found ", conffname);
-          return 1;
-        }
-      }
-    }
-    else
-    {
-      // absolute path to config
+      std::error_code ec;
       if(!fs::create_directories(basedir, ec))
       {
         if(ec)
@@ -262,29 +210,27 @@ main(int argc, char *argv[])
           return 1;
         }
       }
-      if(genconfigOnly)
+    }
+
+    if(genconfigOnly)
+    {
+      if(!llarp_ensure_config(conffname.c_str(), basedir.string().c_str(),
+            overWrite, asRouter))
+        return 1;
+    }
+    else
+    {
+      std::error_code ec;
+      if(!fs::exists(fname, ec))
       {
-        // find or create file
-        if(!llarp_ensure_config(conffname.c_str(), basedir.string().c_str(),
-                                overWrite, asRouter))
-          return 1;
-      }
-      else
-      {
-        // does this file exist?
-        if(!fs::exists(conffname, ec))
-        {
-          llarp::LogError("Config file not found ", conffname);
-          return 1;
-        }
+        llarp::LogError("Config file not found ", conffname);
+        return 1;
       }
     }
   }
   else
   {
     auto basepath = llarp::GetDefaultConfigDir();
-    // I don't think this is necessary with this condition
-    // conffname = resolvePath(conffname);
 
     llarp::LogDebug("Find or create ", basepath.string());
     std::error_code ec;

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -196,7 +196,6 @@ main(int argc, char *argv[])
     // when we have an explicit filepath
     fs::path fname   = fs::path(conffname);
     fs::path basedir = fname.parent_path();
-    conffname        = fname.string();
 
     if(!basedir.empty())
     {

--- a/llarp/util/bencode.hpp
+++ b/llarp/util/bencode.hpp
@@ -387,7 +387,8 @@ namespace llarp
             return bencode_read_integer(buffer, &v);
           }
           return bencode_discard(buffer);
-        }, buf);
+        },
+        buf);
     // rewind
     buf->cur = buf->base;
     return ret;


### PR DESCRIPTION
resolvePath was leaking memory (the returned char * from realpath was
never freed), but upon closer inspection resolvePath doesn't seem right:
shell/glob/~ expansion is the job of the shell, not the argument (but
worse, if you pass it something like '~' (quoted) it would expand, which
is wrong.

Also de-duplicate some code.

(Strongly recommend to view this diff hiding whitespace changes).