### PR TITLE
fix GenVersion.cmake

### DIFF
--- a/cmake/GenVersion.cmake
+++ b/cmake/GenVersion.cmake
@@ -30,14 +30,13 @@
 # Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 # Check what commit we're on
-execute_process(COMMAND "${GIT}" rev-parse --short=9 HEAD RESULT_VARIABLE RET OUTPUT_VARIABLE COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND "${GIT}" rev-parse --short HEAD RESULT_VARIABLE RET OUTPUT_VARIABLE COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(RET)
 	# Something went wrong, set the version tag to -unknown
     message(WARNING "Cannot determine current commit. Make sure that you are building either from a Git working tree or from a source archive.")
     set(VERSIONTAG "unknown")
 else()
-	string(SUBSTRING ${COMMIT} 0 9 COMMIT)
 	message(STATUS "You are currently on commit ${COMMIT}")
 
 	# Get all the tags


### PR DESCRIPTION
* rev-parse --short without any argument defaults to 8 chars
* truncation is absolutely moot here
* rev-list --abbrev-commit also uses 8 chars by default

because of length mismatch (COMMIT - 9 chars, TAGGEDCOMMIT - 8 chars) it always was mismatching them even when it should've been detecting that it's at release tag.
cut out explicit lengths and leave everything to use defaults, because they work (they both rely on the same core.abbrev setting so no length mismatch should happen).