### PR TITLE
use std::shared_ptr not a bare pointer to prevent memleak

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -473,7 +473,7 @@ namespace llarp
           }
           else
           {
-            auto replyMsg = std::make_shared<dns::Message>(std::move(msg));
+            auto replyMsg = std::make_shared< dns::Message >(std::move(msg));
             using service::Address;
             using service::OutboundContext;
             return EnsurePathToService(
@@ -493,7 +493,7 @@ namespace llarp
           }
           else
           {
-            auto replyMsg = std::make_shared<dns::Message>(std::move(msg));
+            auto replyMsg = std::make_shared< dns::Message >(std::move(msg));
             return EnsurePathToSNode(
                 addr.as_array(),
                 [=](const RouterID &, exit::BaseSession_ptr s) {

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -473,7 +473,7 @@ namespace llarp
           }
           else
           {
-            auto *replyMsg = new dns::Message(std::move(msg));
+            auto replyMsg = std::make_shared<dns::Message>(std::move(msg));
             using service::Address;
             using service::OutboundContext;
             return EnsurePathToService(
@@ -493,7 +493,7 @@ namespace llarp
           }
           else
           {
-            auto *replyMsg = new dns::Message(std::move(msg));
+            auto replyMsg = std::make_shared<dns::Message>(std::move(msg));
             return EnsurePathToSNode(
                 addr.as_array(),
                 [=](const RouterID &, exit::BaseSession_ptr s) {

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -271,7 +271,7 @@ namespace llarp
 
       template < typename Addr_t, typename Endpoint_t >
       void
-      SendDNSReply(Addr_t addr, Endpoint_t ctx, dns::Message* query,
+      SendDNSReply(Addr_t addr, Endpoint_t ctx, std::shared_ptr<dns::Message> query,
                    std::function< void(dns::Message) > reply, bool snode,
                    bool sendIPv6)
       {
@@ -283,7 +283,6 @@ namespace llarp
         else
           query->AddNXReply();
         reply(*query);
-        delete query;
       }
       /// our dns resolver
       std::shared_ptr< dns::Proxy > m_Resolver;

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -271,7 +271,8 @@ namespace llarp
 
       template < typename Addr_t, typename Endpoint_t >
       void
-      SendDNSReply(Addr_t addr, Endpoint_t ctx, std::shared_ptr<dns::Message> query,
+      SendDNSReply(Addr_t addr, Endpoint_t ctx,
+                   std::shared_ptr< dns::Message > query,
                    std::function< void(dns::Message) > reply, bool snode,
                    bool sendIPv6)
       {


### PR DESCRIPTION
if `EnsurePathToXXXX` returns false it doesn't call the hook which causes a leak. 