### PR TITLE
Add IWP session stats to JSON API

### DIFF
--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -196,6 +196,7 @@ namespace llarp
       {
         msg.FlushUnAcked(util::memFn(&Session::EncryptAndSend, this), now);
       }
+      m_Stats.totalInFlightTX++;
       LogDebug("send message ", msgid);
       return true;
     }
@@ -298,15 +299,25 @@ namespace llarp
     util::StatusObject
     Session::ExtractStatus() const
     {
-      return {{"tx", m_CurrentTX},
-              {"rx", m_CurrentRX},
-              {"state", m_State},
+      const auto now = m_Parent->Now();
+
+      return {{"txRateCurrent", m_Stats.currentRateTX},
+              {"rxRateCurrent", m_Stats.currentRateRX},
+              {"rxPktsRcvd", m_Stats.totalPacketsRX},
+
+              {"txPktsAcked", m_Stats.totalAckedTX},
+              {"txPktsDropped", m_Stats.totalDroppedTX},
+              {"txPktsInFlight", m_Stats.totalInFlightTX},
+
+              {"state", toString(m_State)},
               {"inbound", m_Inbound},
               {"replayFilter", m_ReplayFilter.size()},
-              {"txMsgs", m_TXMsgs.size()},
-              {"rxMsgs", m_RXMsgs.size()},
+              {"txMsgQueueSize", m_TXMsgs.size()},
+              {"rxMsgQueueSize", m_RXMsgs.size()},
               {"remoteAddr", m_RemoteAddr.ToString()},
-              {"remoteRC", m_RemoteRC.ExtractStatus()}};
+              {"remoteRC", m_RemoteRC.ExtractStatus()},
+              {"created", m_CreatedAt},
+              {"uptime", (now - m_CreatedAt)}};
     }
 
     bool
@@ -328,8 +339,8 @@ namespace llarp
     void
     Session::ResetRates()
     {
-      m_CurrentTX = m_TXRate;
-      m_CurrentRX = m_RXRate;
+      m_Stats.currentRateTX = m_TXRate;
+      m_Stats.currentRateRX = m_RXRate;
       m_RXRate    = 0;
       m_TXRate    = 0;
     }
@@ -350,6 +361,9 @@ namespace llarp
         {
           if(itr->second.IsTimedOut(now))
           {
+            m_Stats.totalDroppedTX++;
+            m_Stats.totalInFlightTX--;
+            LogWarn("Dropped unacked packet to ", m_RemoteAddr);
             itr->second.InformTimeout();
             itr = m_TXMsgs.erase(itr);
           }
@@ -661,6 +675,8 @@ namespace llarp
         auto itr = m_TXMsgs.find(acked);
         if(itr != m_TXMsgs.end())
         {
+          m_Stats.totalAckedTX++;
+          m_Stats.totalInFlightTX--;
           itr->second.Completed();
           m_TXMsgs.erase(itr);
         }
@@ -880,6 +896,9 @@ namespace llarp
     Session::Recv_LL(ILinkSession::Packet_t data)
     {
       m_RXRate += data.size();
+
+      // TODO: differentiate between good and bad RX packets here
+      m_Stats.totalPacketsRX++;
       switch(m_State)
       {
         case State::Initial:
@@ -922,6 +941,26 @@ namespace llarp
           break;
       }
       return true;
+    }
+
+    std::string
+    Session::toString(State state)
+    {
+      switch(state)
+      {
+        case State::Initial:
+          return "Initial";
+        case State::Introduction:
+          return "Introduction";
+        case State::LinkIntro:
+          return "LinkIntro";
+        case State::Ready:
+          return "Ready";
+        case State::Closed:
+          return "Close";
+        default:
+          return "Invalid";
+      }
     }
   }  // namespace iwp
 }  // namespace llarp

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -305,6 +305,10 @@ namespace llarp
               {"rxRateCurrent", m_Stats.currentRateRX},
               {"rxPktsRcvd", m_Stats.totalPacketsRX},
 
