### PR TITLE
prevent crash on exit.

### DIFF
--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -1007,10 +1007,6 @@ namespace libuv
           {
             static_cast< glue* >(h->data)->Close();
           }
-          else if(h->type == UV_TIMER)
-          {
-            CloseUVTimer((uv_timer_t*)h);
-          }
         },
         nullptr);
   }


### PR DESCRIPTION
dont close timers on closeall to prevent libuv abort on exit since closing the event loop also closes timers, who knew!?