### PR TITLE
AlignedBuffer<N>::Hash fix

### DIFF
--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -269,7 +269,9 @@ namespace llarp
       size_t
       operator()(const AlignedBuffer& buf) const
       {
-        return *(reinterpret_cast< const size_t* >(buf.data()));
+        size_t hash;
+        std::memcpy(&hash, buf.data(), sizeof(hash));
+        return hash;
       }
     };
 

--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -36,6 +36,8 @@ namespace llarp
   struct alignas(std::max_align_t) AlignedBuffer
 #endif
   {
+    static_assert(sz >= 8, "AlignedBuffer cannot be used with buffers smaller than 8 bytes");
+
     static constexpr size_t SIZE = sz;
 
     using Data = std::array< byte_t, SIZE >;

--- a/test/util/test_llarp_util_aligned.cpp
+++ b/test/util/test_llarp_util_aligned.cpp
@@ -7,13 +7,14 @@
 #include <type_traits>
 #include <unordered_map>
 
-using TestSizes = ::testing::Types< std::integral_constant< std::size_t, 2 >,
-                                    std::integral_constant< std::size_t, 3 >,
-                                    std::integral_constant< std::size_t, 4 >,
-                                    std::integral_constant< std::size_t, 8 >,
+using TestSizes = ::testing::Types< std::integral_constant< std::size_t, 8 >,
+                                    std::integral_constant< std::size_t, 12 >,
                                     std::integral_constant< std::size_t, 16 >,
                                     std::integral_constant< std::size_t, 32 >,
-                                    std::integral_constant< std::size_t, 64 > >;
+                                    std::integral_constant< std::size_t, 64 >,
+                                    std::integral_constant< std::size_t, 77 >,
+                                    std::integral_constant< std::size_t, 1024 >,
+                                    std::integral_constant< std::size_t, 3333 > >;
 
 template < typename T >
 struct AlignedBufferTest : public ::testing::Test


### PR DESCRIPTION
Use `memcpy` to extract hash value

Using the straight `reinterpret_cast` runs into type aliasing issues, which manifest on armhf and sometimes on amd64 for the larger 1024 test (which we removed but get readded here).  C++20 adds `std::bit_cast` to deal with exactly this, but `std::memcpy` is the pre-C++20 way to do it reliably.