### PR TITLE
Spread snapp path builds evenly

### DIFF
--- a/llarp/constants/path.hpp
+++ b/llarp/constants/path.hpp
@@ -1,6 +1,7 @@
 #ifndef LLARP_CONSTANTS_PATH_HPP
 #define LLARP_CONSTANTS_PATH_HPP
 
+#include <chrono>
 #include <cstddef>
 
 #include <util/types.hpp>
@@ -17,7 +18,13 @@ namespace llarp
     /// pad messages to the nearest this many bytes
     constexpr std::size_t pad_size = 128;
     /// default path lifetime in ms
-    static constexpr auto default_lifetime = 20min;
+    static constexpr std::chrono::milliseconds default_lifetime = 20min;
+    /// minimum into lifetime we will advertise
+    static constexpr std::chrono::milliseconds min_intro_lifetime =
+        default_lifetime / 2;
+    /// spacing frequency at which we try to build paths for introductions
+    static constexpr std::chrono::milliseconds intro_path_spread =
+        default_lifetime / 4;
     /// after this many ms a path build times out
     static constexpr auto build_timeout = 30s;
 

--- a/llarp/constants/path.hpp
+++ b/llarp/constants/path.hpp
@@ -17,7 +17,7 @@ namespace llarp
     /// pad messages to the nearest this many bytes
     constexpr std::size_t pad_size = 128;
     /// default path lifetime in ms
-    static constexpr auto default_lifetime = 10min;
+    static constexpr auto default_lifetime = 20min;
     /// after this many ms a path build times out
     static constexpr auto build_timeout = 30s;
 

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -1278,12 +1278,13 @@ namespace llarp
         return false;
 
       size_t numBuilding = NumInStatus(path::ePathBuilding);
-      if (numBuilding > 0)
+      if(numBuilding > 0)
         return false;
 
       static constexpr auto buildSpread = path::default_lifetime / 4;
