### PR TITLE
Reduce introset publishing interal to 2.5min instead of 1.25min

### DIFF
--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -65,7 +65,7 @@ namespace llarp
     {
       /// minimum interval for publishing introsets
       static const llarp_time_t INTROSET_PUBLISH_INTERVAL =
-          path::default_lifetime / 8;
+          path::default_lifetime / 4;
 
       static const llarp_time_t INTROSET_PUBLISH_RETRY_INTERVAL = 5000;
 


### PR DESCRIPTION
We want to have some redundancy, but having 8 active at once seems
extreme; reduce to 4.