### PR TITLE
Optimize AlignedBuffer:::IsZero()

### DIFF
--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -20,6 +20,9 @@ extern "C"
 {
   extern void
   randombytes(unsigned char* const ptr, unsigned long long sz);
+
+  extern int
+  sodium_is_zero(const unsigned char *n, const size_t nlen);
 }
 namespace llarp
 {
@@ -188,9 +191,7 @@ namespace llarp
     bool
     IsZero() const
     {
-      auto notZero = [](byte_t b) { return b != 0; };
-
-      return std::find_if(begin(), end(), notZero) == end();
+      return sodium_is_zero(data(), size());
     }
 
     void


### PR DESCRIPTION
`extern`  is a bit ugly, but this was already used in `AlignedBuffer`...

Interesting note: I actually got better performance with something like this in `IsZero()`:

```cpp
if (sz % sizeof(uint64_t) == 0) {
  // cast data() as uint64_t* and iterate over array as such
} else {
  // delegate to sodium_is_zero
}
```
