### PR TITLE
Aligned buffer simplify

### DIFF
--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -28,7 +28,7 @@ namespace llarp
 {
   /// aligned buffer that is sz bytes long and aligns to the nearest Alignment
   template < size_t sz >
-  struct AlignedBuffer
+  struct alignas(uint64_t) AlignedBuffer
   {
     static constexpr size_t SIZE = sz;
 
@@ -36,34 +36,23 @@ namespace llarp
 
     AlignedBuffer()
     {
-      new(&m_val) Data;
       Zero();
     }
 
     explicit AlignedBuffer(const byte_t* data)
     {
-      new(&m_val) Data;
-      auto& b = as_array();
-      for(size_t idx = 0; idx < sz; ++idx)
-      {
-        b[idx] = data[idx];
-      }
+      *this = data;
     }
 
     explicit AlignedBuffer(const Data& buf)
     {
-      new(&m_val) Data;
-      std::copy(buf.begin(), buf.end(), begin());
+      m_data = buf;
     }
 
     AlignedBuffer&
     operator=(const byte_t* data)
     {
-      auto& b = as_array();
-      for(size_t idx = 0; idx < sz; ++idx)
-      {
-        b[idx] = data[idx];
-      }
+      std::memcpy(m_data.data(), data, sz);
       return *this;
     }
 
@@ -87,37 +76,37 @@ namespace llarp
     bool
     operator==(const AlignedBuffer& other) const
     {
-      return as_array() == other.as_array();
+      return m_data == other.m_data;
     }
 
     bool
     operator!=(const AlignedBuffer& other) const
     {
-      return as_array() != other.as_array();
+      return m_data != other.m_data;
     }
 
     bool
     operator<(const AlignedBuffer& other) const
     {
-      return as_array() < other.as_array();
+      return m_data < other.m_data;
     }
 
     bool
     operator>(const AlignedBuffer& other) const
     {
-      return as_array() > other.as_array();
+      return m_data > other.m_data;
     }
 
     bool
     operator<=(const AlignedBuffer& other) const
     {
-      return as_array() <= other.as_array();
+      return m_data <= other.m_data;
     }
 
     bool
     operator>=(const AlignedBuffer& other) const
     {
-      return as_array() >= other.as_array();
+      return m_data >= other.m_data;
     }
 
     AlignedBuffer
@@ -133,9 +122,9 @@ namespace llarp
     operator^=(const AlignedBuffer& other)
     {
       // Mutate in place instead.
-      for(size_t i = 0; i < as_array().size(); ++i)
+      for(size_t i = 0; i < sz; ++i)
       {
-        as_array()[i] ^= other.as_array()[i];
+        m_data[i] ^= other.m_data[i];
       }
       return *this;
     }
@@ -143,13 +132,13 @@ namespace llarp
     byte_t& operator[](size_t idx)
     {
       assert(idx < SIZE);
-      return as_array()[idx];
+      return m_data[idx];
     }
 
     const byte_t& operator[](size_t idx) const
     {
       assert(idx < SIZE);
-      return as_array()[idx];
+      return m_data[idx];
     }
 
     static constexpr size_t
@@ -161,31 +150,31 @@ namespace llarp
     void
     Fill(byte_t f)
     {
-      as_array().fill(f);
+      m_data.fill(f);
     }
 
     Data&
     as_array()
     {
-      return reinterpret_cast< Data& >(m_val);
+      return m_data;
     }
 
     const Data&
     as_array() const
     {
-      return reinterpret_cast< const Data& >(m_val);
+      return m_data;
     }
 
     byte_t*
     data()
     {
-      return as_array().data();
+      return m_data.data();
     }
 
     const byte_t*
     data() const
     {
-      return as_array().data();
+      return m_data.data();
     }
 
     bool
@@ -197,7 +186,7 @@ namespace llarp
     void
     Zero()
     {
-      as_array().fill(0);
+      m_data.fill(0);
     }
 
     void
@@ -209,25 +198,25 @@ namespace llarp
     typename Data::iterator
     begin()
     {
-      return as_array().begin();
+      return m_data.begin();
     }
 
     typename Data::iterator
     end()
     {
-      return as_array().end();
+      return m_data.end();
     }
 
     typename Data::const_iterator
     begin() const
     {
-      return as_array().cbegin();
+      return m_data.cbegin();
     }
 
     typename Data::const_iterator
     end() const
     {
-      return as_array().cend();
+      return m_data.cend();
     }
 
     bool
@@ -279,10 +268,7 @@ namespace llarp
     };
 
    private:
-    using AlignedStorage = typename std::aligned_storage< sizeof(Data),
-                                                          alignof(uint64_t) >::
-        type;  // why did we align to the nearest double-precision float
-    AlignedStorage m_val;
+    Data m_data;
   };
 }  // namespace llarp
 

--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -28,7 +28,7 @@ namespace llarp
 {
   /// aligned buffer that is sz bytes long and aligns to the nearest Alignment
   template < size_t sz >
-  struct alignas(uint64_t) AlignedBuffer
+  struct alignas(std::max_align_t) AlignedBuffer
   {
     static constexpr size_t SIZE = sz;
 


### PR DESCRIPTION
Simplifies alignment implementation and changes alignment from uint64_t to std::max_align_t.  See commit comments for more details.