### PR TITLE
Add [network]:enabled to ignored settings list

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -204,7 +204,7 @@ namespace llarp
         "network", "blacklist-snode", false, true, "", [this](std::string arg) {
           RouterID id;
           if (not id.FromString(arg))
-            throw std::invalid_argument(stringify("Invalide RouterID: ", arg));
+            throw std::invalid_argument(stringify("Invalid RouterID: ", arg));
 
           auto itr = m_snodeBlacklist.emplace(std::move(id));
           if (itr.second)
@@ -509,6 +509,8 @@ namespace llarp
     addIgnoreOption("router", "threads");
 
     addIgnoreOption("metrics", "json-metrics-path");
+
+    addIgnoreOption("network", "enabled");
   }
 
   void

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -228,6 +228,7 @@ namespace llarp
     bool
     ExitEnabled() const
     {
+      return false; // FIXME - have to fix the FIXME because FIXME
       throw std::runtime_error("FIXME: this needs to be derived from config");
       /*
       // TODO: use equal_range ?


### PR DESCRIPTION
No one knows what this option does or did, but it is in some generated
config files.