### PR TITLE
default to port 53 in dns section entries

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -228,22 +228,20 @@ namespace llarp
   DnsConfig::defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params)
   {
     (void)params;
-
-    conf.defineOption<std::string>(
-        "dns", "upstream", false, true, std::nullopt, [=](std::string arg) {
-          IpAddress addr{arg};
-          const auto maybePort = addr.getPort();
-          if (not maybePort.has_value())
-            addr.setPort(53);
-          m_upstreamDNS.push_back(std::move(addr));
-        });
-
-    conf.defineOption<std::string>("dns", "bind", false, std::nullopt, [=](std::string arg) {
+    static auto parseDNSAddr = [](auto arg) {
       IpAddress addr{arg};
       const auto maybePort = addr.getPort();
       if (not maybePort.has_value())
         addr.setPort(53);
-      m_bind = std::move(addr);
+      return addr;
+    };
+    conf.defineOption<std::string>(
+        "dns", "upstream", false, true, std::nullopt, [=](std::string arg) {
+          m_upstreamDNS.push_back(parseDNSAddr(std::move(arg)));
+        });
+
+    conf.defineOption<std::string>("dns", "bind", false, std::nullopt, [=](std::string arg) {
+      m_bind = parseDNSAddr(std::move(arg));
     });
   }
 

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -231,11 +231,20 @@ namespace llarp
 
     conf.defineOption<std::string>(
         "dns", "upstream", false, true, std::nullopt, [=](std::string arg) {
-          m_upstreamDNS.push_back(IpAddress(arg));
+          IpAddress addr{arg};
+          const auto maybePort = addr.getPort();
+          if (not maybePort.has_value())
+            addr.setPort(53);
+          m_upstreamDNS.push_back(std::move(addr));
         });
 
-    conf.defineOption<std::string>(
-        "dns", "bind", false, std::nullopt, [=](std::string arg) { m_bind = IpAddress(arg); });
+    conf.defineOption<std::string>("dns", "bind", false, std::nullopt, [=](std::string arg) {
+      IpAddress addr{arg};
+      const auto maybePort = addr.getPort();
+      if (not maybePort.has_value())
+        addr.setPort(53);
+      m_bind = std::move(addr);
+    });
   }
 
   LinksConfig::LinkInfo

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -228,7 +228,7 @@ namespace llarp
   DnsConfig::defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params)
   {
     (void)params;
-    static auto parseDNSAddr = [](auto arg) {
+    auto parseDNSAddr = [](auto arg) {
       IpAddress addr{arg};
       const auto maybePort = addr.getPort();
       if (not maybePort.has_value())

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -189,11 +189,11 @@ namespace llarp
       if (not service)
         throw std::runtime_error(stringify("Failed to construct endpoint of type ", endpointType));
 
-      if (not service->LoadKeyFile())
-        throw std::runtime_error("Endpoint's keyfile could not be loaded");
-
       // pass conf to service
       service->Configure(conf.network, conf.dns);
+
+      if (not service->LoadKeyFile())
+        throw std::runtime_error("Endpoint's keyfile could not be loaded");
 
       // autostart if requested
       if (autostart)


### PR DESCRIPTION
IpAddresses in dns section config were not defaulting to port 53 when no port was provided.

Fixes #1264