### PR TITLE
Fix avx2 cpu detection on amd64 (again)

### DIFF
--- a/crypto/libntrup/src/ntru.cpp
+++ b/crypto/libntrup/src/ntru.cpp
@@ -1,6 +1,6 @@
 #include <libntrup/ntru.h>
 
-#if __AVX2__
+#ifdef __x86_64__
 #include <cpuid.h>
 #include <array>
 


### PR DESCRIPTION
The optional runtime detection code also shouldn't rely on being compiled in avx2 mode.