### PR TITLE
JSONRPC updates

### DIFF
--- a/libabyss/include/abyss/server.hpp
+++ b/libabyss/include/abyss/server.hpp
@@ -23,14 +23,10 @@ namespace abyss
 
     struct IRPCHandler
     {
-      using Method_t = std::string;
-      using Params   = nlohmann::json;
-      using Response = nlohmann::json;
-
       IRPCHandler(ConnImpl* impl);
 
-      virtual Response
-      HandleJSONRPC(Method_t method, const Params& params) = 0;
+      virtual nlohmann::json
+      HandleJSONRPC(std::string method, const nlohmann::json& params) = 0;
 
       virtual ~IRPCHandler();
 

--- a/llarp/rpc/rpc.cpp
+++ b/llarp/rpc/rpc.cpp
@@ -292,15 +292,18 @@ namespace llarp
           : ::abyss::httpd::IRPCHandler(conn)
           , router(r)
           , m_dispatch{
-                {"llarp.admin.wakeup", [=](auto&&) { return StartRouter(); }},
+                {"llarp.admin.wakeup",
+                 [this](auto&&) { return StartRouter(); }},
                 {"llarp.admin.link.neighbor",
-                 [=](auto&&) { return ListNeighbors(); }},
+                 [this](auto&&) { return ListNeighbors(); }},
                 {"llarp.admin.exit.list",
-                 [=](auto&&) { return ListExitLevels(); }},
-                {"llarp.admin.dumpstate", [=](auto&&) { return DumpState(); }},
-                {"llarp.admin.status", [=](auto&&) { return DumpStatus(); }},
-                {"llarp.our.addresses", [=](auto&&) { return OurAddresses(); }},
-                {"llarp.version", [=](auto&&) { return DumpVersion(); }}}
+                 [this](auto&&) { return ListExitLevels(); }},
+                {"llarp.admin.dumpstate",
+                 [this](auto&&) { return DumpState(); }},
+                {"llarp.admin.status", [this](auto&&) { return DumpStatus(); }},
+                {"llarp.our.addresses",
+                 [this](auto&&) { return OurAddresses(); }},
+                {"llarp.version", [this](auto&&) { return DumpVersion(); }}}
       {
       }
 

--- a/llarp/rpc/rpc.cpp
+++ b/llarp/rpc/rpc.cpp
@@ -291,19 +291,20 @@ namespace llarp
       Handler(::abyss::httpd::ConnImpl* conn, AbstractRouter* r)
           : ::abyss::httpd::IRPCHandler(conn)
           , router(r)
-          , m_dispatch{
-                {"llarp.admin.wakeup",
-                 [this](auto&&) { return StartRouter(); }},
-                {"llarp.admin.link.neighbor",
-                 [this](auto&&) { return ListNeighbors(); }},
-                {"llarp.admin.exit.list",
-                 [this](auto&&) { return ListExitLevels(); }},
-                {"llarp.admin.dumpstate",
-                 [this](auto&&) { return DumpState(); }},
-                {"llarp.admin.status", [this](auto&&) { return DumpStatus(); }},
-                {"llarp.our.addresses",
-                 [this](auto&&) { return OurAddresses(); }},
-                {"llarp.version", [this](auto&&) { return DumpVersion(); }}}
+          , m_dispatch{{"llarp.admin.wakeup",
+                        [this](const auto&) { return StartRouter(); }},
+                       {"llarp.admin.link.neighbor",
+                        [this](const auto&) { return ListNeighbors(); }},
+                       {"llarp.admin.exit.list",
+                        [this](const auto&) { return ListExitLevels(); }},
+                       {"llarp.admin.dumpstate",
+                        [this](const auto&) { return DumpState(); }},
+                       {"llarp.admin.status",
+                        [this](const auto&) { return DumpStatus(); }},
+                       {"llarp.our.addresses",
+                        [this](const auto&) { return OurAddresses(); }},
+                       {"llarp.version",
+                        [this](const auto&) { return DumpVersion(); }}}
       {
       }
 

--- a/test/test_libabyss.cpp
+++ b/test/test_libabyss.cpp
@@ -107,12 +107,12 @@ struct ServerHandler : public abyss::httpd::IRPCHandler
   {
   }
 
-  Response
-  HandleJSONRPC(Method_t method, const Params& /*params*/)
+  nlohmann::json
+  HandleJSONRPC(std::string method, const nlohmann::json& /*params*/)
   {
     test->AssertMethod(method);
     test->called = true;
-    return Response();
+    return {};
   }
 
   ~ServerHandler()


### PR DESCRIPTION
(On top of #1110, only the last commit here is relevant).

- Fixes the JSONRPC callable to take the json parameters argument

- Removes the Response/Params/Method_t typedefs as they seemed to
  obscure the underlying types (json/json/string) rather than usefully
  abstract them.