### PR TITLE
Dont touch self.signed if client

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -100,7 +100,7 @@ run_main_context(std::string conffname, llarp_main_runtime_opts opts)
 #ifndef _WIN32
     signal(SIGHUP, handle_signal);
 #endif
-    code = llarp_main_setup(ctx);
+    code = llarp_main_setup(ctx, opts.isRelay);
     llarp::util::SetThreadName("llarp-mainloop");
     if (code == 0)
       code = llarp_main_run(ctx, opts);

--- a/include/llarp.h
+++ b/include/llarp.h
@@ -191,7 +191,7 @@ extern "C"
 
   /// setup main context, returns 0 on success
   int
-  llarp_main_setup(struct llarp_main* ptr);
+  llarp_main_setup(struct llarp_main* ptr, bool isRelay);
 
   /// run main context, returns 0 on success, blocks until program end
   int

--- a/include/llarp.hpp
+++ b/include/llarp.hpp
@@ -64,7 +64,7 @@ namespace llarp
     LoadDatabase();
 
     int
-    Setup();
+    Setup(bool isRelay);
 
     int
     Run(llarp_main_runtime_opts opts);

--- a/llarp/config/key_manager.cpp
+++ b/llarp/config/key_manager.cpp
@@ -61,7 +61,7 @@ namespace llarp
     m_lokidRPCPassword = config.lokid.lokidRPCPassword;
 
     RouterContact rc;
-    bool exists = rc.Read(m_rcPath.c_str());
+    bool exists = rc.Read(m_rcPath);
     if (not exists and not genIfAbsent)
     {
       LogError("Could not read RouterContact at path ", m_rcPath);
@@ -216,7 +216,7 @@ namespace llarp
       LogInfo("Generating new key", filepath);
       keygen(key);
 
-      if (!key.SaveToFile(filepath.c_str()))
+      if (!key.SaveToFile(filepath))
       {
         LogError("Failed to save new key");
         return false;
@@ -224,7 +224,7 @@ namespace llarp
     }
 
     LogDebug("Loading key from file ", filepath);
-    return key.LoadFromFile(filepath.c_str());
+    return key.LoadFromFile(filepath);
   }
 
   bool

--- a/llarp/config/key_manager.cpp
+++ b/llarp/config/key_manager.cpp
@@ -26,7 +26,7 @@ namespace llarp
   }
 
   bool
-  KeyManager::initialize(const llarp::Config& config, bool genIfAbsent)
+  KeyManager::initialize(const llarp::Config& config, bool genIfAbsent, bool isRouter)
   {
     if (m_initialized)
       return false;
@@ -61,7 +61,7 @@ namespace llarp
     m_lokidRPCPassword = config.lokid.lokidRPCPassword;
 
     RouterContact rc;
-    bool exists = rc.Read(m_rcPath);
+    bool exists = rc.Read(m_rcPath.c_str());
     if (not exists and not genIfAbsent)
     {
       LogError("Could not read RouterContact at path ", m_rcPath);
@@ -70,7 +70,7 @@ namespace llarp
 
     // we need to back up keys if our self.signed doesn't appear to have a
     // valid signature
-    m_needBackup = (not rc.VerifySignature());
+    m_needBackup = (isRouter and not rc.VerifySignature());
 
     // if our RC file can't be verified, assume it is out of date (e.g. uses
     // older encryption) and needs to be regenerated. before doing so, backup
@@ -216,7 +216,7 @@ namespace llarp
       LogInfo("Generating new key", filepath);
       keygen(key);
 
-      if (!key.SaveToFile(filepath))
+      if (!key.SaveToFile(filepath.c_str()))
       {
         LogError("Failed to save new key");
         return false;
@@ -224,7 +224,7 @@ namespace llarp
     }
 
     LogDebug("Loading key from file ", filepath);
-    return key.LoadFromFile(filepath);
+    return key.LoadFromFile(filepath.c_str());
   }
 
   bool

--- a/llarp/config/key_manager.hpp
+++ b/llarp/config/key_manager.hpp
@@ -43,9 +43,10 @@ namespace llarp
     /// @param config should be a prepared config object
     /// @param genIfAbsent determines whether or not we will create files if they
     ///        do not exist.
+    /// @param isRouter
     /// @return true on success, false otherwise
     bool
-    initialize(const llarp::Config& config, bool genIfAbsent);
+    initialize(const llarp::Config& config, bool genIfAbsent, bool isRouter);
 
     /// Obtain the self-signed RouterContact
     ///

--- a/llarp/config/key_manager.hpp
+++ b/llarp/config/key_manager.hpp
@@ -66,11 +66,12 @@ namespace llarp
     llarp::SecretKey encryptionKey;
     llarp::SecretKey transportKey;
 
-   private:
     fs::path m_rcPath;
     fs::path m_idKeyPath;
     fs::path m_encKeyPath;
     fs::path m_transportKeyPath;
+
+   private:
     std::atomic_bool m_initialized;
     std::atomic_bool m_needBackup;
 

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -72,7 +72,7 @@ namespace llarp
   }
 
   int
