### PR TITLE
don't deadlock on path queue removal if full

### DIFF
--- a/llarp/router/outbound_message_handler.cpp
+++ b/llarp/router/outbound_message_handler.cpp
@@ -83,8 +83,13 @@ namespace llarp
   void
   OutboundMessageHandler::QueueRemoveEmptyPath(const PathID_t &pathid)
   {
-    m_Killer.TryAccess(
-        [self = this, pathid]() { self->removedPaths.pushBack(pathid); });
+    m_Killer.TryAccess([self = this, pathid]() {
+      if(self->removedPaths.full())
+      {
+        self->RemoveEmptyPathQueues();
+      }
+      self->removedPaths.pushBack(pathid);
+    });
   }
 
   // TODO: this


### PR DESCRIPTION
when we want to remove lots of paths flush queue when full then add to queue