### PR TITLE
Fix IPv6 lookups to return empty response

### DIFF
--- a/llarp/dns/message.cpp
+++ b/llarp/dns/message.cpp
@@ -194,6 +194,31 @@ namespace llarp
     }
 
     void
+    Message::AddNSReply(std::string name, RR_TTL_t ttl)
+    {
+      if(not questions.empty())
+      {
+        hdr_fields = reply_flags(hdr_fields);
+
+        const auto& question = questions[0];
+        answers.emplace_back();
+        auto& rec                     = answers.back();
+        rec.rr_name                   = question.qname;
+        rec.rr_type                   = qTypeNS;
+        rec.rr_class                  = qClassIN;
+        rec.ttl                       = ttl;
+        std::array< byte_t, 512 > tmp = {{0}};
+        llarp_buffer_t buf(tmp);
+        if(EncodeName(&buf, name))
+        {
+          buf.sz = buf.cur - buf.base;
+          rec.rData.resize(buf.sz);
+          memcpy(rec.rData.data(), buf.base, buf.sz);
+        }
+      }
+    }
+
+    void
     Message::AddCNAMEReply(std::string name, RR_TTL_t ttl)
     {
       if(questions.size())

--- a/llarp/dns/message.hpp
+++ b/llarp/dns/message.hpp
@@ -69,6 +69,9 @@ namespace llarp
       void
       AddAReply(std::string name, RR_TTL_t ttl = 1);
 
+      void
+      AddNSReply(std::string name, RR_TTL_t ttl = 1);
+
       bool
       Encode(llarp_buffer_t* buf) const override;
 

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -509,12 +509,14 @@ namespace llarp
       else if(msg.questions[0].qtype == dns::qTypeA
               || msg.questions[0].qtype == dns::qTypeAAAA)
       {
-        const bool isV6 =
-            msg.questions[0].qtype == dns::qTypeAAAA && SupportsV6();
+        const bool isV6 = msg.questions[0].qtype == dns::qTypeAAAA;
         const bool isV4 = msg.questions[0].qtype == dns::qTypeA;
         llarp::service::Address addr;
+        if(isV6 && !SupportsV6())
+        { // empty reply but not a NXDOMAIN so that client can retry IPv4
+        }
         // on MacOS this is a typeA query
-        if(is_random_snode(msg))
+        else if(is_random_snode(msg))
         {
           RouterID random;
           if(Router()->GetRandomGoodRouter(random))

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -513,7 +513,8 @@ namespace llarp
         const bool isV4 = msg.questions[0].qtype == dns::qTypeA;
         llarp::service::Address addr;
         if(isV6 && !SupportsV6())
-        { // empty reply but not a NXDOMAIN so that client can retry IPv4
+        {  // empty reply but not a NXDOMAIN so that client can retry IPv4
+          msg.AddNSReply("localhost.loki.");
         }
         // on MacOS this is a typeA query
         else if(is_random_snode(msg))


### PR DESCRIPTION
The logic here wasn't quite right and was returning an A record in response to an AAAA lookup.  DNS resolvers didn't accept that, so `ping` would delay 5 seconds (waiting for the AAAA lookup to return something valid) before giving up and trying an A lookup.

This returns nothing, which is better, but not quite enough: this gives empty responses, which produces warnings in host/dig.