### PR TITLE
clean up where some code is and add clarity

### DIFF
--- a/llarp/router/outbound_message_handler.hpp
+++ b/llarp/router/outbound_message_handler.hpp
@@ -108,7 +108,6 @@ namespace llarp
 
     llarp::thread::Queue< MessageQueueEntry > outboundQueue;
     llarp::thread::Queue< PathID_t > removedPaths;
-    bool removedSomePaths;
 
     mutable util::Mutex _mutex;  // protects pendingSessionMessageQueues
 


### PR DESCRIPTION
Cleans up where some...cleanup...happens.

Also s/!/not/ because "not" is just nicer to read.