### PR TITLE
fix one hop mode path builds

### DIFF
--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -613,7 +613,7 @@ namespace llarp
       std::set<RouterID> exclude = prev;
       for (const auto& snode : SnodeBlacklist())
         exclude.insert(snode);
-      if (hop == numHops - 1)
+      if (hop == numHops - 1 and numHops > 1)
       {
         // diversify endpoints
         ForEachPath([&exclude](const path::Path_ptr& path) { exclude.insert(path->Endpoint()); });


### PR DESCRIPTION
when in 1 hop mode we where hitting a case where we were failing to build paths

this was because we were trying to diversify the endpoints used which is not
applicable in 1 hop mode because first hops are sticky. it was excluding the sticky first hops causing a build fail every time after initial path builds.