### PR TITLE
Fix MacOS compilation by adding some c++17 fs modernisms to cppbackport

### DIFF
--- a/llarp/config/key_manager.cpp
+++ b/llarp/config/key_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <system_error>
 #include <util/logging/logger.hpp>
+#include <util/fs.hpp>
 #include "config/config.hpp"
 #include "crypto/crypto.hpp"
 #include "crypto/types.hpp"

--- a/vendor/cppbackport-master/lib/fs/filestatus.cpp
+++ b/vendor/cppbackport-master/lib/fs/filestatus.cpp
@@ -182,6 +182,12 @@ namespace cpp17
     }
 
     bool
+    exists(const path& p)
+    {
+      return exists(status(p));
+    }
+
+    bool
     exists(const path& p, __attribute__((unused)) std::error_code& ec)
     {
       return exists(status(p));

--- a/vendor/cppbackport-master/lib/fs/filestatus.h
+++ b/vendor/cppbackport-master/lib/fs/filestatus.h
@@ -66,6 +66,7 @@ file_status symlink_status(const path&);
 bool status_known(file_status);
 
 bool exists(file_status);
+bool exists(const path&);
 bool exists(const path&, std::error_code&);
 bool is_block_file(file_status);
 bool is_block_file(const path&);

--- a/vendor/cppbackport-master/lib/fs/path.cpp
+++ b/vendor/cppbackport-master/lib/fs/path.cpp
@@ -50,6 +50,14 @@ namespace cpp17
     }
 
     path&
+    path::operator+=(const path& p)
+    {
+      s += p.s;
+
+      return *this;
+    }
+
+    path&
     path::operator=(const path& p)
     {
       s = p.s;

--- a/vendor/cppbackport-master/lib/fs/path.h
+++ b/vendor/cppbackport-master/lib/fs/path.h
@@ -74,6 +74,9 @@ public:
 	/// Copy assignment
 	path& operator=(const path&);
 
+	/// Append oeprator
+	path& operator+=(const path&);
+
 	template< typename Source >
 	path& operator=(const Source& source)
 	{

--- a/vendor/cppbackport-master/lib/fs/rename.cpp
+++ b/vendor/cppbackport-master/lib/fs/rename.cpp
@@ -45,7 +45,17 @@ void rename(const path& from, const path& to)
 		if (copy_file(from, to))
 			cpp17::filesystem::remove(from);
 	}
-}
+} // end rename
+
+void rename(const path& from, const path& to, __attribute__((unused)) std::error_code& ec)
+{
+	if (std::rename(from.c_str(), to.c_str()) != 0)
+	{
+		if (copy_file(from, to))
+			cpp17::filesystem::remove(from);
+	}
+} // end rename with ec
+
 }
 }
 

--- a/vendor/cppbackport-master/lib/fs/rename.h
+++ b/vendor/cppbackport-master/lib/fs/rename.h
@@ -36,7 +36,9 @@ namespace cpp17
 namespace filesystem
 {
 void rename(const path& from, const path& to);
+void rename(const path& from, const path& to, std::error_code& ec);
 }
+
 }
 
 #endif // PBL_CPP_FS_RENAME_H


### PR DESCRIPTION
MacOS failed compilation:

```
/Users/admin/Sites/loki-network-dev/llarp/config/key_manager.cpp:142:17: error: no viable overloaded '+='
        newPath += ext;
        ~~~~~~~ ^  ~~~
/Users/admin/Sites/loki-network-dev/llarp/config/key_manager.cpp:144:17: error: no matching function for call to 'exists'
        if (not fs::exists(newPath))
                ^~~~~~~~~~
/Users/admin/Sites/loki-network-dev/cmake/../vendor/cppbackport-master/lib/fs/filestatus.h:68:6: note: candidate function not
      viable: no known conversion from 'fs::path' to 'cpp17::filesystem::file_status' for 1st argument
bool exists(file_status);
     ^
/Users/admin/Sites/loki-network-dev/cmake/../vendor/cppbackport-master/lib/fs/filestatus.h:69:6: note: candidate function not
      viable: requires 2 arguments, but 1 was provided
bool exists(const path&, std::error_code&);
     ^
/Users/admin/Sites/loki-network-dev/llarp/config/key_manager.cpp:182:41: error: too many arguments to function call, expected 2,
      have 3
      fs::rename(filepath, newFilepath, ec);
      ~~~~~~~~~~                        ^~
/Users/admin/Sites/loki-network-dev/cmake/../vendor/cppbackport-master/lib/fs/rename.h:38:1: note: 'rename' declared here
void rename(const path& from, const path& to);
^
```

we could have just changed keymanager but I figure with Stephen's style, he'll be prone to attempting to use them again, so best to just implement them since it's easy enough.