### PR TITLE
No LINUX variable in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ endif(JEMALLOC)
 
 
 find_package(PkgConfig QUIET)
-if(PKG_CONFIG_FOUND AND LINUX)
+if(PKG_CONFIG_FOUND)
     pkg_check_modules(SD libsystemd)
     # Default WITH_SYSTEMD to true if we found it
     option(WITH_SYSTEMD "enable systemd integration for sd_notify" ${SD_FOUND})


### PR DESCRIPTION
Just let the pkg_check fail when libsystemd isn't install; it shouldn't
hurt anything.