### PR TITLE
Remove dead code in llarp_nodedb::Insert()

### DIFF
--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -97,13 +97,12 @@ struct llarp_nodedb
   std::string
   getRCFilePath(const llarp::RouterID &pubkey) const;
 
-  /// insert and optionally write to disk
+  /// insert without writing to disk
   bool
-  Insert(const llarp::RouterContact &rc, bool writeToDisk = false)
-      LOCKS_EXCLUDED(access);
+  Insert(const llarp::RouterContact &rc) LOCKS_EXCLUDED(access);
 
-  /// unconditional insert and write to disk in background
-  /// updates the inserted time of the entry
+  /// invokes Insert() asynchronously with an optional completion
+  /// callback
   void
   InsertAsync(llarp::RouterContact rc,
               std::shared_ptr< llarp::Logic > l             = nullptr,


### PR DESCRIPTION
Pruning a dead code path in nodedb and updating documentation accordingly