### PR TITLE
allow building from source tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+external/date/test export-ignore
+external/nlohmann/doc export-ignore
+external/nlohmann/test export-ignore
+external/nlohmann/benchmarks/data export-ignore
+*.exe export-ignore
+*.png export-ignore
+*.gif export-ignore

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,6 +1,7 @@
 
 find_package(Git QUIET)
-if(GIT_FOUND OR Git_FOUND)
+set(GIT_INDEX_FILE "${PROJECT_SOURCE_DIR}/.git/index")
+if(EXISTS ${GIT_INDEX_FILE} AND GIT_FOUND OR Git_FOUND)
   message(STATUS "Found Git: ${GIT_EXECUTABLE}")
 
   add_custom_command(
@@ -11,9 +12,9 @@ if(GIT_FOUND OR Git_FOUND)
                       "-D" "DEST=${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp"
                       "-P" "${CMAKE_CURRENT_LIST_DIR}/GenVersion.cmake"
     DEPENDS           "${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in"
-                      "${CMAKE_CURRENT_SOURCE_DIR}/../.git/index")
+                      "${GIT_INDEX_FILE}")
 else()
-  message(WARNING "Git was not found! Setting version to to nogit")
+  message(STATUS "Git was not found! Setting version to to nogit")
   set(VERSIONTAG "nogit")
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp")
 endif()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,7 +1,7 @@
 
 find_package(Git QUIET)
 set(GIT_INDEX_FILE "${PROJECT_SOURCE_DIR}/.git/index")
-if(EXISTS ${GIT_INDEX_FILE} AND GIT_FOUND OR Git_FOUND)
+if(EXISTS ${GIT_INDEX_FILE} AND ( GIT_FOUND OR Git_FOUND) )
   message(STATUS "Found Git: ${GIT_EXECUTABLE}")
 
   add_custom_command(


### PR DESCRIPTION
the 0.6.4 source tarballs don't build because they have no `.git/index` this makes it so that future tarballs build.