### PR TITLE
windows fix wchar/char path conversions

### DIFF
--- a/cmake/win32.cmake
+++ b/cmake/win32.cmake
@@ -2,6 +2,8 @@ if(NOT WIN32)
   return()
 endif()
 
+include(CheckCXXSourceCompiles)
+
 enable_language(RC)
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -46,6 +48,39 @@ endif()
 if (STATIC_LINK_RUNTIME)
   set(LIBUV_USE_STATIC ON)
 endif()
+
+# Figure out if we need -lstdc++fs or -lc++fs and add it to the `filesystem` interface, if needed
+# (otherwise just leave it an empty interface library; linking to it will do nothing).  The former
+# is needed for gcc before v9, and the latter with libc++ before llvm v9.  But this gets more
+# complicated than just using the compiler, because clang on linux by default uses libstdc++, so
+# we'll just give up and see what works.
+
+add_library(filesystem INTERFACE)
+
+set(filesystem_code [[
+#include <filesystem>
+
+int main() {
+    auto cwd = std::filesystem::current_path();
+    return !cwd.string().empty();
+}
+]])
+
+check_cxx_source_compiles("${filesystem_code}" filesystem_compiled)
+if(filesystem_compiled)
+  message(STATUS "No extra link flag needed for std::filesystem")
+else()
+  foreach(fslib stdc++fs c++fs)
+    set(CMAKE_REQUIRED_LIBRARIES -l${fslib})
+    check_cxx_source_compiles("${filesystem_code}" filesystem_compiled_${fslib})
+    if (filesystem_compiled_${fslib})
+      message(STATUS "Using -l${fslib} for std::filesystem support")
+      target_link_libraries(filesystem INTERFACE ${fslib})
+      break()
+    endif()
+  endforeach()
+endif()
+unset(CMAKE_REQUIRED_LIBRARIES)
 
 if(LIBUV_ROOT)
   add_subdirectory(${LIBUV_ROOT})

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -216,7 +216,7 @@ main(int argc, char* argv[])
   {
     llarp::ensureConfig(
         llarp::GetDefaultDataDir(), llarp::GetDefaultConfigPath(), overwrite, opts.isRelay);
-    conffname = llarp::GetDefaultConfigPath().c_str();
+    conffname = llarp::GetDefaultConfigPath().string().c_str();
   }
 
   if (genconfigOnly)

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -72,7 +72,7 @@ namespace llarp
     conf.defineOption<std::string>("router", "nickname", false, "", AssignmentAcceptor(m_nickname));
 
     conf.defineOption<std::string>(
-        "router", "data-dir", false, GetDefaultDataDir(), [this](std::string arg) {
+        "router", "data-dir", false, GetDefaultDataDir().string(), [this](std::string arg) {
           fs::path dir = arg;
           if (not fs::exists(dir))
             throw std::runtime_error(

--- a/llarp/config/key_manager.cpp
+++ b/llarp/config/key_manager.cpp
@@ -61,7 +61,7 @@ namespace llarp
     m_lokidRPCPassword = config.lokid.lokidRPCPassword;
 
     RouterContact rc;
-    bool exists = rc.Read(m_rcPath.c_str());
+    bool exists = rc.Read(m_rcPath.string().c_str());
     if (not exists and not genIfAbsent)
     {
       LogError("Could not read RouterContact at path ", m_rcPath);
@@ -186,7 +186,7 @@ namespace llarp
   bool
   KeyManager::backupKeyFilesByMoving() const
   {
-    std::vector<std::string> files = {m_rcPath, m_idKeyPath, m_encKeyPath, m_transportKeyPath};
+    std::vector<std::string> files = {m_rcPath.string(), m_idKeyPath.string(), m_encKeyPath.string(), m_transportKeyPath.string()};
 
     for (auto& filepath : files)
     {
@@ -216,7 +216,7 @@ namespace llarp
       LogInfo("Generating new key", filepath);
       keygen(key);
 
-      if (!key.SaveToFile(filepath.c_str()))
+      if (!key.SaveToFile(filepath.string().c_str()))
       {
         LogError("Failed to save new key");
         return false;
@@ -224,7 +224,7 @@ namespace llarp
     }
 
     LogDebug("Loading key from file ", filepath);
-    return key.LoadFromFile(filepath.c_str());
+    return key.LoadFromFile(filepath.string().c_str());
   }
 
   bool

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -51,7 +51,7 @@ namespace llarp
       jobQueueSize = 1024;
     logic = std::make_shared<Logic>(jobQueueSize);
 
-    nodedb_dir = config->router.m_dataDir / nodedb_dirname;
+    nodedb_dir = fs::path(config->router.m_dataDir / nodedb_dirname).string();
 
     return true;
   }

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -488,7 +488,7 @@ namespace llarp
       }
       if (isListFile)
       {
-        if (not BDecodeReadFile(router.c_str(), b_list))
+        if (not BDecodeReadFile(router.string().c_str(), b_list))
         {
           throw std::runtime_error(stringify("failed to read bootstrap list file '", router, "'"));
         }
@@ -496,7 +496,7 @@ namespace llarp
       else
       {
         RouterContact rc;
-        if (not rc.Read(router.c_str()))
+        if (not rc.Read(router.string().c_str()))
         {
           throw std::runtime_error(
               stringify("failed to decode bootstrap RC, file='", router, "' rc=", rc));


### PR DESCRIPTION
adds the cmake detection logic for win32 and fixes those pesky path to string conversions which are implicit on every other platform but must be explicit on win32 since it exposes the underlying filesystem character encoding (`wchar_t`/`char16_t` vs `char`)