### PR TITLE
Don't include net/if.h to help xenial

### DIFF
--- a/include/tuntap.h
+++ b/include/tuntap.h
@@ -36,7 +36,12 @@
 #include <netinet/in.h>
 #endif
 
+#if defined(Linux)
+// Once we drop xenial support we can just include net/if.h on linux
+#include <linux/if.h>
+#else
 #include <net/if.h>
+#endif
 
 #if defined Linux
 #include <netinet/in.h>


### PR DESCRIPTION
Loading both net/if.h and linux/if.h on xenial breaks compilation
because xenial's kernel/glibc headers are broken AF.

We don't actually need anything from net/if.h here, so just include linux/if.h instead.