+              // leave 'tx' and 'rx' as duplicates of 'xRateCurrent' for compat
+              {"tx", m_Stats.currentRateTX},
+              {"rx", m_Stats.currentRateRX},
+
               {"txPktsAcked", m_Stats.totalAckedTX},
               {"txPktsDropped", m_Stats.totalDroppedTX},
               {"txPktsInFlight", m_Stats.totalInFlightTX},

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -345,8 +345,8 @@ namespace llarp
     {
       m_Stats.currentRateTX = m_TXRate;
       m_Stats.currentRateRX = m_RXRate;
-      m_RXRate    = 0;
-      m_TXRate    = 0;
+      m_RXRate              = 0;
+      m_TXRate              = 0;
     }
 
     void

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -313,7 +313,7 @@ namespace llarp
               {"txPktsDropped", m_Stats.totalDroppedTX},
               {"txPktsInFlight", m_Stats.totalInFlightTX},
 
-              {"state", toString(m_State)},
+              {"state", StateToString(m_State)},
               {"inbound", m_Inbound},
               {"replayFilter", m_ReplayFilter.size()},
               {"txMsgQueueSize", m_TXMsgs.size()},
@@ -948,7 +948,7 @@ namespace llarp
     }
 
     std::string
-    Session::toString(State state)
+    Session::StateToString(State state)
     {
       switch(state)
       {

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -143,7 +143,7 @@ namespace llarp
         /// we are closed now
         Closed
       };
-      static std::string toString(State state);
+      static std::string StateToString(State state);
       State m_State;
 
       struct Stats

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -143,7 +143,8 @@ namespace llarp
         /// we are closed now
         Closed
       };
-      static std::string StateToString(State state);
+      static std::string
+      StateToString(State state);
       State m_State;
 
       struct Stats
@@ -154,8 +155,8 @@ namespace llarp
 
         uint64_t totalPacketsRX = 0;
 
-        uint64_t totalAckedTX = 0;
-        uint64_t totalDroppedTX = 0;
+        uint64_t totalAckedTX    = 0;
+        uint64_t totalDroppedTX  = 0;
         uint64_t totalInFlightTX = 0;
       };
       Stats m_Stats;

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -143,7 +143,23 @@ namespace llarp
         /// we are closed now
         Closed
       };
+      static std::string toString(State state);
       State m_State;
+
+      struct Stats
+      {
+        // rate
+        uint64_t currentRateRX = 0;
+        uint64_t currentRateTX = 0;
+
+        uint64_t totalPacketsRX = 0;
+
+        uint64_t totalAckedTX = 0;
+        uint64_t totalDroppedTX = 0;
+        uint64_t totalInFlightTX = 0;
+      };
+      Stats m_Stats;
+
       /// are we inbound session ?
       const bool m_Inbound;
       /// parent link layer
@@ -165,11 +181,9 @@ namespace llarp
       llarp_time_t m_LastTX = 0;
       llarp_time_t m_LastRX = 0;
 
+      // accumulate for periodic rate calculation
       uint64_t m_TXRate = 0;
       uint64_t m_RXRate = 0;
-
-      uint64_t m_CurrentTX = 0;
-      uint64_t m_CurrentRX = 0;
 
       llarp_time_t m_ResetRatesAt = 0;
 


### PR DESCRIPTION
IWP session JSON now looks like:

```json
          {
            "created": 1581100813495,
            "inbound": false,
            "remoteAddr": "51.15.58.238:1092",
            "remoteRC": {
              "addresses": [
                {
                  "dialect": "iwp",
                  "in6_addr": "::ffff:51.15.58.238",
                  "port": 1092,
                  "pubkey": "6323893e9aef463ddcef056b2b1aff310bcfb8db3b90176ce25f76bed090144c",
                  "rank": 2
                }
              ],
              "exit": false,
              "identity": "4b637c243a38373e6e85a6cd7cf491fb6583da18b991eb51f25acc9dd5d0b74c",
              "lastUpdated": 1581098115111,
              "publicRouter": true
            },
            "replayFilter": 9,
            "rxMsgQueueSize": 0,
            "rxPktsRcvd": 841,
            "rxRateCurrent": 9127,
            "state": "Ready",
            "txMsgQueueSize": 0,
            "txPktsAcked": 214,
            "txPktsDropped": 0,
            "txPktsInFlight": 0,
            "txRateCurrent": 5694,
            "uptime": 53293
          },
```