### PR TITLE
discard unknown fields in introset for future use

### DIFF
--- a/llarp/service/intro_set.cpp
+++ b/llarp/service/intro_set.cpp
@@ -186,7 +186,10 @@ namespace llarp
       if(!BEncodeMaybeReadDictEntry("z", Z, read, key, buf))
         return false;
 
-      return read;
+      if(read)
+        return true;
+
+      return bencode_discard(buf);
     }
 
     bool


### PR DESCRIPTION
this allows us to put more things into introset in the future without breaking compat