### PR TITLE
fix memleak in jsonrpc

### DIFF
--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -81,6 +81,7 @@ namespace libuv
       m_Accept->close = &ExplicitCloseAccept;
       m_Conn.write    = nullptr;
       m_Conn.closed   = nullptr;
+      m_Conn.tick     = nullptr;
     }
 
     conn_glue(conn_glue* parent) : m_TCP(nullptr), m_Accept(nullptr)
@@ -306,7 +307,6 @@ namespace libuv
       if(m_Accept && m_Accept->tick)
       {
         m_Accept->tick(m_Accept);
-        return;
       }
       if(m_Conn.tick)
       {

--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -304,9 +304,14 @@ namespace libuv
     Tick()
     {
       if(m_Accept && m_Accept->tick)
+      {
         m_Accept->tick(m_Accept);
+        return;
+      }
       if(m_Conn.tick)
+      {
         m_Conn.tick(&m_Conn);
+      }
     }
 
     void
@@ -346,6 +351,7 @@ namespace libuv
     bool
     Server()
     {
+      uv_check_start(&m_Ticker, &OnTick);
       m_Accept->close = &ExplicitCloseAccept;
       return uv_tcp_bind(&m_Handle, m_Addr, 0) == 0
           && uv_listen(Stream(), 5, &OnAccept) == 0;


### PR DESCRIPTION
llarp_tcp_acceptor ticker wasn't being called so connections where not
being cleaned up