### PR TITLE
Use unique /16 netblock for path build hop selection

### DIFF
--- a/llarp/exit/session.cpp
+++ b/llarp/exit/session.cpp
@@ -69,6 +69,7 @@ namespace llarp
 
     bool
     BaseSession::SelectHop(llarp_nodedb* db, const std::set< RouterID >& prev,
+                           const std::vector< IPRange >& prevRanges,
                            RouterContact& cur, size_t hop,
                            llarp::path::PathRole roles)
     {
@@ -86,8 +87,7 @@ namespace llarp
         m_router->LookupRouter(m_ExitRouter, nullptr);
         return false;
       }
-
-      return path::Builder::SelectHop(db, exclude, cur, hop, roles);
+      return path::Builder::SelectHop(db, exclude, prevRanges, cur, hop, roles);
     }
 
     bool

--- a/llarp/exit/session.hpp
+++ b/llarp/exit/session.hpp
@@ -65,8 +65,8 @@ namespace llarp
 
       bool
       SelectHop(llarp_nodedb* db, const std::set< RouterID >& prev,
-                RouterContact& cur, size_t hop,
-                llarp::path::PathRole roles) override;
+                const std::vector< IPRange >& prevRanges, RouterContact& cur,
+                size_t hop, llarp::path::PathRole roles) override;
 
       bool
       ShouldBuildMore(llarp_time_t now) const override;

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -420,6 +420,13 @@ namespace llarp
                                          bool isV6) -> bool {
         using service::Address;
         using service::OutboundContext;
+        if(self->HasAddress(addr))
+        {
+          const auto ip = self->ObtainIPForAddr(addr, false);
+          msg->AddINReply(ip, isV6);
+          reply(*msg);
+          return true;
+        }
         return self->EnsurePathToService(
             addr,
             [=](const Address &, OutboundContext *ctx) {

--- a/llarp/net/address_info.cpp
+++ b/llarp/net/address_info.cpp
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #endif
 #include <net/net.hpp>
+#include <net/ip.hpp>
 #include <util/bencode.h>
 #include <util/mem.h>
 #include <util/printer.hpp>

--- a/llarp/net/address_info.cpp
+++ b/llarp/net/address_info.cpp
@@ -26,6 +26,13 @@ namespace llarp
     return lhs.rank < rhs.rank || lhs.ip < rhs.ip || lhs.port < rhs.port;
   }
 
+  IPRange
+  AddressInfo::IPRangeV4(byte_t mask) const
+  {
+    const auto h_ip = net::IPPacket::In6ToHUInt(ip);
+    return IPRange{h_ip, netmask_ipv6_bits(mask + 96)};
+  }
+
   bool
   AddressInfo::DecodeKey(const llarp_buffer_t &key, llarp_buffer_t *buf)
   {

--- a/llarp/net/address_info.hpp
+++ b/llarp/net/address_info.hpp
@@ -2,7 +2,7 @@
 #define LLARP_AI_HPP
 
 #include <crypto/types.hpp>
-#include <net/net.h>
+#include <net/net.hpp>
 #include <util/bencode.hpp>
 #include <util/mem.h>
 
@@ -32,6 +32,10 @@ namespace llarp
     {
       return bencode_decode_dict(*this, buf);
     }
+
+    /// make a netrange that excludes N bits of excluding netmask
+    IPRange
+    IPRangeV4(byte_t excludeNetmaskBits) const;
 
     bool
     BEncode(llarp_buffer_t* buf) const;

--- a/llarp/net/net.cpp
+++ b/llarp/net/net.cpp
@@ -1078,7 +1078,7 @@ namespace llarp
   {
     char buf[INET6_ADDRSTRLEN + 1] = {0};
     std::string str;
-    in6_addr inaddr = {};
+    in6_addr inaddr = net::IPPacket::HUIntToIn6(addr);
     size_t numset   = 0;
     uint128_t bits  = netmask_bits.h;
     while(bits)
@@ -1096,6 +1096,12 @@ namespace llarp
   {
     return IPRange{net::IPPacket::ExpandV4(ipaddr_ipv4_bits(a, b, c, d)),
                    netmask_ipv6_bits(mask + 96)};
+  }
+
+  IPRange
+  iprange_ipv4_from_ip(huint32_t ip, byte_t mask)
+  {
+    return IPRange{net::IPPacket::ExpandV4(ip), netmask_ipv6_bits(mask + 96)};
   }
 
   bool
@@ -1123,4 +1129,11 @@ namespace llarp
     }
     return false;
   }
+
+  bool
+  IPRange::Contains(const in6_addr& ip) const
+  {
+    return Contains(net::IPPacket::In6ToHUInt(ip));
+  }
+
 }  // namespace llarp

--- a/llarp/net/net.hpp
+++ b/llarp/net/net.hpp
@@ -2,7 +2,6 @@
 #define LLARP_NET_HPP
 
 #include <net/uint128.hpp>
-#include <net/address_info.hpp>
 #include <net/net_int.hpp>
 #include <net/net.h>
 #include <util/mem.hpp>
@@ -69,6 +68,9 @@ namespace llarp
     {
       return (addr & netmask_bits) == (ip & netmask_bits);
     }
+
+    bool
+    Contains(const in6_addr& ip) const;
 
     bool
     ContainsV4(const huint32_t& ip) const;
@@ -143,6 +145,9 @@ namespace llarp
 
   IPRange
   iprange_ipv4(byte_t a, byte_t b, byte_t c, byte_t d, byte_t mask);
+
+  IPRange
+  iprange_ipv4_from_ip(huint32_t ip, byte_t mask);
 
   bool
   IsIPv4Bogon(const huint32_t& addr);

--- a/llarp/net/net_addr.cpp
+++ b/llarp/net/net_addr.cpp
@@ -1,6 +1,7 @@
 #include <net/net.hpp>
 #include <net/net_addr.hpp>
 #include <util/string_view.hpp>
+#include <net/address_info.hpp>
 
 // for addrinfo
 #ifndef _WIN32

--- a/llarp/net/net_addr.hpp
+++ b/llarp/net/net_addr.hpp
@@ -1,7 +1,6 @@
 #ifndef LLARP_NET_ADDR_HPP
 #define LLARP_NET_ADDR_HPP
 
-#include <net/address_info.hpp>
 #include <net/net.h>
 #include <net/net.hpp>
 #include <util/string_view.hpp>
@@ -11,6 +10,8 @@
 
 namespace llarp
 {
+  struct AddressInfo;
+
   // real work
   struct Addr
   {

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -496,7 +496,7 @@ bool
 llarp_nodedb::select_random_exit(llarp::RouterContact &result)
 {
   const auto maybe_result =
-      MaybeSelectRandomHopWhere([](const llarp::RouterContact &rc) -> bool {
+      MaybeSelectRandomWhere([](const llarp::RouterContact &rc) -> bool {
         return rc.IsExit() and rc.IsPublicRouter();
       });
   if(maybe_result.has_value())
@@ -511,8 +511,8 @@ bool
 llarp_nodedb::select_random_hop_excluding(
     llarp::RouterContact &result, const std::set< llarp::RouterID > &exclude)
 {
-  const auto maybe_result = MaybeSelectRandomHopWhere(
-      [exclude](const llarp::RouterContact &rc) -> bool {
+  const auto maybe_result =
+      MaybeSelectRandomWhere([exclude](const llarp::RouterContact &rc) -> bool {
         return exclude.count(rc.pubkey) == 0;
       });
   if(maybe_result.has_value())
@@ -527,8 +527,8 @@ bool
 llarp_nodedb::select_random_hop_excluding_ranges(
     llarp::RouterContact &result, const std::vector< llarp::IPRange > &exclude)
 {
-  const auto maybe_result = MaybeSelectRandomHopWhere(
-      [exclude](const llarp::RouterContact &rc) -> bool {
+  const auto maybe_result =
+      MaybeSelectRandomWhere([exclude](const llarp::RouterContact &rc) -> bool {
         if(not rc.IsPublicRouter())
           return false;
         for(const auto &range : exclude)

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -155,9 +155,15 @@ struct llarp_nodedb
   bool
   select_random_exit(llarp::RouterContact &rc) EXCLUDES(access);
 
+  /***
+      given a filter function accept we start at a random
+      location in the netdb, check each entry until accept returns true
+      @returns an optional containing the RC of the router we selected if we
+     selected one
+   */
   template < typename Filter_t >
   nonstd::optional< llarp::RouterContact >
-  MaybeSelectRandomHopWhere(Filter_t accept)
+  MaybeSelectRandomWhere(Filter_t accept)
   {
     llarp::util::Lock lock(access);
     const size_t sz = entries.size();

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -504,11 +504,12 @@ namespace llarp
     bool
     Path::Expired(llarp_time_t now) const
     {
+      if(_status == ePathExpired)
+        return true;
       if(_status == ePathFailed)
         return true;
-      if(_status == ePathBuilding)
-        return false;
-      if(_status == ePathEstablished || _status == ePathTimeout)
+      if(_status == ePathBuilding || _status == ePathEstablished
+         || _status == ePathTimeout)
       {
         return now >= ExpireTime();
       }

--- a/llarp/path/path_context.cpp
+++ b/llarp/path/path_context.cpp
@@ -294,6 +294,14 @@ namespace llarp
       return map.size() / 2;
     }
 
+    uint64_t
+    PathContext::CurrentOurPaths()
+    {
+      util::Lock lock(m_OurPaths.first);
+      auto& map = m_OurPaths.second;
+      return map.size() / 2;
+    }
+
     void
     PathContext::PutTransitHop(std::shared_ptr< TransitHop > hop)
     {

--- a/llarp/path/path_context.hpp
+++ b/llarp/path/path_context.hpp
@@ -167,6 +167,10 @@ namespace llarp
       uint64_t
       CurrentTransitPaths();
 
+      /// current number of paths we own
+      uint64_t
+      CurrentOurPaths();
+
      private:
       AbstractRouter* m_Router;
       SyncTransitMap_t m_TransitPaths;

--- a/llarp/path/pathbuilder.hpp
+++ b/llarp/path/pathbuilder.hpp
@@ -55,7 +55,8 @@ namespace llarp
 
       bool
       SelectHop(llarp_nodedb* db, const std::set< RouterID >& prev,
-                RouterContact& cur, size_t hop, PathRole roles) override;
+                const std::vector< IPRange >& prevRanges, RouterContact& cur,
+                size_t hop, PathRole roles) override;
 
       bool
       ShouldBuildMore(llarp_time_t now) const override;

--- a/llarp/path/pathset.hpp
+++ b/llarp/path/pathset.hpp
@@ -8,6 +8,7 @@
 #include <util/status.hpp>
 #include <util/thread/threading.hpp>
 #include <util/time.hpp>
+#include <net/net.hpp>
 
 #include <functional>
 #include <list>
@@ -258,7 +259,8 @@ namespace llarp
 
       virtual bool
       SelectHop(llarp_nodedb* db, const std::set< RouterID >& prev,
-                RouterContact& cur, size_t hop, PathRole roles) = 0;
+                const std::vector< IPRange >& excludeRanges, RouterContact& cur,
+                size_t hop, PathRole roles) = 0;
 
       virtual bool
       BuildOneAlignedTo(const RouterID endpoint) = 0;

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -688,7 +688,9 @@ namespace llarp
       else
       {
         ss << " client | known/connected: " << nodedb()->num_loaded() << "/"
-           << NumberOfConnectedRouters() << " | path success: ";
+           << NumberOfConnectedRouters() << " | "
+           << pathContext().CurrentOurPaths() << " active paths";
+        ss << " | path success: ";
         hiddenServiceContext().ForEachService(
             [&ss](const auto &name, const auto &ep) {
               ss << " [" << name << " " << std::setprecision(4)

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -609,6 +609,7 @@ namespace llarp
 
     bool
     Endpoint::SelectHop(llarp_nodedb* db, const std::set< RouterID >& prev,
+                        const std::vector< IPRange >& prevRanges,
                         RouterContact& cur, size_t hop, path::PathRole roles)
 
     {
@@ -628,7 +629,7 @@ namespace llarp
           exclude.insert(path->Endpoint());
         });
       }
-      return path::Builder::SelectHop(db, exclude, cur, hop, roles);
+      return path::Builder::SelectHop(db, exclude, prevRanges, cur, hop, roles);
     }
 
     void

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -353,7 +353,8 @@ namespace llarp
 
       bool
       SelectHop(llarp_nodedb* db, const std::set< RouterID >& prev,
-                RouterContact& cur, size_t hop, path::PathRole roles) override;
+                const std::vector< IPRange >& prevRanges, RouterContact& cur,
+                size_t hop, path::PathRole roles) override;
 
       virtual void
       PathBuildStarted(path::Path_ptr path) override;

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -322,6 +322,7 @@ namespace llarp
     bool
     OutboundContext::SelectHop(llarp_nodedb* db,
                                const std::set< RouterID >& prev,
+                               const std::vector< IPRange >& prevRanges,
                                RouterContact& cur, size_t hop,
                                path::PathRole roles)
     {
@@ -349,7 +350,7 @@ namespace llarp
         ++m_BuildFails;
         return false;
       }
-      return path::Builder::SelectHop(db, exclude, cur, hop, roles);
+      return path::Builder::SelectHop(db, exclude, prevRanges, cur, hop, roles);
     }
 
     bool

--- a/llarp/service/outbound_context.hpp
+++ b/llarp/service/outbound_context.hpp
@@ -98,7 +98,8 @@ namespace llarp
 
       bool
       SelectHop(llarp_nodedb* db, const std::set< RouterID >& prev,
-                RouterContact& cur, size_t hop, path::PathRole roles) override;
+                const std::vector< IPRange >& prevRanges, RouterContact& cur,
+                size_t hop, path::PathRole roles) override;
 
       bool
       HandleHiddenServiceFrame(path::Path_ptr p, const ProtocolFrame& frame);


### PR DESCRIPTION
* make all client path builds use unqiue /16 netblocks for path hop selection to avoid multiple hops over provisioned clusters
* fix dns lookup regression with inbound sessions
