### PR TITLE
Miss Match & ours/theirs

### DIFF
--- a/llarp/dht/taglookup.cpp
+++ b/llarp/dht/taglookup.cpp
@@ -19,7 +19,7 @@ namespace llarp
         return false;
       if (introset.topic.value() != target)
       {
-        llarp::LogWarn("got introset with missmatched topic in tag lookup");
+        llarp::LogWarn("got introset with mismatched topic in tag lookup");
         return false;
       }
       return true;

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -69,7 +69,7 @@ namespace llarp
       if (msg->rc.pubkey != m_ExpectedIdent)
       {
         LogError(
-            "ident key missmatch from ",
+            "ident key mismatch from ",
             m_RemoteAddr,
             " ",
             msg->rc.pubkey,
@@ -89,7 +89,7 @@ namespace llarp
     {
       if (msg->rc.pubkey != m_RemoteRC.pubkey)
       {
-        LogError("ident key missmatch");
+        LogError("ident key mismatch");
         return false;
       }
       m_RemoteRC = msg->rc;
@@ -455,7 +455,7 @@ namespace llarp
       const auto begin = pkt.data() + PacketOverhead;
       if (not std::equal(begin, begin + token.size(), token.data()))
       {
-        LogError("token missmatch from ", m_RemoteAddr);
+        LogError("token mismatch from ", m_RemoteAddr);
         return;
       }
       m_LastRX = m_Parent->Now();
@@ -565,7 +565,7 @@ namespace llarp
       if (H != expected)
       {
         LogError(
-            "keyed hash missmatch ",
+            "keyed hash mismatch ",
             H,
             " != ",
             expected,
@@ -614,7 +614,7 @@ namespace llarp
         if (pkt[PacketOverhead] != LLARP_PROTO_VERSION)
         {
           LogError(
-              "protocol version missmatch ", int(pkt[PacketOverhead]), " != ", LLARP_PROTO_VERSION);
+              "protocol version mismatch ", int(pkt[PacketOverhead]), " != ", LLARP_PROTO_VERSION);
           continue;
         }
         recvMsgs->emplace_back(std::move(pkt));
@@ -827,7 +827,7 @@ namespace llarp
         }
         else
         {
-          LogError("hash missmatch for message ", itr->first);
+          LogError("hash mismatch for message ", itr->first);
         }
         m_RXMsgs.erase(itr);
       }

--- a/llarp/messages/link_intro.cpp
+++ b/llarp/messages/link_intro.cpp
@@ -45,7 +45,7 @@ namespace llarp
         return false;
       if (version != LLARP_PROTO_VERSION)
       {
-        llarp::LogWarn("llarp protocol version missmatch ", version, " != ", LLARP_PROTO_VERSION);
+        llarp::LogWarn("llarp protocol version mismatch ", version, " != ", LLARP_PROTO_VERSION);
         return false;
       }
       llarp::LogDebug("LIM version ", version);

--- a/llarp/router/rc_lookup_handler.cpp
+++ b/llarp/router/rc_lookup_handler.cpp
@@ -186,7 +186,7 @@ namespace llarp
   bool
   RCLookupHandler::CheckRenegotiateValid(RouterContact newrc, RouterContact oldrc)
   {
-    // missmatch of identity ?
+    // mismatch of identity ?
     if (newrc.pubkey != oldrc.pubkey)
       return false;
 

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -321,7 +321,7 @@ namespace llarp
   {
     if (netID != NetID::DefaultValue())
     {
-      llarp::LogError("netid mismatch: '", netID, "' != '", NetID::DefaultValue(), "'");
+      llarp::LogError("netid mismatch: '", netID, "' (theirs) != '", NetID::DefaultValue(), "' (ours)");
       return false;
     }
     if (IsExpired(now))

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -321,7 +321,7 @@ namespace llarp
   {
     if (netID != NetID::DefaultValue())
     {
-      llarp::LogError("netid missmatch: '", netID, "' != '", NetID::DefaultValue(), "'");
+      llarp::LogError("netid mismatch: '", netID, "' != '", NetID::DefaultValue(), "'");
       return false;
     }
     if (IsExpired(now))

--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -245,7 +245,7 @@ namespace llarp
       }
       if (strbuf.sz != sz)
       {
-        llarp::LogError("bdecode buffer size missmatch ", strbuf.sz, "!=", sz);
+        llarp::LogError("bdecode buffer size mismatch ", strbuf.sz, "!=", sz);
         return false;
       }
       memcpy(data(), strbuf.base, sz);


### PR DESCRIPTION
Miss Match was not happy that her name was being used in the code, so I changed it to mismatch.

(i.e. fix speeling mistack: missmatch -> mismatch)

Also annotate the netid mismatch message to indicate which of the mismatched values is ours or theirs.