### PR TITLE
C++17 niceties

### DIFF
--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -484,7 +484,7 @@ llarp_nodedb::LoadAll()
 size_t
 llarp_nodedb::num_loaded() const
 {
-  auto l = llarp::util::shared_lock(access);
+  std::shared_lock l{access};
   return entries.size();
 }
 

--- a/llarp/profiling.cpp
+++ b/llarp/profiling.cpp
@@ -217,7 +217,7 @@ namespace llarp
   bool
   Profiling::Save(const char* fname)
   {
-    auto lock = util::shared_lock(m_ProfilesMutex);
+    std::shared_lock lock{m_ProfilesMutex};
     size_t sz = (m_Profiles.size() * (RouterProfile::MaxSize + 32 + 8)) + 8;
 
     std::vector<byte_t> tmp(sz, 0);
@@ -243,7 +243,7 @@ namespace llarp
   bool
   Profiling::BEncode(llarp_buffer_t* buf) const
   {
-    auto lock = util::shared_lock(m_ProfilesMutex);
+    std::shared_lock lock{m_ProfilesMutex};
     return BEncodeNoLock(buf);
   }
 

--- a/llarp/router/outbound_session_maker.cpp
+++ b/llarp/router/outbound_session_maker.cpp
@@ -170,7 +170,7 @@ namespace llarp
   void
   OutboundSessionMaker::DoEstablish(const RouterID& router)
   {
-    auto l = util::unique_lock(_mutex);
+    std::unique_lock l{_mutex};
 
     auto itr = pendingSessions.find(router);
 
@@ -193,7 +193,7 @@ namespace llarp
   OutboundSessionMaker::GotRouterContact(const RouterID& router, const RouterContact& rc)
   {
     {
-      auto l = util::unique_lock(_mutex);
+      std::unique_lock l{_mutex};
 
       // in case other request found RC for this router after this request was
       // made

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -150,7 +150,7 @@ namespace llarp
       return true;
     };
 
-    auto l = util::shared_lock(nodedb()->access);
+    std::shared_lock l{nodedb()->access};
     return pick_router(nodedb()->entries);
   }
 

--- a/llarp/util/meta/traits.hpp
+++ b/llarp/util/meta/traits.hpp
@@ -10,19 +10,6 @@ namespace llarp
 {
   namespace traits
   {
-#ifdef __cpp_lib_void_t
-    using std::void_t;
-#else
-    /// C++17 void_t backport
-    template <typename... Ts>
-    struct void_t_impl
-    {
-      using type = void;
-    };
-    template <typename... Ts>
-    using void_t = typename void_t_impl<Ts...>::type;
-#endif
-
     /// Represents the empty type
     struct Bottom
     {
@@ -46,7 +33,7 @@ namespace llarp
     // - has dereference operator
     // - has arrow operator
     template <typename T>
-    struct is_pointy<T, std::conditional_t<false, void_t<decltype(*std::declval<T>())>, void>>
+    struct is_pointy<T, std::conditional_t<false, std::void_t<decltype(*std::declval<T>())>, void>>
         : public std::true_type
     {
     };
@@ -65,7 +52,7 @@ namespace llarp
         T,
         std::conditional_t<
             false,
-            void_t< typename T::value_type,
+            std::void_t< typename T::value_type,
                     typename T::size_type,
                     typename T::iterator,
                     typename T::const_iterator,

--- a/llarp/util/str.hpp
+++ b/llarp/util/str.hpp
@@ -24,10 +24,7 @@ namespace llarp
 
   /// Trim leading and trailing (ascii) whitespace from the given string;
   /// returns a std::string_view of the trimmed part of the string.
-#ifdef __GNUG__
-  [[gnu::warn_unused_result]]
-#endif
-  std::string_view
+  [[nodiscard]] std::string_view
   TrimWhitespace(std::string_view str);
 
   template <typename... T>
@@ -35,11 +32,7 @@ namespace llarp
   stringify(T&&... stuff)
   {
     std::ostringstream o;
-#ifdef __cpp_fold_expressions
     (o << ... << std::forward<T>(stuff));
-#else
-    (void)std::initializer_list<int>{(o << std::forward<T>(stuff), 0)...};
-#endif
     return o.str();
   }
 

--- a/llarp/util/thread/barrier.hpp
+++ b/llarp/util/thread/barrier.hpp
@@ -25,7 +25,7 @@ namespace llarp
       bool
       Block()
       {
-        std::unique_lock<std::mutex> lock{mutex};
+        std::unique_lock lock{mutex};
         if (pending == 1)
         {
           pending = 0;

--- a/llarp/util/thread/thread_pool.cpp
+++ b/llarp/util/thread/thread_pool.cpp
@@ -64,7 +64,7 @@ namespace llarp
     void
     ThreadPool::waitThreads()
     {
-      std::unique_lock<std::mutex> lock(m_gateMutex);
+      std::unique_lock lock{m_gateMutex};
       m_numThreadsCV.wait(lock, [this] { return allThreadsReady(); });
     }
 
@@ -72,7 +72,7 @@ namespace llarp
     ThreadPool::releaseThreads()
     {
       {
-        std::lock_guard<std::mutex> lock(m_gateMutex);
+        std::lock_guard lock{m_gateMutex};
         m_numThreadsReady = 0;
         ++m_gateCount;
       }
@@ -82,7 +82,7 @@ namespace llarp
     void
     ThreadPool::interrupt()
     {
-      std::lock_guard<std::mutex> lock(m_gateMutex);
+      std::lock_guard lock{m_gateMutex};
 
       size_t count = m_idleThreads;
 
@@ -96,14 +96,14 @@ namespace llarp
     ThreadPool::worker()
     {
       // Lock will be valid until the end of the statement
-      size_t gateCount = (std::lock_guard<std::mutex>(m_gateMutex), m_gateCount);
+      size_t gateCount = (std::lock_guard{m_gateMutex}, m_gateCount);
 
       util::SetThreadName(m_name);
 
       for (;;)
       {
         {
-          std::unique_lock<std::mutex> lock(m_gateMutex);
+          std::unique_lock lock{m_gateMutex};
           ++m_numThreadsReady;
           m_numThreadsCV.notify_one();
 


### PR DESCRIPTION
- class template argument deduction lets us write `std::unique_lock
  foo{mutex}` instead of `std::unique_lock<mutex_type> foo{mutex}` which
  makes the `unique_lock` and `shared_lock` functions unnecessary.

- Replace GNU-specific warn_unused_result attribute with C++17-standard
  [[nodiscard]]

- Remove pre-C++17 workaround code for fold expressions, void_t