### PR TITLE
Shorten version and prefix with v

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -680,7 +680,7 @@ namespace llarp
 #if defined(WITH_SYSTEMD)
     {
       std::stringstream ss;
-      ss << "WATCHDOG=1\nSTATUS=" << llarp::VERSION_FULL;
+      ss << "WATCHDOG=1\nSTATUS=v" << llarp::VERSION_STR;
       if(IsServiceNode())
       {
         ss << " snode | known/svc/clients: " << nodedb()->num_loaded() << "/"


### PR DESCRIPTION
So we get `v0.7.0` instead of `lokinet-0.7.0-abcdef12`; the latter is
useful for devs, but not so much for random operators (and you can
always go get the full version from the binary).