### PR TITLE
Don't ignore .exe, .png, .gif

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,3 @@ external/date/test export-ignore
 external/nlohmann/doc export-ignore
 external/nlohmann/test export-ignore
 external/nlohmann/benchmarks/data export-ignore
-*.exe export-ignore
-*.png export-ignore
-*.gif export-ignore


### PR DESCRIPTION
These are part of the source code (in the documentation, and used in the
Windows build) so we really should still be including them.  (We can aim
at eliminating them, but should eliminate them from git, not just from
exported source).