### PR TITLE
Use endpoint path for outbound context introset update

### DIFF
--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -197,11 +197,6 @@ namespace llarp
       bool
       HasPendingPathToService(const Address& remote) const;
 
-      /// return false if we don't have a path to the service
-      /// return true if we did and we removed it
-      bool
-      ForgetPathToService(const Address& remote);
-
       bool
       HandleDataMessage(path::Path_ptr path, const PathID_t from,
                         std::shared_ptr< ProtocolMessage > msg) override;
@@ -253,8 +248,6 @@ namespace llarp
       bool
       SendTo(const ConvoTag tag, const llarp_buffer_t& pkt, ProtocolType t);
 
-      ;
-
       bool
       HandleDataDrop(path::Path_ptr p, const PathID_t& dst, uint64_t s);
 
@@ -262,6 +255,12 @@ namespace llarp
       CheckPathIsDead(path::Path_ptr p, llarp_time_t latency);
 
       using PendingBufferQueue = std::deque< PendingBuffer >;
+
+      bool
+      WantsOutboundSession(const Address&) const override;
+
+      void
+      MarkAddressOutbound(const Address&) override;
 
       bool
       ShouldBundleRC() const override;

--- a/llarp/service/endpoint_state.hpp
+++ b/llarp/service/endpoint_state.hpp
@@ -95,6 +95,8 @@ namespace llarp
       /// conversations
       ConvoMap m_Sessions;
 
+      OutboundSessions_t m_OutboundSessions;
+
       std::unordered_map< Tag, CachedTagResult, Tag::Hash > m_PrefetchedTags;
 
       bool

--- a/llarp/service/endpoint_types.hpp
+++ b/llarp/service/endpoint_types.hpp
@@ -54,6 +54,9 @@ namespace llarp
 
     using ConvoMap = std::unordered_map< ConvoTag, Session, ConvoTag::Hash >;
 
+    /// set of outbound addresses to maintain to
+    using OutboundSessions_t = std::unordered_set< Address, Address::Hash >;
+
     using PathEnsureHook = std::function< void(Address, OutboundContext*) >;
 
   }  // namespace service

--- a/llarp/service/handler.hpp
+++ b/llarp/service/handler.hpp
@@ -72,6 +72,13 @@ namespace llarp
       virtual bool
       HasInboundConvo(const Address& addr) const = 0;
 
+      /// do we want a session outbound to addr
+      virtual bool
+      WantsOutboundSession(const Address& addr) const = 0;
+
+      virtual void
+      MarkAddressOutbound(const Address& addr) = 0;
+
       virtual void
       QueueRecvData(RecvDataEvent ev) = 0;
     };

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -278,6 +278,7 @@ namespace llarp
       // check for expiration
       if(remoteIntro.ExpiresSoon(now))
       {
+        UpdateIntroSet();
         // shift intro if it expires "soon"
         if(ShiftIntroduction())
           SwapIntros();  // swap intros if we shifted
@@ -292,10 +293,6 @@ namespace llarp
           itr = m_BadIntros.erase(itr);
         else
           ++itr;
-      }
-      if(currentIntroSet.HasExpiredIntros(now))
-      {
-        UpdateIntroSet();
       }
       // send control message if we look too quiet
       if(lastGoodSend)

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -227,7 +227,8 @@ namespace llarp
       if(updatingIntroSet || markedBad)
         return;
       const auto addr = currentIntroSet.A.Addr();
-
+      // we want to use the parent endpoint's paths because outbound context
+      // does not implement path::PathSet::HandleGotIntroMessage
       const auto paths    = GetManyPathsWithUniqueEndpoints(m_Endpoint, 2);
       uint64_t relayOrder = 0;
       for(const auto& path : paths)

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -228,7 +228,7 @@ namespace llarp
         return;
       const auto addr = currentIntroSet.A.Addr();
 
-      const auto paths    = GetManyPathsWithUniqueEndpoints(this, 2);
+      const auto paths    = GetManyPathsWithUniqueEndpoints(m_Endpoint, 2);
       uint64_t relayOrder = 0;
       for(const auto& path : paths)
       {


### PR DESCRIPTION
outbound context does not override `pathset::HandleGotIntroMessage` who's default behavior is to drop messages when not overrided. thus we should use the parent endpoint's paths for lookups as it will properly handle replies.