### PR TITLE
Remove llarp::str(string_view)

### DIFF
--- a/libabyss/src/http.cpp
+++ b/libabyss/src/http.cpp
@@ -32,8 +32,7 @@ namespace abyss
       if (ShouldProcessHeader(lowerHeader))
       {
         val = val.substr(val.find_first_not_of(' '));
-        // llarp::str() here for gcc 5 compat
-        Header.Headers.emplace(std::move(lowerHeader), llarp::str(val));
+        Header.Headers.emplace(std::move(lowerHeader), val);
       }
       return true;
     }

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -253,7 +253,7 @@ namespace llarp
     LinkInfo info;
     info.port = 0;
     info.addressFamily = AF_INET;
-    info.interface = str(name);
+    info.interface = name;
 
     std::vector<std::string_view> splits = split(value, ',');
     for (std::string_view str : splits)
@@ -301,7 +301,7 @@ namespace llarp
 
     conf.addUndeclaredHandler(
         "connect", [this](std::string_view section, std::string_view name, std::string_view value) {
-          fs::path file = str(value);
+          fs::path file = value;
           if (not fs::exists(file))
             throw std::runtime_error(stringify(
                 "Specified bootstrap file ",

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -301,7 +301,7 @@ namespace llarp
 
     conf.addUndeclaredHandler(
         "connect", [this](std::string_view section, std::string_view name, std::string_view value) {
-          fs::path file = value;
+          fs::path file{value.begin(), value.end()};
           if (not fs::exists(file))
             throw std::runtime_error(stringify(
                 "Specified bootstrap file ",

--- a/llarp/config/ini.cpp
+++ b/llarp/config/ini.cpp
@@ -131,9 +131,9 @@ namespace llarp
           LogError(m_FileName, " invalid line (", lineno, "): '", line, "'");
           return false;
         }
-        SectionValues_t& sect = m_Config[str(sectName)];
+        SectionValues_t& sect = m_Config[std::string{sectName}];
         LogDebug(m_FileName, ": ", sectName, ".", k, "=", v);
-        sect.emplace(str(k), str(v));  // str()'s here for gcc 5 compat
+        sect.emplace(k, v);
       }
       else  // malformed?
       {

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -190,7 +190,7 @@ namespace llarp
         {
           routerStr = conf.m_exitNode;
         }
-        routerStr = str(TrimWhitespace(routerStr));
+        routerStr = TrimWhitespace(routerStr);
         if (!(exitRouter.FromString(routerStr)
               || HexDecode(routerStr.c_str(), exitRouter.begin(), exitRouter.size())))
         {

--- a/llarp/util/str.hpp
+++ b/llarp/util/str.hpp
@@ -36,14 +36,6 @@ namespace llarp
     return o.str();
   }
 
-  // Shortcut for explicitly casting a string_view to a string.  Saves 8 characters compared to
-  // `std::string(view)`.
-  inline std::string
-  str(std::string_view s)
-  {
-    return std::string{s};
-  }
-
   /// Split a string on a given delimiter
   //
   /// @param str is the string to split

--- a/test/util/test_llarp_util_str.cpp
+++ b/test/util/test_llarp_util_str.cpp
@@ -13,7 +13,7 @@ TEST_CASE("TrimWhitespace -- positive tests", "[str][trim]")
   auto fo = "\fthe   "s;
   auto fum = " \t\r\n\v\f Beanstalk\n\n\n\t\r\f\v   \n\n\r\f\f\f\f\v"s;
   for (auto* s: {&fee, &fi, &fo, &fum})
-    *s = llarp::str(llarp::TrimWhitespace(*s));
+    *s = llarp::TrimWhitespace(*s);
 
   REQUIRE( fee == "J a c k" );
   REQUIRE( fi == "a\nd" );
@@ -26,7 +26,7 @@ TEST_CASE("TrimWhitespace -- negative tests", "[str][trim]")
   // Test that things that shouldn't be trimmed don't get trimmed
   auto c = GENERATE(range(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()));
   std::string plant = c + "bean"s + c;
-  plant = llarp::str(llarp::TrimWhitespace(plant));
+  plant = llarp::TrimWhitespace(plant);
   if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v')
     REQUIRE( plant == "bean" );
   else


### PR DESCRIPTION
It was a workaround for pre-C++17 std::string which didn't support
passing a string_view to various functions/operators.  There's only one
place left that needs an explicit conversion, and that's where it is
used as a map key; so just be explicit there and remove llarp::str()
everywhere else.

Edit: plus a workaround for ghc::filesystem::path for macos.