### PR TITLE
Remove unused argument

### DIFF
--- a/llarp/router/i_outbound_session_maker.hpp
+++ b/llarp/router/i_outbound_session_maker.hpp
@@ -44,7 +44,7 @@ namespace llarp
     HavePendingSessionTo(const RouterID &router) const = 0;
 
     virtual void
-    ConnectToRandomRouters(int numDesired, llarp_time_t now) = 0;
+    ConnectToRandomRouters(int numDesired) = 0;
 
     virtual util::StatusObject
     ExtractStatus() const = 0;

--- a/llarp/router/outbound_session_maker.cpp
+++ b/llarp/router/outbound_session_maker.cpp
@@ -118,7 +118,7 @@ namespace llarp
   }
 
   void
-  OutboundSessionMaker::ConnectToRandomRouters(int numDesired, llarp_time_t now)
+  OutboundSessionMaker::ConnectToRandomRouters(int numDesired)
   {
     int remainingDesired = numDesired;
 

--- a/llarp/router/outbound_session_maker.hpp
+++ b/llarp/router/outbound_session_maker.hpp
@@ -47,7 +47,7 @@ namespace llarp
         LOCKS_EXCLUDED(_mutex);
 
     void
-    ConnectToRandomRouters(int numDesired, llarp_time_t now) override;
+    ConnectToRandomRouters(int numDesired) override;
 
     util::StatusObject
     ExtractStatus() const override;

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -723,7 +723,7 @@ namespace llarp
     {
       size_t dlt = connectToNum - connected;
       LogInfo("connecting to ", dlt, " random routers to keep alive");
-      _outboundSessionMaker.ConnectToRandomRouters(dlt, now);
+      _outboundSessionMaker.ConnectToRandomRouters(dlt);
     }
 
     _hiddenServiceContext.Tick(now);
@@ -1118,7 +1118,7 @@ namespace llarp
     }
     if(connected >= want)
       return;
-    _outboundSessionMaker.ConnectToRandomRouters(want, Now());
+    _outboundSessionMaker.ConnectToRandomRouters(want);
   }
 
   bool


### PR DESCRIPTION
Fixed a compiler warning about an unused argument, plus the argument
legitimately appears unused/obsolete now.