-  Context::Setup()
+  Context::Setup(bool isRelay)
   {
     llarp::LogInfo(llarp::VERSION_FULL, " ", llarp::RELEASE_MOTTO);
     llarp::LogInfo("starting up");
@@ -92,7 +92,7 @@ namespace llarp
 
     nodedb = std::make_unique<llarp_nodedb>(router->diskworker(), nodedb_dir);
 
-    if (!router->Configure(config.get(), nodedb.get()))
+    if (!router->Configure(config.get(), isRelay, nodedb.get()))
     {
       llarp::LogError("Failed to configure router");
       return 1;
@@ -323,9 +323,9 @@ extern "C"
   }
 
   int
-  llarp_main_setup(struct llarp_main* ptr)
+  llarp_main_setup(struct llarp_main* ptr, bool isRelay)
   {
-    return ptr->ctx->Setup();
+    return ptr->ctx->Setup(isRelay);
   }
 
   int

--- a/llarp/dht/messages/gotrouter.cpp
+++ b/llarp/dht/messages/gotrouter.cpp
@@ -124,7 +124,6 @@ namespace llarp
           return false;
         if (txid == 0)  // txid == 0 on gossip
         {
-          LogWarn("Received Gossiped RC, generating RCGossipReceivedEvent");
           auto* router = dht.GetRouter();
           router->NotifyRouterEvent<tooling::RCGossipReceivedEvent>(router->pubkey(), rc);
           router->GossipRCIfNeeded(rc);

--- a/llarp/router/abstractrouter.hpp
+++ b/llarp/router/abstractrouter.hpp
@@ -137,7 +137,7 @@ namespace llarp
     Sign(Signature& sig, const llarp_buffer_t& buf) const = 0;
 
     virtual bool
-    Configure(Config* conf, llarp_nodedb* nodedb) = 0;
+    Configure(Config* conf, bool isRouter, llarp_nodedb* nodedb) = 0;
 
     virtual bool
     IsServiceNode() const = 0;

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -262,7 +262,6 @@ namespace llarp
   Router::HandleSaveRC() const
   {
     std::string fname = our_rc_file.string();
-    LogWarn("WRITING RC TO DISK @ ", fname);
     _rc.Write(fname.c_str());
   }
 

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -262,6 +262,7 @@ namespace llarp
   Router::HandleSaveRC() const
   {
     std::string fname = our_rc_file.string();
+    LogWarn("WRITING RC TO DISK @ ", fname);
     _rc.Write(fname.c_str());
   }
 

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -391,20 +391,25 @@ namespace llarp
     _rc.SetNick(conf->router.m_nickname);
     _outboundSessionMaker.maxConnectedRouters = conf->router.m_maxConnectedRouters;
     _outboundSessionMaker.minConnectedRouters = conf->router.m_minConnectedRouters;
-    encryption_keyfile = conf->router.m_dataDir / our_enc_key_filename;
-    our_rc_file = conf->router.m_dataDir / our_rc_filename;
-    transport_keyfile = conf->router.m_dataDir / our_transport_key_filename;
+
+    encryption_keyfile = m_keyManager->m_encKeyPath;
+    our_rc_file = m_keyManager->m_rcPath;
+    transport_keyfile = m_keyManager->m_transportKeyPath;
+    ident_keyfile = m_keyManager->m_idKeyPath;
+
     _ourAddress = conf->router.m_publicAddress;
 
     RouterContact::BlockBogons = conf->router.m_blockBogons;
 
     // Lokid Config
     usingSNSeed = conf->lokid.usingSNSeed;
-    ident_keyfile = conf->lokid.ident_keyfile;
     whitelistRouters = conf->lokid.whitelistRouters;
     lokidRPCAddr = IpAddress(conf->lokid.lokidRPCAddr);  // TODO: make config's option an IpAddress
     lokidRPCUser = conf->lokid.lokidRPCUser;
     lokidRPCPassword = conf->lokid.lokidRPCPassword;
+
+    if (usingSNSeed)
+      ident_keyfile = conf->lokid.ident_keyfile;
 
     // TODO: add config flag for "is service node"
     if (conf->links.m_InboundLinks.size())
@@ -514,11 +519,6 @@ namespace llarp
         bootstrapRCList,
         whitelistRouters,
         m_isServiceNode);
-
-    if (!usingSNSeed)
-    {
-      ident_keyfile = conf->router.m_dataDir / our_identity_filename;
-    }
 
     // create inbound links, if we are a service node
     for (const LinksConfig::LinkInfo& serverConfig : conf->links.m_InboundLinks)

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -234,7 +234,7 @@ namespace llarp
   }
 
   bool