-      const auto sinceEpoch = m_lastBuildStarted.time_since_epoch();
-      const auto sinceEpochMs = std::chrono::duration_cast< std::chrono::milliseconds >(sinceEpoch);
+      const auto sinceEpoch             = m_lastBuildStarted.time_since_epoch();
+      const auto sinceEpochMs =
+          std::chrono::duration_cast< std::chrono::milliseconds >(sinceEpoch);
 
       return ((now - sinceEpochMs.count()) > buildSpread);
     }

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -75,10 +75,10 @@ namespace llarp
     Endpoint::RegenAndPublishIntroSet(bool forceRebuild)
     {
       const auto now = llarp::time_now_ms();
-      std::set< Introduction > I;
+      std::set< Introduction > introset;
       if(!GetCurrentIntroductionsWithFilter(
-             I, [now](const service::Introduction& intro) -> bool {
-               return not intro.ExpiresSoon(now, 2min);
+             introset, [now](const service::Introduction& intro) -> bool {
+               return not intro.ExpiresSoon(now, path::default_lifetime * 2);
              }))
       {
         LogWarn("could not publish descriptors for endpoint ", Name(),
@@ -88,7 +88,7 @@ namespace llarp
         return;
       }
       introSet().I.clear();
-      for(auto& intro : I)
+      for(auto& intro : introset)
       {
         introSet().I.emplace_back(std::move(intro));
       }

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -78,7 +78,7 @@ namespace llarp
       std::set< Introduction > introset;
       if(!GetCurrentIntroductionsWithFilter(
              introset, [now](const service::Introduction& intro) -> bool {
-               return not intro.ExpiresSoon(now, path::default_lifetime * 2);
+               return not intro.ExpiresSoon(now, path::min_intro_lifetime);
              }))
       {
         LogWarn("could not publish descriptors for endpoint ", Name(),
@@ -1282,8 +1282,7 @@ namespace llarp
       if(numBuilding > 0)
         return false;
 
-      static constexpr auto buildSpread = path::default_lifetime / 4;
-      return ((now - lastBuild) > buildSpread);
+      return ((now - lastBuild) > path::intro_path_spread);
     }
 
     std::shared_ptr< Logic >

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -456,7 +456,7 @@ namespace llarp
     }
 
     bool
-    Endpoint::PublishIntroSet(const EncryptedIntroSet& i, AbstractRouter* r)
+    Endpoint::PublishIntroSet(const EncryptedIntroSet& introset, AbstractRouter* r)
     {
       /// number of routers to publish to
       static constexpr size_t PublishRedundancy = 2;
@@ -466,7 +466,7 @@ namespace llarp
       size_t published = 0;
       for(const auto& path : paths)
       {
-        if(PublishIntroSetVia(i, r, path, published))
+        if(PublishIntroSetVia(introset, r, path, published))
         {
           published++;
         }
@@ -525,10 +525,10 @@ namespace llarp
     }
 
     bool
-    Endpoint::PublishIntroSetVia(const EncryptedIntroSet& i, AbstractRouter* r,
+    Endpoint::PublishIntroSetVia(const EncryptedIntroSet& introset, AbstractRouter* r,
                                  path::Path_ptr path, uint64_t relayOrder)
     {
-      auto job = new PublishIntroSetJob(this, GenTXID(), i, relayOrder);
+      auto job = new PublishIntroSetJob(this, GenTXID(), introset, relayOrder);
       if(job->SendRequestViaPath(path, r))
       {
         m_state->m_LastPublishAttempt = Now();
@@ -563,9 +563,9 @@ namespace llarp
       ForEachPath([&](const path::Path_ptr& p) {
         if(!p->IsReady())
           return;
-        for(const auto& i : introSet().I)
+        for(const auto& introset : introSet().I)
         {
-          if(i == p->intro)
+          if(introset == p->intro)
             return;
         }
         ++numNotInIntroset;

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -633,7 +633,6 @@ namespace llarp
     void
     Endpoint::PathBuildStarted(path::Path_ptr path)
     {
-      m_lastBuildStarted = std::chrono::steady_clock::now();
       path::Builder::PathBuildStarted(path);
     }
 
@@ -1284,11 +1283,7 @@ namespace llarp
         return false;
 
       static constexpr auto buildSpread = path::default_lifetime / 4;
-      const auto sinceEpoch             = m_lastBuildStarted.time_since_epoch();
-      const auto sinceEpochMs =
-          std::chrono::duration_cast< std::chrono::milliseconds >(sinceEpoch);
-
-      return ((now - sinceEpochMs.count()) > buildSpread);
+      return ((now - lastBuild) > buildSpread);
     }
 
     std::shared_ptr< Logic >

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -456,7 +456,8 @@ namespace llarp
     }
 
     bool
-    Endpoint::PublishIntroSet(const EncryptedIntroSet& introset, AbstractRouter* r)
+    Endpoint::PublishIntroSet(const EncryptedIntroSet& introset,
+                              AbstractRouter* r)
     {
       /// number of routers to publish to
       static constexpr size_t PublishRedundancy = 2;
@@ -525,8 +526,9 @@ namespace llarp
     }
 
     bool
-    Endpoint::PublishIntroSetVia(const EncryptedIntroSet& introset, AbstractRouter* r,
-                                 path::Path_ptr path, uint64_t relayOrder)
+    Endpoint::PublishIntroSetVia(const EncryptedIntroSet& introset,
+                                 AbstractRouter* r, path::Path_ptr path,
+                                 uint64_t relayOrder)
     {
       auto job = new PublishIntroSetJob(this, GenTXID(), introset, relayOrder);
       if(job->SendRequestViaPath(path, r))

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -459,7 +459,6 @@ namespace llarp
 
       std::unique_ptr< EndpointState > m_state;
       thread::Queue< RecvDataEvent > m_RecvQueue;
-      std::chrono::steady_clock::time_point m_lastBuildStarted;
     };
 
     using Endpoint_ptr = std::shared_ptr< Endpoint >;

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -356,6 +356,9 @@ namespace llarp
                 RouterContact& cur, size_t hop, path::PathRole roles) override;
 
       virtual void
+      PathBuildStarted(path::Path_ptr path) override;
+
+      virtual void
       IntroSetPublishFail();
       virtual void
       IntroSetPublished();
@@ -456,6 +459,7 @@ namespace llarp
 
       std::unique_ptr< EndpointState > m_state;
       thread::Queue< RecvDataEvent > m_RecvQueue;
+      std::chrono::steady_clock::time_point m_lastBuildStarted;
     };
 
     using Endpoint_ptr = std::shared_ptr< Endpoint >;


### PR DESCRIPTION
Notice what a PITA it is to deal with `std::chrono` and `llarp_time_t` at the same time...
