### PR TITLE
strip rr from dns reply for .snode and .loki

### DIFF
--- a/llarp/dns/message.cpp
+++ b/llarp/dns/message.cpp
@@ -79,13 +79,14 @@ namespace llarp
     bool
     Message::Encode(llarp_buffer_t* buf) const
     {
+      LogInfo("Encode ", *this);
       MessageHeader hdr;
       hdr.id       = hdr_id;
       hdr.fields   = hdr_fields;
       hdr.qd_count = questions.size();
       hdr.an_count = answers.size();
-      hdr.ns_count = authorities.size();
-      hdr.ar_count = additional.size();
+      hdr.ns_count = 0;
+      hdr.ar_count = 0;
 
       if(!hdr.Encode(buf))
         return false;
@@ -96,14 +97,6 @@ namespace llarp
 
       for(const auto& answer : answers)
         if(!answer.Encode(buf))
-          return false;
-
-      for(const auto& auth : authorities)
-        if(!auth.Encode(buf))
-          return false;
-
-      for(const auto& rr : additional)
-        if(!rr.Encode(buf))
           return false;
 
       return true;
@@ -162,12 +155,18 @@ namespace llarp
       }
     }
 
+    static constexpr uint16_t
+    reply_flags(uint16_t setbits)
+    {
+      return setbits | flags_QR | flags_AA | flags_RA;
+    }
+
     void
     Message::AddINReply(llarp::huint128_t ip, bool isV6, RR_TTL_t ttl)
     {
       if(questions.size())
       {
-        hdr_fields |= flags_QR | flags_AA | flags_RA;
+        hdr_fields = reply_flags(hdr_fields);
         ResourceRecord rec;
         rec.rr_name  = questions[0].qname;
         rec.rr_class = qClassIN;
@@ -193,7 +192,8 @@ namespace llarp
     {
       if(questions.size())
       {
-        hdr_fields |= flags_QR | flags_AA | flags_RA;
+        hdr_fields = reply_flags(hdr_fields);
+
         const auto& question = questions[0];
         answers.emplace_back();
         auto& rec                     = answers.back();
@@ -217,7 +217,8 @@ namespace llarp
     {
       if(questions.size())
       {
-        hdr_fields |= flags_QR | flags_AA | flags_RA;
+        hdr_fields = reply_flags(hdr_fields);
+
         const auto& question = questions[0];
         answers.emplace_back();
         auto& rec                     = answers.back();
@@ -241,7 +242,8 @@ namespace llarp
     {
       if(questions.size())
       {
-        hdr_fields |= flags_QR | flags_AA;
+        hdr_fields = reply_flags(hdr_fields);
+
         const auto& question = questions[0];
         answers.emplace_back();
         auto& rec                     = answers.back();
@@ -266,7 +268,7 @@ namespace llarp
       if(questions.size())
       {
         // authorative response with recursion available
-        hdr_fields |= flags_QR | flags_AA | flags_RA;
+        hdr_fields = reply_flags(hdr_fields);
         // don't allow recursion on this request
         hdr_fields &= ~flags_RD;
         hdr_fields |= flags_RCODENameError;

--- a/llarp/dns/message.cpp
+++ b/llarp/dns/message.cpp
@@ -121,24 +121,6 @@ namespace llarp
           return false;
         }
       }
-      /*
-      for(auto& auth : authorities)
-      {
-        if(!auth.Decode(buf))
-        {
-          llarp::LogError("failed to decode auth");
-          return false;
-        }
-      }
-      for(auto& rr : additional)
-      {
-        if(!rr.Decode(buf))
-        {
-          llarp::LogError("failed to decode additional");
-          return false;
-        }
-      }
-      */
       return true;
     }
 

--- a/llarp/dns/message.cpp
+++ b/llarp/dns/message.cpp
@@ -79,7 +79,6 @@ namespace llarp
     bool
     Message::Encode(llarp_buffer_t* buf) const
     {
-      LogInfo("Encode ", *this);
       MessageHeader hdr;
       hdr.id       = hdr_id;
       hdr.fields   = hdr_fields;

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -554,7 +554,7 @@ namespace llarp
           }
           else
           {
-            auto replyMsg = std::make_shared< dns::Message >(std::move(msg));
+            auto replyMsg = std::make_shared< dns::Message >(msg);
             using service::Address;
             using service::OutboundContext;
             return EnsurePathToService(

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -448,7 +448,7 @@ namespace llarp
           }
           else
           {
-            auto replyMsg = std::make_shared< dns::Message >(msg);
+            auto replyMsg = std::make_shared< dns::Message >(std::move(msg));
             using service::Address;
             using service::OutboundContext;
             return EnsurePathToService(

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -278,6 +278,7 @@ namespace llarp
         if(ctx)
         {
           huint128_t ip = ObtainIPForAddr(addr, snode);
+          query->answers.clear();
           query->AddINReply(ip, sendIPv6);
         }
         else

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -667,7 +667,7 @@ namespace llarp
 
         auto range = serviceLookups.equal_range(addr);
         auto i     = range.first;
-        if(i != range.second)
+        while(i != range.second)
         {
           i->second(addr, itr->second.get());
           ++i;
@@ -945,7 +945,7 @@ namespace llarp
         LogError(Name(), " failed to lookup ", addr.ToString(), " from ",
                  endpoint);
         fails[endpoint] = fails[endpoint] + 1;
-        // inform all
+        // inform one
         auto range = lookups.equal_range(addr);
         auto itr   = range.first;
         if(itr != range.second)


### PR DESCRIPTION
also fixes some documentation in `service::Endpoint`