### PR TITLE
Enable AVX2 compilation whenever possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ project(${PROJECT_NAME} C CXX)
 # Core options
 option(USE_AVX2 "enable avx2 code" OFF)
 option(USE_NETNS "enable networking namespace support. Linux only" OFF)
-option(AMD_RYZEN_HACK "hack for AMD Ryzen FPU bug (support FMA3 and FMA4 in FPU, but does not show in CPUID)" OFF)
 option(NATIVE_BUILD "optimise for host system and FPU" ON)
 option(EMBEDDED_CFG "optimise for older hardware or embedded systems" OFF)
 if (NOT MSVC)
@@ -162,6 +161,8 @@ endif(WOW64_CROSS_COMPILE OR WIN64_CROSS_COMPILE)
 
 if(DEBIAN)
   add_definitions(-DDEBIAN)
+elseif(NATIVE_BUILD)
+  set(CRYPTO_FLAGS -march=native -mtune=native)
 elseif(NOT NON_PC_TARGET)
   if (USE_AVX2)
     set(CRYPTO_FLAGS -march=haswell -mtune=haswell -mfpmath=sse)
@@ -169,16 +170,6 @@ elseif(NOT NON_PC_TARGET)
     # Public binary releases
     set(CRYPTO_FLAGS -march=nocona -mtune=haswell -mfpmath=sse)
   endif()
-endif()
-
-# only needed if using AVX2
-if(AMD_RYZEN_HACK AND USE_AVX2)
-  set(CRYPTO_FLAGS -march=native -mfpmath=sse -mavx -mavx2 -mfma)
-  message(WARNING "This option may be removed in a future release. Contact your computer manufacturer for updated ROMs or microcode patches.")
-endif(AMD_RYZEN_HACK AND USE_AVX2)
-
-if(NATIVE_BUILD AND NOT DEBIAN)
-  set(CRYPTO_FLAGS -march=native -mtune=native)
 endif()
 
 if(EMBEDDED_CFG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,10 +164,10 @@ if(DEBIAN)
   add_definitions(-DDEBIAN)
 elseif(NOT NON_PC_TARGET)
   if (USE_AVX2)
-    set(CRYPTO_FLAGS -march=haswell -mtune=native -mfpmath=sse)
+    set(CRYPTO_FLAGS -march=haswell -mtune=haswell -mfpmath=sse)
   else()
     # Public binary releases
-    set(CRYPTO_FLAGS -march=nocona -mtune=core2 -mfpmath=sse)
+    set(CRYPTO_FLAGS -march=nocona -mtune=haswell -mfpmath=sse)
   endif()
 endif()
 

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -37,7 +37,6 @@ set(NTRU_REF_SRC
 )
 
 set(NTRU_SRC
-  ${NTRU_AVX_SRC}
   ${NTRU_REF_SRC}
   libntrup/src/ntru.cpp
   )
@@ -47,21 +46,41 @@ set(CRYPTOGRAPHY_SRC ${NTRU_SRC})
 add_library(${CRYPTOGRAPHY_LIB} STATIC ${CRYPTOGRAPHY_SRC})
 add_log_tag(${CRYPTOGRAPHY_LIB})
 
+# The avx implementation uses runtime CPU feature detection to enable itself, so we *always* want to
+# compile it with avx2 support even if we aren't compiling with AVX2 enabled.
+add_library(cryptography_avx_lib STATIC ${NTRU_AVX_SRC})
+if(USE_AVX2)
+  # Assume cxxflags are already enabling AVX2
+else()
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-mavx2 COMPILER_SUPPORTS_AVX2)
+  check_cxx_compiler_flag(-mfma COMPILER_SUPPORTS_FMA)
+  if(COMPILER_SUPPORTS_AVX2 AND COMPILER_SUPPORTS_FMA)
+    target_compile_options(cryptography_avx_lib PRIVATE -mavx2 -mfma)
+    message(STATUS "Building libntrup with runtime AVX2/FMA support")
+  else()
+    message(STATUS "Not building with libntrup runtime AVX2/FMA support (can't figure out how to compile with AVX2/FMA: -mavx2 -mfma didn't work)")
+  endif()
+endif()
+target_link_libraries(${CRYPTOGRAPHY_LIB} PRIVATE cryptography_avx_lib)
+
 option(DOWNLOAD_SODIUM "Allow libsodium to be downloaded and built locally if not found on the system" OFF)
 
 find_package(Sodium 1.0.17)
 
 if(sodium_FOUND)
   target_include_directories(${CRYPTOGRAPHY_LIB} PUBLIC ${sodium_INCLUDE_DIR})
-  target_link_libraries(${CRYPTOGRAPHY_LIB} ${sodium_LIBRARY_RELEASE})
+  target_include_directories(cryptography_avx_lib PUBLIC ${sodium_INCLUDE_DIR})
+  target_link_libraries(${CRYPTOGRAPHY_LIB} PUBLIC ${sodium_LIBRARY_RELEASE})
 elseif(DOWNLOAD_SODIUM)
   message(STATUS "Sodium >= 1.0.17 not found, but DOWNLOAD_SODIUM specified, so downloading it")
   include(DownloadLibSodium)
-  target_link_libraries(${CRYPTOGRAPHY_LIB} sodium_vendor)
+  target_link_libraries(${CRYPTOGRAPHY_LIB} PUBLIC sodium_vendor)
 else()
   message(FATAL_ERROR "Could not find libsodium >= 1.0.17; either install it on your system or use -DDOWNLOAD_SODIUM=ON to download and build an internal copy")
 endif()
 
 target_include_directories(${CRYPTOGRAPHY_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/libntrup/include")
+target_include_directories(cryptography_avx_lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/libntrup/include")
 
 


### PR DESCRIPTION
Currently we do runtime AVX2 detection, but it's a bit broken: it only compiles to anything more than stubs if the whole project is compiled with AVX2 support.

This changes it to always attempt to compile the AVX2 ntru code with `-mavx2 -mfma` even when the rest of the code doesn't have AVX2 features enabled so that the run-time detection can let us ship a non-AVX2 binary with the ntru AVX2 optimizations behind the run-time CPU feature detection.

This PR also cleans up the way we set the CPU compiler flags because it was a bit convoluted.