### PR TITLE
keyfile was being initialized before being set by configure call.

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -161,8 +161,7 @@ namespace llarp
     conf.defineOption<std::string>(
         "network", "strict-connect", false, "", AssignmentAcceptor(m_strictConnect));
 
-    conf.defineOption<std::string>(
-        "network", "keyfile", false, "", [this](std::string arg) { m_keyfile = arg; });
+    conf.defineOption<std::string>("network", "keyfile", false, "", AssignmentAcceptor(m_keyfile));
 
     conf.defineOption<bool>(
         "network", "reachable", false, ReachableDefault, AssignmentAcceptor(m_reachable));

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -189,11 +189,11 @@ namespace llarp
       if (not service)
         throw std::runtime_error(stringify("Failed to construct endpoint of type ", endpointType));
 
-      if (not service->LoadKeyFile())
-        throw std::runtime_error("Endpoint's keyfile could not be loaded");
-
       // pass conf to service
       service->Configure(conf.network, conf.dns);
+
+      if (not service->LoadKeyFile())
+        throw std::runtime_error("Endpoint's keyfile could not be loaded");
 
       // autostart if requested
       if (autostart)

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -51,7 +51,7 @@ namespace llarp
       if (conf.m_hops)
         numHops = conf.m_hops;
 
-      return m_state->Configure(std::move(conf));
+      return m_state->Configure(conf);
     }
 
     llarp_ev_loop_ptr


### PR DESCRIPTION
this made it so that snapps always use ephemeral keys.
this fixes this.