### PR TITLE
Fix various unit tests

### DIFF
--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -36,22 +36,22 @@ namespace llarp
 
   struct RouterConfig
   {
-    size_t m_minConnectedRouters;
-    size_t m_maxConnectedRouters;
+    size_t m_minConnectedRouters = 0;
+    size_t m_maxConnectedRouters = 0;
 
     std::string m_netId;
     std::string m_nickname;
 
     fs::path m_dataDir;
 
-    bool m_blockBogons;
+    bool m_blockBogons = false;
 
     IpAddress m_publicAddress;
 
-    int m_workerThreads;
-    int m_numNetThreads;
+    int m_workerThreads = -1;
+    int m_numNetThreads = -1;
 
-    size_t m_JobQueueSize;
+    size_t m_JobQueueSize = 0;
 
     std::string m_routerContactFile;
     std::string m_encryptionKeyFile;
@@ -72,9 +72,9 @@ namespace llarp
 
     std::string m_keyfile;
     std::string m_endpointType;
-    bool m_reachable;
-    int m_hops;
-    int m_paths;
+    bool m_reachable = false;
+    int m_hops = -1;
+    int m_paths = -1;
     std::set<RouterID> m_snodeBlacklist;
 #ifdef LOKINET_EXITS
     std::string m_exitNode;
@@ -104,7 +104,7 @@ namespace llarp
     struct LinkInfo
     {
       std::string interface;
-      int addressFamily;
+      int addressFamily = -1;
       uint16_t port = -1;
     };
     /// Create a LinkInfo from the given string.
@@ -129,7 +129,7 @@ namespace llarp
 
   struct ApiConfig
   {
-    bool m_enableRPCServer;
+    bool m_enableRPCServer = false;
     std::string m_rpcBindAddr;
 
     void
@@ -138,8 +138,8 @@ namespace llarp
 
   struct LokidConfig
   {
-    bool usingSNSeed;
-    bool whitelistRouters;
+    bool usingSNSeed = false;
+    bool whitelistRouters = false;
     fs::path ident_keyfile;
     std::string lokidRPCAddr;
     std::string lokidRPCUser;
@@ -158,8 +158,8 @@ namespace llarp
 
   struct LoggingConfig
   {
-    LogType m_logType;
-    LogLevel m_logLevel;
+    LogType m_logType = LogType::Unknown;
+    LogLevel m_logLevel = eLogNone;
     std::string m_logFile;
 
     void

--- a/llarp/config/key_manager.hpp
+++ b/llarp/config/key_manager.hpp
@@ -41,8 +41,7 @@ namespace llarp
     /// NOTE: blocks on I/O
     ///
     /// @param config should be a prepared config object
-    /// @param genIfAbsent determines whether or not we will create files if
-    /// they
+    /// @param genIfAbsent determines whether or not we will create files if they
     ///        do not exist.
     /// @return true on success, false otherwise
     bool

--- a/test/crypto/test_llarp_key_manager.cpp
+++ b/test/crypto/test_llarp_key_manager.cpp
@@ -113,6 +113,7 @@ TEST_F(KeyManagerTest, TestBackupFileByMoving_FailsIfBackupNamesAreExausted)
 TEST_F(KeyManagerTest, TestInitialize_MakesKeyfiles)
 {
   llarp::Config conf;
+  conf.LoadDefault(false, {});
 
   KeyManager keyManager;
   ASSERT_TRUE(keyManager.initialize(conf, true));
@@ -128,6 +129,7 @@ TEST_F(KeyManagerTest, TestInitialize_MakesKeyfiles)
 TEST_F(KeyManagerTest, TestInitialize_RespectsGenFlag)
 {
   llarp::Config conf;
+  conf.LoadDefault(false, {});
 
   KeyManager keyManager;
   ASSERT_FALSE(keyManager.initialize(conf, false));

--- a/test/crypto/test_llarp_key_manager.cpp
+++ b/test/crypto/test_llarp_key_manager.cpp
@@ -14,11 +14,6 @@
 using namespace ::llarp;
 using namespace ::testing;
 
-static constexpr auto rcFile = "rc.signed";
-static constexpr auto encFile = "encryption.key";
-static constexpr auto transportFile = "transport.key";
-static constexpr auto identFile = "identity.key";
-
 struct KeyManagerTest : public test::LlarpTest< llarp::sodium::CryptoLibSodium >
 {
   // paranoid file guards for anything KeyManager might touch
@@ -28,10 +23,10 @@ struct KeyManagerTest : public test::LlarpTest< llarp::sodium::CryptoLibSodium >
   test::FileGuard m_identFileGuard;
 
   KeyManagerTest()
-      : m_rcFileGuard(rcFile)
-      , m_encFileGuard(encFile)
-      , m_transportFileGuard(transportFile)
-      , m_identFileGuard(identFile)
+      : m_rcFileGuard(our_rc_filename)
+      , m_encFileGuard(our_enc_key_filename)
+      , m_transportFileGuard(our_transport_key_filename)
+      , m_identFileGuard(our_identity_filename)
   {
   }
 
@@ -40,7 +35,7 @@ struct KeyManagerTest : public test::LlarpTest< llarp::sodium::CryptoLibSodium >
   generateRcFile()
   {
     RouterContact rc;
-    return rc.Write(rcFile);
+    return rc.Write(our_rc_filename);
   }
 };
 
@@ -123,11 +118,11 @@ TEST_F(KeyManagerTest, TestInitialize_MakesKeyfiles)
   ASSERT_TRUE(keyManager.initialize(conf, true));
 
   // KeyManager doesn't generate RC file, but should generate others
-  ASSERT_FALSE(fs::exists(rcFile));
+  ASSERT_FALSE(fs::exists(our_rc_filename));
 
-  ASSERT_TRUE(fs::exists(encFile));
-  ASSERT_TRUE(fs::exists(transportFile));
-  ASSERT_TRUE(fs::exists(identFile));
+  ASSERT_TRUE(fs::exists(our_enc_key_filename));
+  ASSERT_TRUE(fs::exists(our_transport_key_filename));
+  ASSERT_TRUE(fs::exists(our_identity_filename));
 }
 
 TEST_F(KeyManagerTest, TestInitialize_RespectsGenFlag)
@@ -138,10 +133,10 @@ TEST_F(KeyManagerTest, TestInitialize_RespectsGenFlag)
   ASSERT_FALSE(keyManager.initialize(conf, false));
 
   // KeyManager shouldn't have touched any files without (genIfAbsent == true)
-  ASSERT_FALSE(fs::exists(rcFile));
-  ASSERT_FALSE(fs::exists(encFile));
-  ASSERT_FALSE(fs::exists(transportFile));
-  ASSERT_FALSE(fs::exists(identFile));
+  ASSERT_FALSE(fs::exists(our_rc_filename));
+  ASSERT_FALSE(fs::exists(our_enc_key_filename));
+  ASSERT_FALSE(fs::exists(our_transport_key_filename));
+  ASSERT_FALSE(fs::exists(our_identity_filename));
 }
 
 TEST_F(KeyManagerTest, TestInitialize_DetectsBadRcFile)
@@ -151,7 +146,7 @@ TEST_F(KeyManagerTest, TestInitialize_DetectsBadRcFile)
   conf.lokid.whitelistRouters = false;
 
   std::fstream f;
-  f.open(rcFile, std::ios::out);
+  f.open(our_rc_filename, std::ios::out);
   f << "bad_rc_file";
   f.close();
 
@@ -159,23 +154,23 @@ TEST_F(KeyManagerTest, TestInitialize_DetectsBadRcFile)
   ASSERT_TRUE(keyManager.initialize(conf, true));
   ASSERT_TRUE(keyManager.needBackup());
 
-  ASSERT_TRUE(fs::exists(encFile));
-  ASSERT_TRUE(fs::exists(transportFile));
-  ASSERT_TRUE(fs::exists(identFile));
+  ASSERT_TRUE(fs::exists(our_enc_key_filename));
+  ASSERT_TRUE(fs::exists(our_transport_key_filename));
+  ASSERT_TRUE(fs::exists(our_identity_filename));
 
   // test that keys are sane
   SecretKey key;
 
   key.Zero();
-  ASSERT_TRUE(key.LoadFromFile(encFile));
+  ASSERT_TRUE(key.LoadFromFile(our_enc_key_filename));
   ASSERT_FALSE(key.IsZero());
 
   key.Zero();
-  ASSERT_TRUE(key.LoadFromFile(transportFile));
+  ASSERT_TRUE(key.LoadFromFile(our_transport_key_filename));
   ASSERT_FALSE(key.IsZero());
 
   key.Zero();
-  ASSERT_TRUE(key.LoadFromFile(identFile));
+  ASSERT_TRUE(key.LoadFromFile(our_identity_filename));
   ASSERT_FALSE(key.IsZero());
 }
 

--- a/test/crypto/test_llarp_key_manager.cpp
+++ b/test/crypto/test_llarp_key_manager.cpp
@@ -147,6 +147,7 @@ TEST_F(KeyManagerTest, TestInitialize_RespectsGenFlag)
 TEST_F(KeyManagerTest, TestInitialize_DetectsBadRcFile)
 {
   llarp::Config conf;
+  conf.LoadDefault(false, {});
 
   std::fstream f;
   f.open(rcFile, std::ios::out);

--- a/test/crypto/test_llarp_key_manager.cpp
+++ b/test/crypto/test_llarp_key_manager.cpp
@@ -148,6 +148,7 @@ TEST_F(KeyManagerTest, TestInitialize_DetectsBadRcFile)
 {
   llarp::Config conf;
   conf.LoadDefault(false, {});
+  conf.lokid.whitelistRouters = false;
 
   std::fstream f;
   f.open(rcFile, std::ios::out);


### PR DESCRIPTION
These tests were perhaps failing because of uninitialized values. If this fixes the unit tests, we probably should do one of:

* Ensure that Config cant' be used when it hasn't been initialized, or
* Provide proper values at construction time (this is problematic because it will conflict with other default values provided in InitializeConfig(), etc.)