### PR TITLE
hotfix: make user install VC2015 runtime

### DIFF
--- a/llarp/ev/ev_win32.cpp
+++ b/llarp/ev/ev_win32.cpp
@@ -191,9 +191,9 @@ tun_ev_loop(void* u)
       // LeaveCriticalSection(&HandlerMtx);
     }
     logic->call_soon([ev]() {
-      if (ev->t->tick)
+      ev->flush_write();      
+      if(ev->t->tick)
         ev->t->tick(ev->t);
-      ev->flush_write();
     });
   }
   llarp::LogDebug("exit TUN event loop thread from system managed thread pool");


### PR DESCRIPTION
this will be patched away before a 0.7.1+ release tho as i can now build everything with g++