### PR TITLE
Lower the ev tick interval to 10ms

### DIFF
--- a/llarp/ev/ev.h
+++ b/llarp/ev/ev.h
@@ -40,7 +40,7 @@ typedef SSIZE_T ssize_t;
  * event handler (cross platform high performance event system for IO)
  */
 
-#define EV_TICK_INTERVAL 100
+#define EV_TICK_INTERVAL 10
 
 // forward declare
 struct llarp_threadpool;


### PR DESCRIPTION
When there's nothing waiting we wait this long unconditionally, but that
can add a lot of latency across a path.

There are likely better ways to handle this via libuv's run handlers,
but this addresses the latency until we figure that out.