### PR TITLE
add llarp.admin.die rpc call to gracefully kill router

### DIFF
--- a/libabyss/include/abyss/server.hpp
+++ b/libabyss/include/abyss/server.hpp
@@ -37,6 +37,10 @@ namespace abyss
       bool
       ShouldClose(llarp_time_t now) const;
 
+      /// return true if the host header is correct
+      virtual bool
+      ValidateHost(const std::string& host) const = 0;
+
      private:
       ConnImpl* m_Impl;
     };

--- a/libabyss/src/client.cpp
+++ b/libabyss/src/client.cpp
@@ -192,6 +192,7 @@ namespace abyss
           authgen << ", " << opt.first << "=" << opt.second;
         }
         m_SendHeaders.clear();
+        m_SendHeaders.emplace("Host", "localhost");
         m_SendHeaders.emplace("Authorization", authgen.str());
         SendRequest();
         return true;
@@ -320,6 +321,7 @@ namespace abyss
         std::string body;
         std::stringstream ss;
         body = m_RequestBody.dump();
+        m_SendHeaders.emplace("Host", "localhost");
         m_SendHeaders.emplace("Content-Type", "application/json");
         m_SendHeaders.emplace("Content-Length", std::to_string(body.size()));
         m_SendHeaders.emplace("Accept", "application/json");

--- a/libabyss/src/server.cpp
+++ b/libabyss/src/server.cpp
@@ -96,7 +96,8 @@ namespace abyss
       {
         // TODO: header whitelist
         return name == string_view("content-type")
-            || name == string_view("content-length");
+            || name == string_view("content-length")
+            || name == string_view("host");
       }
 
       bool
@@ -161,6 +162,17 @@ namespace abyss
           else
           {
             m_BodyParser.reset(json::MakeParser(contentLength));
+          }
+          itr = Header.Headers.find("host");
+          if(itr == Header.Headers.end())
+          {
+            return WriteResponseSimple(400, "Bad Request", "text/plain",
+                                       "no host header provided");
+          }
+          if(not handler->ValidateHost(itr->second))
+          {
+            return WriteResponseSimple(400, "Bad Request", "text/plain",
+                                       "invalid host header");
           }
         }
         if(!m_BodyParser->FeedData(buf, sz))

--- a/test/test_libabyss.cpp
+++ b/test/test_libabyss.cpp
@@ -107,6 +107,12 @@ struct ServerHandler : public abyss::httpd::IRPCHandler
   {
   }
 
+  bool
+  ValidateHost(const std::string & /*hostname */) const override
+  {
+    return true;
+  }
+  
   Response
   HandleJSONRPC(Method_t method, const Params& /*params*/)
   {


### PR DESCRIPTION
also patches possible dns rebinding vuln. moving to lokimq makes this irrelevant. 