### PR TITLE
Remove llvm from travis-ci homebrew packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,6 @@ addons:
     - cmake
     - curl
     - libuv
-    - llvm
     - make
     - mingw-w64
     - ninja


### PR DESCRIPTION
It doesn't seem like we need this for the mac build.