### PR TITLE
dont request descriptors for inbound sessions

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -420,6 +420,13 @@ namespace llarp
                                          bool isV6) -> bool {
         using service::Address;
         using service::OutboundContext;
+        if(self->HasAddress(addr))
+        {
+          const auto ip = self->ObtainIPForAddr(addr, false);
+          msg->AddINReply(ip, isV6);
+          reply(*msg);
+          return true;
+        }
         return self->EnsurePathToService(
             addr,
             [=](const Address &, OutboundContext *ctx) {


### PR DESCRIPTION
when we have an inbound session and we do a forward dns lookup we should not look up the descriptor on the network as we already have a session with them.