-  Router::Configure(Config* conf, llarp_nodedb* nodedb)
+  Router::Configure(Config* conf, bool isRouter, llarp_nodedb* nodedb)
   {
     if (nodedb == nullptr)
     {
@@ -242,7 +242,7 @@ namespace llarp
     }
     _nodedb = nodedb;
 
-    if (not m_keyManager->initialize(*conf, true))
+    if (not m_keyManager->initialize(*conf, true, isRouter))
       throw std::runtime_error("KeyManager failed to initialize");
 
     if (!FromConfig(conf))
@@ -331,6 +331,9 @@ namespace llarp
   bool
   Router::UpdateOurRC(bool rotateKeys)
   {
+    if (IsServiceNode())
+      return false;
+
     SecretKey nextOnionKey;
     RouterContact nextRC = _rc;
     if (rotateKeys)
@@ -660,16 +663,19 @@ namespace llarp
 
     const bool isSvcNode = IsServiceNode();
 
-    if (_rc.ExpiresSoon(now, std::chrono::milliseconds(randint() % 10000))
-        || (now - _rc.last_updated) > rcRegenInterval)
+    if (isSvcNode)
     {
-      LogInfo("regenerating RC");
-      if (!UpdateOurRC(false))
-        LogError("Failed to update our RC");
-    }
-    else
-    {
-      GossipRCIfNeeded(_rc);
+      if (_rc.ExpiresSoon(now, std::chrono::milliseconds(randint() % 10000))
+          || (now - _rc.last_updated) > rcRegenInterval)
+      {
+        LogInfo("regenerating RC");
+        if (!UpdateOurRC(false))
+          LogError("Failed to update our RC");
+      }
+      else
+      {
+        GossipRCIfNeeded(_rc);
+      }
     }
     const bool gotWhitelist = _rcLookupHandler.HaveReceivedWhitelist();
     // remove RCs for nodes that are no longer allowed by network policy
@@ -876,60 +882,57 @@ namespace llarp
 
     routerProfiling().Load(routerProfilesFile.c_str());
 
-    // set public signing key
-    _rc.pubkey = seckey_topublic(identity());
-    // set router version if service node
+    // initialize our RC if we're a service node
     if (IsServiceNode())
     {
+      // set public signing key
+      _rc.pubkey = seckey_topublic(identity());
       _rc.routerVersion = RouterVersion(llarp::VERSION, LLARP_PROTO_VERSION);
-    }
 
-    _linkManager.ForEachInboundLink([&](LinkLayer_ptr link) {
-      AddressInfo ai;
-      if (link->GetOurAddressInfo(ai))
+      _linkManager.ForEachInboundLink([&](LinkLayer_ptr link) {
+        AddressInfo ai;
+        if (link->GetOurAddressInfo(ai))
+        {
+          // override ip and port
+          if (not _ourAddress.isEmpty())
+          {
+            ai.fromIpAddress(_ourAddress);
+          }
+          if (RouterContact::BlockBogons && IsBogon(ai.ip))
+            return;
+          LogInfo("adding address: ", ai);
+          _rc.addrs.push_back(ai);
+          if (ExitEnabled())
+          {
+            const IpAddress address = ai.toIpAddress();
+            _rc.exits.emplace_back(_rc.pubkey, address);
+            LogInfo("Exit relay started, advertised as exiting at: ", address);
+          }
+        }
+      });
+
+      // set public encryption key
+      _rc.enckey = seckey_topublic(encryption());
+
+      LogInfo("Signing rc...");
+      if (!_rc.Sign(identity()))
       {
-        // override ip and port
-        if (not _ourAddress.isEmpty())
-        {
-          ai.fromIpAddress(_ourAddress);
-        }
-        if (RouterContact::BlockBogons && IsBogon(ai.ip))
-          return;
-        LogInfo("adding address: ", ai);
-        _rc.addrs.push_back(ai);
-        if (ExitEnabled())
-        {
-          const IpAddress address = ai.toIpAddress();
-          _rc.exits.emplace_back(_rc.pubkey, address);
-          LogInfo("Exit relay started, advertised as exiting at: ", address);
-        }
+        LogError("failed to sign rc");
+        return false;
       }
-    });
 
-    // set public encryption key
-    _rc.enckey = seckey_topublic(encryption());
+      if (!SaveRC())
+      {
+        LogError("failed to save RC");
+        return false;
+      }
+      _outboundSessionMaker.SetOurRouter(pubkey());
+      if (!_linkManager.StartLinks(_logic, cryptoworker))
+      {
+        LogWarn("One or more links failed to start.");
+        return false;
+      }
 
-    LogInfo("Signing rc...");
-    if (!_rc.Sign(identity()))
-    {
-      LogError("failed to sign rc");
-      return false;
-    }
-
-    if (!SaveRC())
-    {
-      LogError("failed to save RC");
-      return false;
-    }
-    _outboundSessionMaker.SetOurRouter(pubkey());
-    if (!_linkManager.StartLinks(_logic, cryptoworker))
-    {
-      LogWarn("One or more links failed to start.");
-      return false;
-    }
-
-    if (IsServiceNode())
-    {
       // initialize as service node
       if (!InitServiceNode())
       {
@@ -949,13 +952,6 @@ namespace llarp
       // regenerate keys and resign rc before everything else
       CryptoManager::instance()->identity_keygen(_identity);
       CryptoManager::instance()->encryption_keygen(_encryption);
-      _rc.pubkey = seckey_topublic(identity());
-      _rc.enckey = seckey_topublic(encryption());
-      if (!_rc.Sign(identity()))
-      {
-        LogError("failed to regenerate keys and sign RC");
-        return false;
-      }
     }
 
     LogInfo("starting hidden service context...");

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -327,7 +327,7 @@ namespace llarp
     Close();
 
     bool
-    Configure(Config* conf, llarp_nodedb* nodedb = nullptr) override;
+    Configure(Config* conf, bool isRouter, llarp_nodedb* nodedb = nullptr) override;
 
     bool
     StartJsonRpc() override;

--- a/test/crypto/test_llarp_key_manager.cpp
+++ b/test/crypto/test_llarp_key_manager.cpp
@@ -116,7 +116,7 @@ TEST_F(KeyManagerTest, TestInitialize_MakesKeyfiles)
   conf.LoadDefault(false, {});
 
   KeyManager keyManager;
-  ASSERT_TRUE(keyManager.initialize(conf, true));
+  ASSERT_TRUE(keyManager.initialize(conf, true, true));
 
   // KeyManager doesn't generate RC file, but should generate others
   ASSERT_FALSE(fs::exists(our_rc_filename));
@@ -132,7 +132,7 @@ TEST_F(KeyManagerTest, TestInitialize_RespectsGenFlag)
   conf.LoadDefault(false, {});
 
   KeyManager keyManager;
-  ASSERT_FALSE(keyManager.initialize(conf, false));
+  ASSERT_FALSE(keyManager.initialize(conf, false, true));
 
   // KeyManager shouldn't have touched any files without (genIfAbsent == true)
   ASSERT_FALSE(fs::exists(our_rc_filename));
@@ -153,7 +153,7 @@ TEST_F(KeyManagerTest, TestInitialize_DetectsBadRcFile)
   f.close();
 
   KeyManager keyManager;
-  ASSERT_TRUE(keyManager.initialize(conf, true));
+  ASSERT_TRUE(keyManager.initialize(conf, true, true));
   ASSERT_TRUE(keyManager.needBackup());
 
   ASSERT_TRUE(fs::exists(our_enc_key_filename));


### PR DESCRIPTION
This PR causes `router.cpp` to ignore our `self.signed` file if we're a client.

This was causing issues because `KeyManager` tries to do backups if `self.signed` is present and invalid. **We also need to figure out why these RCs are not passing validation.**