### PR TITLE
Include outbound message queue stats in dumpState API response

### DIFF
--- a/llarp/router/outbound_message_handler.cpp
+++ b/llarp/router/outbound_message_handler.cpp
@@ -89,16 +89,13 @@ namespace llarp
   util::StatusObject
   OutboundMessageHandler::ExtractStatus() const
   {
-    util::StatusObject status{ 
-      "queueStats", {
-        { "queued", m_queueStats.queued },
-        { "dropped", m_queueStats.dropped },
-        { "sent", m_queueStats.sent },
-        { "queueWatermark", m_queueStats.queueWatermark },
-        { "perTickMax", m_queueStats.perTickMax },
-        { "numTicks", m_queueStats.numTicks }
-      }
-    };
+    util::StatusObject status{"queueStats",
+                              {{"queued", m_queueStats.queued},
+                               {"dropped", m_queueStats.dropped},
+                               {"sent", m_queueStats.sent},
+                               {"queueWatermark", m_queueStats.queueWatermark},
+                               {"perTickMax", m_queueStats.perTickMax},
+                               {"numTicks", m_queueStats.numTicks}}};
 
     return status;
   }
@@ -252,12 +249,10 @@ namespace llarp
     {
       m_queueStats.queued++;
 
-      // calculate queue high watermark
-      size_t queueSize = outboundQueue.size();
-      if (queueSize > m_queueStats.queueWatermark)
-        m_queueStats.queueWatermark = queueSize;
+      uint32_t queueSize = outboundQueue.size();
+      m_queueStats.queueWatermark =
+          std::max(queueSize, m_queueStats.queueWatermark);
     }
-
 
     return true;
   }
@@ -375,9 +370,8 @@ namespace llarp
       }
     }
 
-    if (sent_count > m_queueStats.perTickMax)
-      m_queueStats.perTickMax = sent_count;
-
+    m_queueStats.perTickMax =
+        std::max((uint32_t)sent_count, m_queueStats.perTickMax);
   }
 
   void

--- a/llarp/router/outbound_message_handler.hpp
+++ b/llarp/router/outbound_message_handler.hpp
@@ -54,6 +54,17 @@ namespace llarp
       RouterID router;
     };
 
+    struct MessageQueueStats
+    {
+      uint64_t queued = 0;
+      uint64_t dropped = 0;
+      uint64_t sent = 0;
+      uint32_t queueWatermark = 0;
+
+      uint32_t perTickMax = 0;
+      uint32_t numTicks = 0;
+    };
+
     using MessageQueue = std::queue< MessageQueueEntry >;
 
     void
@@ -128,6 +139,8 @@ namespace llarp
     // paths cannot have pathid "0", so it can be used as the "pathid"
     // for non-traffic (control) messages, so they can be prioritized.
     static const PathID_t zeroID;
+
+    MessageQueueStats m_queueStats;
   };
 
 }  // namespace llarp

--- a/llarp/router/outbound_message_handler.hpp
+++ b/llarp/router/outbound_message_handler.hpp
@@ -56,13 +56,13 @@ namespace llarp
 
     struct MessageQueueStats
     {
-      uint64_t queued = 0;
-      uint64_t dropped = 0;
-      uint64_t sent = 0;
+      uint64_t queued         = 0;
+      uint64_t dropped        = 0;
+      uint64_t sent           = 0;
       uint32_t queueWatermark = 0;
 
       uint32_t perTickMax = 0;
-      uint32_t numTicks = 0;
+      uint32_t numTicks   = 0;
     };
 
     using MessageQueue = std::queue< MessageQueueEntry >;

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -78,7 +78,8 @@ namespace llarp
           {"dht", _dht->impl->ExtractStatus()},
           {"services", _hiddenServiceContext.ExtractStatus()},
           {"exit", _exitContext.ExtractStatus()},
-          {"links", _linkManager.ExtractStatus()}};
+          {"links", _linkManager.ExtractStatus()},
+          {"outboundMessages", _outboundMessageHandler.ExtractStatus()}};
     }
     else
     {


### PR DESCRIPTION
Adds stats about the outbound message queue, particularly designed to help understand where we are hitting self-imposed limits.

@tewinget and @majestrate , please review with consideration of threading safety.