### PR TITLE
Lookup routers at maximum frequency of 10 minutes

### DIFF
--- a/llarp/router/rc_lookup_handler.cpp
+++ b/llarp/router/rc_lookup_handler.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <router/rc_lookup_handler.hpp>
 
 #include <link/i_link_manager.hpp>
@@ -15,6 +16,8 @@
 #include <iterator>
 #include <functional>
 #include <random>
+
+using namespace std::chrono_literals;
 
 namespace llarp
 {
@@ -112,6 +115,10 @@ namespace llarp
       if(!_dht->impl->LookupRouter(router, fn))
       {
         FinalizeRequest(router, nullptr, RCRequestResult::RouterNotFound);
+      }
+      else
+      {
+        _routerLookupTimes[router] = std::chrono::steady_clock::now();
       }
     }
   }
@@ -248,19 +255,24 @@ namespace llarp
 
     if(useWhitelist)
     {
-      static constexpr size_t LookupPerTick = 25;
+      static constexpr size_t LookupPerTick   = 25;
+      static constexpr auto RerequestInterval = 10min;
 
       std::vector< RouterID > lookupRouters;
       lookupRouters.reserve(LookupPerTick);
+
+      const auto now = std::chrono::steady_clock::now();
 
       {
         // if we are using a whitelist look up a few routers we don't have
         util::Lock l(&_mutex);
         for(const auto &r : whitelistRouters)
         {
-          if(_nodedb->Has(r))
-            continue;
-          lookupRouters.emplace_back(r);
+          if(now > _routerLookupTimes[r] + RerequestInterval
+             and not _nodedb->Has(r))
+          {
+            lookupRouters.emplace_back(r);
+          }
         }
       }
 

--- a/llarp/router/rc_lookup_handler.hpp
+++ b/llarp/router/rc_lookup_handler.hpp
@@ -1,6 +1,7 @@
 #ifndef LLARP_RC_LOOKUP_HANDLER_HPP
 #define LLARP_RC_LOOKUP_HANDLER_HPP
 
+#include <chrono>
 #include <router/i_rc_lookup_handler.hpp>
 
 #include <util/thread/threading.hpp>
@@ -115,6 +116,10 @@ namespace llarp
     bool isServiceNode = false;
 
     std::set< RouterID > whitelistRouters GUARDED_BY(_mutex);
+
+    using TimePoint = std::chrono::steady_clock::time_point;
+    std::unordered_map< RouterID, TimePoint, RouterID::Hash >
+        _routerLookupTimes;
   };
 
 }  // namespace llarp


### PR DESCRIPTION
Partially addresses #1047 by limiting lookup frequency of any router to 10 minutes.