### PR TITLE
fully randomize hop selection

### DIFF
--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -537,17 +537,16 @@ llarp_nodedb::select_random_hop(const llarp::RouterContact &prev,
     return false;
   if(!N)
     return false;
-  llarp_time_t now = llarp::time_now_ms();
 
-  auto itr   = entries.begin();
-  size_t pos = llarp::randint() % sz;
+  auto itr         = entries.begin();
+  const size_t pos = llarp::randint() % sz;
   std::advance(itr, pos);
-  auto start = itr;
+  const auto start = itr;
   while(itr == entries.end())
   {
     if(prev.pubkey != itr->second.rc.pubkey)
     {
-      if(itr->second.rc.addrs.size() && !itr->second.rc.IsExpired(now))
+      if(itr->second.rc.IsPublicRouter())
       {
         result = itr->second.rc;
         return true;
@@ -560,7 +559,7 @@ llarp_nodedb::select_random_hop(const llarp::RouterContact &prev,
   {
     if(prev.pubkey != itr->second.rc.pubkey)
     {
-      if(itr->second.rc.addrs.size() && !itr->second.rc.IsExpired(now))
+      if(itr->second.rc.IsPublicRouter())
       {
         result = itr->second.rc;
         return true;
@@ -583,17 +582,16 @@ llarp_nodedb::select_random_hop_excluding(
   {
     return false;
   }
-  llarp_time_t now = llarp::time_now_ms();
 
-  auto itr   = entries.begin();
-  size_t pos = llarp::randint() % sz;
+  auto itr         = entries.begin();
+  const size_t pos = llarp::randint() % sz;
   std::advance(itr, pos);
-  auto start = itr;
+  const auto start = itr;
   while(itr == entries.end())
   {
     if(exclude.count(itr->first) == 0)
     {
-      if(itr->second.rc.addrs.size() && !itr->second.rc.IsExpired(now))
+      if(itr->second.rc.IsPublicRouter())
       {
         result = itr->second.rc;
         return true;
@@ -606,7 +604,7 @@ llarp_nodedb::select_random_hop_excluding(
   {
     if(exclude.count(itr->first) == 0)
     {
-      if(itr->second.rc.addrs.size() && !itr->second.rc.IsExpired(now))
+      if(itr->second.rc.IsPublicRouter())
       {
         result = itr->second.rc;
         return true;

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -529,45 +529,8 @@ bool
 llarp_nodedb::select_random_hop(const llarp::RouterContact &prev,
                                 llarp::RouterContact &result, size_t N)
 {
-  llarp::util::Lock lock(access);
-  /// checking for "guard" status for N = 0 is done by caller inside of
-  /// pathbuilder's scope
-  size_t sz = entries.size();
-  if(sz < 3)
-    return false;
-  if(!N)
-    return false;
-
-  auto itr         = entries.begin();
-  const size_t pos = llarp::randint() % sz;
-  std::advance(itr, pos);
-  const auto start = itr;
-  while(itr == entries.end())
-  {
-    if(prev.pubkey != itr->second.rc.pubkey)
-    {
-      if(itr->second.rc.IsPublicRouter())
-      {
-        result = itr->second.rc;
-        return true;
-      }
-    }
-    itr++;
-  }
-  itr = entries.begin();
-  while(itr != start)
-  {
-    if(prev.pubkey != itr->second.rc.pubkey)
-    {
-      if(itr->second.rc.IsPublicRouter())
-      {
-        result = itr->second.rc;
-        return true;
-      }
-    }
-    ++itr;
-  }
-  return false;
+  (void)N;
+  return select_random_hop_excluding(result, {prev.pubkey});
 }
 
 bool

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -525,13 +525,6 @@ llarp_nodedb::select_random_exit(llarp::RouterContact &result)
   return false;
 }
 
-bool
-llarp_nodedb::select_random_hop(const llarp::RouterContact &prev,
-                                llarp::RouterContact &result, size_t N)
-{
-  (void)N;
-  return select_random_hop_excluding(result, {prev.pubkey});
-}
 
 bool
 llarp_nodedb::select_random_hop_excluding(

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -155,10 +155,6 @@ struct llarp_nodedb
   select_random_exit(llarp::RouterContact &rc) EXCLUDES(access);
 
   bool
-  select_random_hop(const llarp::RouterContact &prev,
-                    llarp::RouterContact &result, size_t N) EXCLUDES(access);
-
-  bool
   select_random_hop_excluding(llarp::RouterContact &result,
                               const std::set< llarp::RouterID > &exclude)
       EXCLUDES(access);


### PR DESCRIPTION
before we were only using routers who we are directly connected to or recently looked up the RC for. now it's uniform random, this should help with spreading out traffic and anonymity related attributes.