### PR TITLE
SRV Record handling for introsets

### DIFF
--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(liblokinet
   dns/rr.cpp
   dns/serialize.cpp
   dns/server.cpp
+  dns/srv_data.cpp
   dns/unbound_resolver.cpp
 
   consensus/table.cpp

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -325,6 +325,14 @@ namespace llarp
           if (not itr.second)
             throw std::invalid_argument(stringify("Duplicate blacklist-snode: ", arg));
         });
+
+    conf.defineOption<std::string>("network", "srv", false, true, "", [this](std::string arg) {
+          llarp::dns::SRVData newSRV;
+          if (not newSRV.fromString(arg))
+            throw std::invalid_argument(stringify("Invalid SRV Record string: ", arg));
+
+          m_SRVRecords.push_back(std::move(newSRV));
+        });
   }
 
   void

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -322,7 +322,7 @@ namespace llarp
             throw std::invalid_argument(stringify("Invalid RouterID: ", arg));
 
           auto itr = m_snodeBlacklist.emplace(std::move(id));
-          if (itr.second)
+          if (not itr.second)
             throw std::invalid_argument(stringify("Duplicate blacklist-snode: ", arg));
         });
   }

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -327,12 +327,12 @@ namespace llarp
         });
 
     conf.defineOption<std::string>("network", "srv", false, true, "", [this](std::string arg) {
-          llarp::dns::SRVData newSRV;
-          if (not newSRV.fromString(arg))
-            throw std::invalid_argument(stringify("Invalid SRV Record string: ", arg));
+      llarp::dns::SRVData newSRV;
+      if (not newSRV.fromString(arg))
+        throw std::invalid_argument(stringify("Invalid SRV Record string: ", arg));
 
-          m_SRVRecords.push_back(std::move(newSRV));
-        });
+      m_SRVRecords.push_back(std::move(newSRV));
+    });
   }
 
   void

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -14,6 +14,7 @@
 #include <net/ip_range_map.hpp>
 #include <service/address.hpp>
 #include <service/auth.hpp>
+#include <dns/srv_data.hpp>
 
 #include <cstdlib>
 #include <functional>
@@ -92,6 +93,8 @@ namespace llarp
     std::optional<std::string> m_AuthUrl;
     std::optional<std::string> m_AuthMethod;
     std::unordered_set<service::Address, service::Address::Hash> m_AuthWhitelist;
+
+    std::vector<llarp::dns::SRVData> m_SRVRecords;
 
     // TODO:
     // on-up

--- a/llarp/config/definition.hpp
+++ b/llarp/config/definition.hpp
@@ -177,13 +177,20 @@ namespace llarp
     T
     fromString(const std::string& input)
     {
-      std::istringstream iss(input);
-      T t;
-      iss >> t;
-      if (iss.fail())
-        throw std::invalid_argument(stringify(input, " is not a valid ", typeid(T).name()));
+      if constexpr (std::is_same_v<T, std::string>)
+      {
+        return input;
+      }
       else
-        return t;
+      {
+        std::istringstream iss(input);
+        T t;
+        iss >> t;
+        if (iss.fail())
+          throw std::invalid_argument(stringify(input, " is not a valid ", typeid(T).name()));
+        else
+          return t;
+      }
     }
 
     std::string

--- a/llarp/dns/dns.hpp
+++ b/llarp/dns/dns.hpp
@@ -7,6 +7,7 @@ namespace llarp
 {
   namespace dns
   {
+    constexpr uint16_t qTypeSRV = 33;
     constexpr uint16_t qTypeAAAA = 28;
     constexpr uint16_t qTypeTXT = 16;
     constexpr uint16_t qTypeMX = 15;

--- a/llarp/dns/message.cpp
+++ b/llarp/dns/message.cpp
@@ -269,7 +269,8 @@ namespace llarp
       }
     }
 
-    void Message::AddSRVReply(std::vector<SRVData> records, RR_TTL_t ttl)
+    void
+    Message::AddSRVReply(std::vector<SRVData> records, RR_TTL_t ttl)
     {
       hdr_fields = reply_flags(hdr_fields);
 

--- a/llarp/dns/message.cpp
+++ b/llarp/dns/message.cpp
@@ -1,6 +1,7 @@
 #include <dns/message.hpp>
 
 #include <dns/dns.hpp>
+#include <dns/srv_data.hpp>
 #include <util/buffer.hpp>
 #include <util/endian.hpp>
 #include <util/logging/logger.hpp>
@@ -268,10 +269,68 @@ namespace llarp
       }
     }
 
+    void Message::AddSRVReply(std::vector<SRVData> records, RR_TTL_t ttl)
+    {
+      hdr_fields = reply_flags(hdr_fields);
+
+      const auto& question = questions[0];
+
+      for (const auto& srv : records)
+      {
+        if (not srv.IsValid())
+        {
+          AddNXReply();
+          return;
+        }
+
+        answers.emplace_back();
+        auto& rec = answers.back();
+        rec.rr_name = question.qname;
+        rec.rr_type = qTypeSRV;
+        rec.rr_class = qClassIN;
+        rec.ttl = ttl;
+
+        std::array<byte_t, 512> tmp = {{0}};
+        llarp_buffer_t buf(tmp);
+
+        buf.put_uint16(srv.priority);
+        buf.put_uint16(srv.weight);
+        buf.put_uint16(srv.port);
+
+        std::string target;
+        if (srv.target == "")
+        {
+          // get location of second dot (after service.proto) in qname
+          size_t pos = question.qname.find(".");
+          pos = question.qname.find(".", pos + 1);
+
+          target = question.qname.substr(pos + 1);
+        }
+        else
+        {
+          target = srv.target;
+        }
+
+        if (not EncodeName(&buf, target))
+        {
+          AddNXReply();
+          return;
+        }
+
+        buf.sz = buf.cur - buf.base;
+        rec.rData.resize(buf.sz);
+        memcpy(rec.rData.data(), buf.base, buf.sz);
+      }
+    }
+
     void Message::AddNXReply(RR_TTL_t)
     {
       if (questions.size())
       {
+        answers.clear();
+        authorities.clear();
+        additional.clear();
+
         // authorative response with recursion available
         hdr_fields = reply_flags(hdr_fields);
         // don't allow recursion on this request

--- a/llarp/dns/message.hpp
+++ b/llarp/dns/message.hpp
@@ -9,6 +9,8 @@ namespace llarp
 {
   namespace dns
   {
+    struct SRVData;
+
     using MsgID_t = uint16_t;
     using Fields_t = uint16_t;
     using Count_t = uint16_t;
@@ -65,6 +67,9 @@ namespace llarp
 
       void
       AddAReply(std::string name, RR_TTL_t ttl = 1);
+
+      void
+      AddSRVReply(std::vector<SRVData> records, RR_TTL_t ttl = 1);
 
       void
       AddNSReply(std::string name, RR_TTL_t ttl = 1);

--- a/llarp/dns/srv_data.cpp
+++ b/llarp/dns/srv_data.cpp
@@ -35,4 +35,18 @@ namespace llarp::dns
     return false;
   }
 
+  SRVTuple SRVData::toTuple() const
+  {
+    return std::make_tuple(service_proto, priority, weight, port, target);
+  }
+
+  SRVData SRVData::fromTuple(SRVTuple tuple)
+  {
+    SRVData s;
+
+    std::tie(s.service_proto, s.priority, s.weight, s.port, s.target) = std::move(tuple);
+
+    return s;
+  }
+
 } // namespace llarp::dns

--- a/llarp/dns/srv_data.cpp
+++ b/llarp/dns/srv_data.cpp
@@ -1,0 +1,38 @@
+#include <dns/srv_data.hpp>
+
+namespace llarp::dns
+{
+
+  bool SRVData::IsValid() const
+  {
+    // if target is of first two forms outlined above
+    if (target == "." or target.size() == 0)
+    {
+      return true;
+    }
+
+    // check target size is not absurd
+    if (target.size() > TARGET_MAX_SIZE)
+    {
+      return false;
+    }
+
+    // does target end in .loki?
+    size_t pos = target.find(".loki");
+    if (pos != std::string::npos && pos == (target.size() - 5))
+    {
+      return true;
+    }
+
+    // does target end in .snode?
+    pos = target.find(".snode");
+    if (pos != std::string::npos && pos == (target.size() - 6))
+    {
+      return true;
+    }
+
+    // if we're here, target is invalid
+    return false;
+  }
+
+} // namespace llarp::dns

--- a/llarp/dns/srv_data.cpp
+++ b/llarp/dns/srv_data.cpp
@@ -1,5 +1,6 @@
 #include <dns/srv_data.hpp>
 #include <util/str.hpp>
+#include <util/logging/logger.hpp>
 
 #include <limits>
 
@@ -17,6 +18,7 @@ namespace llarp::dns
     // check target size is not absurd
     if (target.size() > TARGET_MAX_SIZE)
     {
+      LogWarn("SRVData target larger than max size (", TARGET_MAX_SIZE, ")");
       return false;
     }
 
@@ -35,6 +37,7 @@ namespace llarp::dns
     }
 
     // if we're here, target is invalid
+    LogWarn("SRVData invalid");
     return false;
   }
 
@@ -57,24 +60,36 @@ namespace llarp::dns
   bool
   SRVData::fromString(std::string_view srvString)
   {
+    LogDebug("SRVData::fromString(\"", srvString, "\")");
+
     // split on spaces, discard trailing empty strings
     auto splits = split(srvString, " ", false);
 
     if (splits.size() != 5 && splits.size() != 4)
     {
+      LogWarn("SRV record should have either 4 or 5 space-separated parts");
       return false;
     }
 
     service_proto = splits[0];
 
     if (not parse_int(splits[1], priority))
+    {
+      LogWarn("SRV record failed to parse \"", splits[1], "\" as uint16_t (priority)");
       return false;
+    }
 
     if (not parse_int(splits[2], weight))
+    {
+      LogWarn("SRV record failed to parse \"", splits[2], "\" as uint16_t (weight)");
       return false;
+    }
 
     if (not parse_int(splits[3], port))
+    {
+      LogWarn("SRV record failed to parse \"", splits[3], "\" as uint16_t (port)");
       return false;
+    }
 
     if (splits.size() == 5)
       target = splits[4];

--- a/llarp/dns/srv_data.cpp
+++ b/llarp/dns/srv_data.cpp
@@ -1,5 +1,7 @@
 #include <dns/srv_data.hpp>
 
+#include <limits>
+
 namespace llarp::dns
 {
 
@@ -47,6 +49,67 @@ namespace llarp::dns
     std::tie(s.service_proto, s.priority, s.weight, s.port, s.target) = std::move(tuple);
 
     return s;
+  }
+
+  bool SRVData::fromString(const std::string& srvString)
+  {
+    size_t prev = 0;
+
+    size_t pos = srvString.find(" ");
+    if (pos == std::string::npos)
+    {
+      return false;
+    }
+    service_proto = srvString.substr(prev, pos - prev);
+
+    prev = pos+1;
+    pos = srvString.find(" ", prev);
+    if (pos == std::string::npos)
+    {
+      return false;
+    }
+    unsigned long number_from_string;
+    number_from_string = std::stoul(srvString.substr(prev, pos - prev));
+    if (number_from_string > std::numeric_limits<uint16_t>::max())
+    {
+      return false;
+    }
+    priority = number_from_string;
+
+    prev = pos+1;
+    pos = srvString.find(" ", prev);
+    if (pos == std::string::npos)
+    {
+      return false;
+    }
+    number_from_string = std::stoul(srvString.substr(prev, pos - prev));
+    if (number_from_string > std::numeric_limits<uint16_t>::max())
+    {
+      return false;
+    }
+    weight = number_from_string;
+
+    prev = pos+1;
+    pos = srvString.find(" ", prev);
+    if (pos == std::string::npos)
+    {
+      return false;
+    }
+    number_from_string = std::stoul(srvString.substr(prev, pos - prev));
+    if (number_from_string > std::numeric_limits<uint16_t>::max())
+    {
+      return false;
+    }
+    port = number_from_string;
+
+    // after final space, interpret rest as target
+    if (srvString.size() <= pos+1)
+    {
+      return false;
+    }
+    target = srvString.substr(pos);
+
+    return IsValid();
   }
 
 } // namespace llarp::dns

--- a/llarp/dns/srv_data.cpp
+++ b/llarp/dns/srv_data.cpp
@@ -5,8 +5,8 @@
 
 namespace llarp::dns
 {
-
-  bool SRVData::IsValid() const
+  bool
+  SRVData::IsValid() const
   {
     // if target is of first two forms outlined above
     if (target == "." or target.size() == 0)
@@ -38,12 +38,14 @@ namespace llarp::dns
     return false;
   }
 
-  SRVTuple SRVData::toTuple() const
+  SRVTuple
+  SRVData::toTuple() const
   {
     return std::make_tuple(service_proto, priority, weight, port, target);
   }
 
-  SRVData SRVData::fromTuple(SRVTuple tuple)
+  SRVData
+  SRVData::fromTuple(SRVTuple tuple)
   {
     SRVData s;
 
@@ -52,7 +54,8 @@ namespace llarp::dns
     return s;
   }
 
-  bool SRVData::fromString(std::string_view srvString)
+  bool
+  SRVData::fromString(std::string_view srvString)
   {
     // split on spaces, discard trailing empty strings
     auto splits = split(srvString, " ", false);
@@ -81,4 +84,4 @@ namespace llarp::dns
     return IsValid();
   }
 
-} // namespace llarp::dns
+}  // namespace llarp::dns

--- a/llarp/dns/srv_data.hpp
+++ b/llarp/dns/srv_data.hpp
@@ -8,14 +8,13 @@
 
 namespace llarp::dns
 {
-
   typedef std::tuple<std::string, uint16_t, uint16_t, uint16_t, std::string> SRVTuple;
 
   struct SRVData
   {
     static constexpr size_t TARGET_MAX_SIZE = 200;
 
-    std::string service_proto; // service and protocol may as well be together
+    std::string service_proto;  // service and protocol may as well be together
 
     uint16_t priority;
     uint16_t weight;
@@ -31,11 +30,14 @@ namespace llarp::dns
     // do some basic validation on the target string
     // note: this is not a conclusive, regex solution,
     // but rather some sanity/safety checks
-    bool IsValid() const;
+    bool
+    IsValid() const;
 
-    SRVTuple toTuple() const;
+    SRVTuple
+    toTuple() const;
 
-    static SRVData fromTuple(SRVTuple tuple);
+    static SRVData
+    fromTuple(SRVTuple tuple);
 
     /* bind-like formatted string for SRV records in config file
      *
@@ -53,7 +55,8 @@ namespace llarp::dns
      *  - a name within the .loki or .snode subdomains. a target
      *    specified in this manner must not end with a full stop.
      */
-    bool fromString(std::string_view srvString);
+    bool
+    fromString(std::string_view srvString);
   };
 
-} // namespace llarp::dns
+}  // namespace llarp::dns

--- a/llarp/dns/srv_data.hpp
+++ b/llarp/dns/srv_data.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <dns/name.hpp>
+#include <dns/serialize.hpp>
+
+namespace llarp::dns
+{
+
+  struct SRVData
+  {
+    static constexpr size_t TARGET_MAX_SIZE = 200;
+
+    std::string service_proto; // service and protocol may as well be together
+
+    uint16_t priority;
+    uint16_t weight;
+    uint16_t port;
+
+    // target string for the SRV record to point to
+    // options:
+    //   empty                     - refer to query name
+    //   dot                       - authoritative "no such service available"
+    //   any other .loki or .snode - target is that .loki or .snode
+    std::string target;
+
+    // do some basic validation on the target string
+    // note: this is not a conclusive, regex solution,
+    // but rather some sanity/safety checks
+    bool IsValid() const;
+
+  };
+
+} // namespace llarp::dns

--- a/llarp/dns/srv_data.hpp
+++ b/llarp/dns/srv_data.hpp
@@ -35,6 +35,24 @@ namespace llarp::dns
     SRVTuple toTuple() const;
 
     static SRVData fromTuple(SRVTuple tuple);
+
+    /* bind-like formatted string for SRV records in config file
+     *
+     * format:
+     *   srv="service.proto priority weight port target"
+     *
+     * exactly one space character between parts.
+     *
+     * target can be empty, which would mean the full string
+     * will end in a space.  if this is the case, the target is
+     * interpreted as the .loki or .snode of the current context.
+     *
+     * if target is not empty, it must be either
+     *  - simply a full stop (dot/period) OR
+     *  - a name within the .loki or .snode subdomains. a target
+     *    specified in this manner must not end with a full stop.
+     */
+    bool fromString(const std::string& srvString);
   };
 
 } // namespace llarp::dns

--- a/llarp/dns/srv_data.hpp
+++ b/llarp/dns/srv_data.hpp
@@ -4,6 +4,7 @@
 #include <dns/serialize.hpp>
 
 #include <tuple>
+#include <string_view>
 
 namespace llarp::dns
 {
@@ -39,12 +40,12 @@ namespace llarp::dns
     /* bind-like formatted string for SRV records in config file
      *
      * format:
-     *   srv="service.proto priority weight port target"
+     *   srv=service.proto priority weight port target
      *
      * exactly one space character between parts.
      *
-     * target can be empty, which would mean the full string
-     * will end in a space.  if this is the case, the target is
+     * target can be empty, in which case the space after port should
+     * be omitted.  if this is the case, the target is
      * interpreted as the .loki or .snode of the current context.
      *
      * if target is not empty, it must be either
@@ -52,7 +53,7 @@ namespace llarp::dns
      *  - a name within the .loki or .snode subdomains. a target
      *    specified in this manner must not end with a full stop.
      */
-    bool fromString(const std::string& srvString);
+    bool fromString(std::string_view srvString);
   };
 
 } // namespace llarp::dns

--- a/llarp/dns/srv_data.hpp
+++ b/llarp/dns/srv_data.hpp
@@ -3,8 +3,12 @@
 #include <dns/name.hpp>
 #include <dns/serialize.hpp>
 
+#include <tuple>
+
 namespace llarp::dns
 {
+
+  typedef std::tuple<std::string, uint16_t, uint16_t, uint16_t, std::string> SRVTuple;
 
   struct SRVData
   {
@@ -28,6 +32,9 @@ namespace llarp::dns
     // but rather some sanity/safety checks
     bool IsValid() const;
 
+    SRVTuple toTuple() const;
+
+    static SRVData fromTuple(SRVTuple tuple);
   };
 
 } // namespace llarp::dns

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -22,6 +22,8 @@
 
 #include <util/str.hpp>
 
+#include <dns/srv_data.hpp>
+
 namespace llarp
 {
   namespace handlers
@@ -478,6 +480,19 @@ namespace llarp
         msg.AddNXReply();
         reply(msg);
         return true;
+      }
+      //TODO: SRV Record
+      else if (msg.questions[0].qtype == dns::qTypeSRV)
+      {
+        llarp::LogWarn("SRV request for: ", qname);
+        std::vector<llarp::dns::SRVData> records;
+        records.emplace_back(llarp::dns::SRVData{"_foo._bar",42,69,1337,"garbage.loki"});
+        records.emplace_back(llarp::dns::SRVData{"_foo._bar",24,25,26,""});
+        records.emplace_back(llarp::dns::SRVData{"_foo._bar",0,0,0,"."});
+
+        msg.AddSRVReply(records);
+
+        reply(msg);
       }
       else
       {

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -320,6 +320,9 @@ namespace llarp
         return self->EnsurePathToService(
             addr,
             [=](const Address&, OutboundContext* ctx) {
+              if (ctx == nullptr)
+                return;
+
               const auto& introset = ctx->GetCurrentIntroSet();
               std::vector<llarp::dns::SRVData> records;
               size_t numRecords = introset.SRVs.size();

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -508,7 +508,7 @@ namespace llarp
         reply(msg);
         return true;
       }
-      //TODO: SRV Record
+      // TODO: SRV Record
       else if (msg.questions[0].qtype == dns::qTypeSRV)
       {
         llarp::service::Address addr;

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -67,6 +67,8 @@ namespace llarp
 
     static constexpr auto INTROSET_PUBLISH_RETRY_INTERVAL = 5s;
 
+    static constexpr auto INTROSET_LOOKUP_RETRY_COOLDOWN = 3s;
+
     struct Endpoint : public path::Builder, public ILookupHolder, public IDataHandler
     {
       static const size_t MAX_OUTBOUND_CONTEXT_COUNT = 4;

--- a/llarp/service/endpoint_state.cpp
+++ b/llarp/service/endpoint_state.cpp
@@ -17,6 +17,12 @@ namespace llarp
         m_Keyfile = conf.m_keyfile->string();
       m_SnodeBlacklist = conf.m_snodeBlacklist;
       m_ExitEnabled = conf.m_AllowExit;
+
+      for (const auto& record : conf.m_SRVRecords)
+      {
+        m_IntroSet.SRVs.push_back(record.toTuple());
+      }
+
       // TODO:
       /*
       if (k == "on-up")

--- a/llarp/service/endpoint_state.hpp
+++ b/llarp/service/endpoint_state.hpp
@@ -88,8 +88,6 @@ namespace llarp
 
       std::unordered_map<Tag, CachedTagResult, Tag::Hash> m_PrefetchedTags;
 
-      util::DecayingHashSet<Address> m_RemoteLookupFilter;
-
       bool
       Configure(const NetworkConfig& conf);
 

--- a/llarp/service/endpoint_state.hpp
+++ b/llarp/service/endpoint_state.hpp
@@ -67,6 +67,7 @@ namespace llarp
       SNodeSessions m_SNodeSessions;
 
       std::unordered_multimap<Address, PathEnsureHook, Address::Hash> m_PendingServiceLookups;
+      std::unordered_map<Address, llarp_time_t, Address::Hash> m_LastServiceLookupTimes;
 
       std::unordered_map<RouterID, uint32_t, RouterID::Hash> m_ServiceLookupFails;
 

--- a/llarp/service/intro_set.cpp
+++ b/llarp/service/intro_set.cpp
@@ -180,7 +180,7 @@ namespace llarp
 
         byte_t* end = buf->cur;
 
-        std::string_view srvString(reinterpret_cast<char *>(begin), end - begin);
+        std::string_view srvString(reinterpret_cast<char*>(begin), end - begin);
 
         try
         {

--- a/llarp/service/intro_set.cpp
+++ b/llarp/service/intro_set.cpp
@@ -2,6 +2,8 @@
 #include <crypto/crypto.hpp>
 #include <path/path.hpp>
 
+#include <lokimq/bt_serialize.h>
+
 namespace llarp
 {
   namespace service
@@ -170,6 +172,28 @@ namespace llarp
       if (!BEncodeMaybeReadDictEntry("n", topic, read, key, buf))
         return false;
 
+      if (key == "s")
+      {
+        byte_t* begin = buf->cur;
+        if (not bencode_discard(buf))
+          return false;
+
+        byte_t* end = buf->cur;
+
+        std::string_view srvString(reinterpret_cast<char *>(begin), end - begin);
+
+        try
+        {
+          lokimq::bt_deserialize(srvString, SRVs);
+        }
+        catch (const lokimq::bt_deserialize_invalid& err)
+        {
+          LogError("Error decoding SRV records from IntroSet: ", err.what());
+          return false;
+        }
+        read = true;
+      }
+
       if (!BEncodeMaybeReadDictInt("t", T, read, key, buf))
         return false;
 
@@ -215,6 +239,16 @@ namespace llarp
         if (!BEncodeWriteDictEntry("n", topic, buf))
           return false;
       }
+
+      if (SRVs.size())
+      {
+        std::string serial = lokimq::bt_serialize(SRVs);
+        if (!bencode_write_bytestring(buf, "s", 1))
+          return false;
+        if (!buf->write(serial.begin(), serial.end()))
+          return false;
+      }
+
       // Timestamp published
       if (!BEncodeWriteDictInt("t", T.count(), buf))
         return false;

--- a/llarp/service/intro_set.hpp
+++ b/llarp/service/intro_set.hpp
@@ -9,6 +9,7 @@
 #include <util/bencode.hpp>
 #include <util/time.hpp>
 #include <util/status.hpp>
+#include <dns/srv_data.hpp>
 
 #include <optional>
 #include <algorithm>
@@ -30,6 +31,7 @@ namespace llarp
       std::vector<Introduction> I;
       PQPubKey K;
       Tag topic;
+      std::vector<llarp::dns::SRVTuple> SRVs;
       llarp_time_t T = 0s;
       std::optional<PoW> W;
       Signature Z;

--- a/llarp/service/outbound_context.hpp
+++ b/llarp/service/outbound_context.hpp
@@ -117,6 +117,12 @@ namespace llarp
       std::string
       Name() const override;
 
+      const IntroSet&
+      GetCurrentIntroSet() const
+      {
+        return currentIntroSet;
+      }
+
      private:
       /// swap remoteIntro with next intro
       void

--- a/llarp/util/str.cpp
+++ b/llarp/util/str.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <cassert>
 #include <string>
 #include <set>
 
@@ -93,6 +94,114 @@ namespace llarp
     }
 
     return splits;
+  }
+
+  using namespace std::literals;
+
+  std::vector<std::string_view> split(std::string_view str, const std::string_view delim, bool trim)
+  { 
+    std::vector<std::string_view> results;
+    // Special case for empty delimiter: splits on each character boundary:
+    if (delim.empty())
+    {
+      results.reserve(str.size());
+      for (size_t i = 0; i < str.size(); i++)
+        results.emplace_back(str.data() + i, 1);
+      return results;
+    }
+
+    for (size_t pos = str.find(delim); pos != std::string_view::npos; pos = str.find(delim))
+    {
+      if (!trim || !results.empty() || pos > 0)
+        results.push_back(str.substr(0, pos));
+      str.remove_prefix(pos + delim.size());
+    }
+    if (!trim || str.size())
+      results.push_back(str);
+    else
+      while (!results.empty() && results.back().empty())
+        results.pop_back();
+    return results;
+  }
+
+  std::vector<std::string_view> split_any(std::string_view str, const std::string_view delims, bool trim)
+  {
+    if (delims.empty())
+      return split(str, delims, trim);
+    std::vector<std::string_view> results;
+    for (size_t pos = str.find_first_of(delims); pos != std::string_view::npos; pos = str.find_first_of(delims))
+    {
+      if (!trim || !results.empty() || pos > 0)
+        results.push_back(str.substr(0, pos));
+      size_t until = str.find_first_not_of(delims, pos+1);
+      if (until == std::string_view::npos)
+        str.remove_prefix(str.size());
+      else
+        str.remove_prefix(until);
+    }
+    if (!trim || str.size())
+      results.push_back(str);
+    else
+      while (!results.empty() && results.back().empty())
+        results.pop_back();
+    return results;
+  }
+
+  void trim(std::string_view& s)
+  {
+    constexpr auto simple_whitespace = " \t\r\n"sv;
+    auto pos = s.find_first_not_of(simple_whitespace);
+    if (pos == std::string_view::npos) { // whole string is whitespace
+      s.remove_prefix(s.size());
+      return;
+    }
+    s.remove_prefix(pos);
+    pos = s.find_last_not_of(simple_whitespace);
+    assert(pos != std::string_view::npos);
+    s.remove_suffix(s.size() - (pos + 1));
+  }
+
+  std::string lowercase_ascii_string(std::string src)
+  {
+    for (char &ch : src)
+      if (ch >= 'A' && ch <= 'Z') ch = ch + ('a' - 'A');
+    return src;
+  }
+
+  std::string friendly_duration(std::chrono::nanoseconds dur) {
+    std::ostringstream os;
+    bool some = false;
+    if (dur >= 24h) {
+      os << dur / 24h << 'd';
+      dur %= 24h;
+      some = true;
+    }
+    if (dur >= 1h || some) {
+      os << dur / 1h << 'h';
+      dur %= 1h;
+      some = true;
+    }
+    if (dur >= 1min || some) {
+      os << dur / 1min << 'm';
+      dur %= 1min;
+      some = true;
+    }
+    if (some) {
+      // If we have >= minutes then don't bother with fractional seconds
+      os << dur / 1s << 's';
+    } else {
+      double seconds = std::chrono::duration<double>(dur).count();
+      os.precision(3);
+      if (dur >= 1s)
+        os << seconds << "s";
+      else if (dur >= 1ms)
+        os << seconds * 1000 << "ms";
+      else if (dur >= 1us)
+        os << seconds * 1'000'000 << u8"µs";
+      else
+        os << seconds * 1'000'000'000 << "ns";
+    }
+    return os.str();
   }
 
 }  // namespace llarp

--- a/llarp/util/str.cpp
+++ b/llarp/util/str.cpp
@@ -98,8 +98,9 @@ namespace llarp
 
   using namespace std::literals;
 
-  std::vector<std::string_view> split(std::string_view str, const std::string_view delim, bool trim)
-  { 
+  std::vector<std::string_view>
+  split(std::string_view str, const std::string_view delim, bool trim)
+  {
     std::vector<std::string_view> results;
     // Special case for empty delimiter: splits on each character boundary:
     if (delim.empty())
@@ -124,16 +125,18 @@ namespace llarp
     return results;
   }
 
-  std::vector<std::string_view> split_any(std::string_view str, const std::string_view delims, bool trim)
+  std::vector<std::string_view>
+  split_any(std::string_view str, const std::string_view delims, bool trim)
   {
     if (delims.empty())
       return split(str, delims, trim);
     std::vector<std::string_view> results;
-    for (size_t pos = str.find_first_of(delims); pos != std::string_view::npos; pos = str.find_first_of(delims))
+    for (size_t pos = str.find_first_of(delims); pos != std::string_view::npos;
+         pos = str.find_first_of(delims))
     {
       if (!trim || !results.empty() || pos > 0)
         results.push_back(str.substr(0, pos));
-      size_t until = str.find_first_not_of(delims, pos+1);
+      size_t until = str.find_first_not_of(delims, pos + 1);
       if (until == std::string_view::npos)
         str.remove_prefix(str.size());
       else
@@ -147,11 +150,13 @@ namespace llarp
     return results;
   }
 
-  void trim(std::string_view& s)
+  void
+  trim(std::string_view& s)
   {
     constexpr auto simple_whitespace = " \t\r\n"sv;
     auto pos = s.find_first_not_of(simple_whitespace);
-    if (pos == std::string_view::npos) { // whole string is whitespace
+    if (pos == std::string_view::npos)
+    {  // whole string is whitespace
       s.remove_prefix(s.size());
       return;
     }
@@ -161,35 +166,45 @@ namespace llarp
     s.remove_suffix(s.size() - (pos + 1));
   }
 
-  std::string lowercase_ascii_string(std::string src)
+  std::string
+  lowercase_ascii_string(std::string src)
   {
-    for (char &ch : src)
-      if (ch >= 'A' && ch <= 'Z') ch = ch + ('a' - 'A');
+    for (char& ch : src)
+      if (ch >= 'A' && ch <= 'Z')
+        ch = ch + ('a' - 'A');
     return src;
   }
 
-  std::string friendly_duration(std::chrono::nanoseconds dur) {
+  std::string
+  friendly_duration(std::chrono::nanoseconds dur)
+  {
     std::ostringstream os;
     bool some = false;
-    if (dur >= 24h) {
+    if (dur >= 24h)
+    {
       os << dur / 24h << 'd';
       dur %= 24h;
       some = true;
     }
-    if (dur >= 1h || some) {
+    if (dur >= 1h || some)
+    {
       os << dur / 1h << 'h';
       dur %= 1h;
       some = true;
     }
-    if (dur >= 1min || some) {
+    if (dur >= 1min || some)
+    {
       os << dur / 1min << 'm';
       dur %= 1min;
       some = true;
     }
-    if (some) {
+    if (some)
+    {
       // If we have >= minutes then don't bother with fractional seconds
       os << dur / 1s << 's';
-    } else {
+    }
+    else
+    {
       double seconds = std::chrono::duration<double>(dur).count();
       os.precision(3);
       if (dur >= 1s)

--- a/llarp/util/str.hpp
+++ b/llarp/util/str.hpp
@@ -47,33 +47,43 @@ namespace llarp
   using namespace std::literals;
 
   /// Returns true if the first string is equal to the second string, compared case-insensitively.
-  inline bool string_iequal(std::string_view s1, std::string_view s2) {
+  inline bool
+  string_iequal(std::string_view s1, std::string_view s2)
+  {
     return std::equal(s1.begin(), s1.end(), s2.begin(), s2.end(), [](char a, char b) {
-        return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)); });
+      return std::tolower(static_cast<unsigned char>(a))
+          == std::tolower(static_cast<unsigned char>(b));
+    });
   }
 
-  /// Returns true if the first string matches any of the given strings case-insensitively.  Arguments
-  /// must be string literals, std::string, or std::string_views
+  /// Returns true if the first string matches any of the given strings case-insensitively.
+  /// Arguments must be string literals, std::string, or std::string_views
   template <typename S1, typename... S>
-  bool string_iequal_any(const S1& s1, const S&... s) {
+  bool
+  string_iequal_any(const S1& s1, const S&... s)
+  {
     return (... || string_iequal(s1, s));
   }
 
   /// Returns true if the first argument begins with the second argument
-  inline bool starts_with(std::string_view str, std::string_view prefix) {
+  inline bool
+  starts_with(std::string_view str, std::string_view prefix)
+  {
     return str.substr(0, prefix.size()) == prefix;
   }
 
   /// Returns true if the first argument ends with the second argument
-  inline bool ends_with(std::string_view str, std::string_view suffix) {
+  inline bool
+  ends_with(std::string_view str, std::string_view suffix)
+  {
     return str.size() >= suffix.size() && str.substr(str.size() - suffix.size()) == suffix;
   }
 
-  /// Splits a string on some delimiter string and returns a vector of string_view's pointing into the
-  /// pieces of the original string.  The pieces are valid only as long as the original string remains
-  /// valid.  Leading and trailing empty substrings are not removed.  If delim is empty you get back a
-  /// vector of string_views each viewing one character.  If `trim` is true then leading and trailing
-  /// empty values will be suppressed.
+  /// Splits a string on some delimiter string and returns a vector of string_view's pointing into
+  /// the pieces of the original string.  The pieces are valid only as long as the original string
+  /// remains valid.  Leading and trailing empty substrings are not removed.  If delim is empty you
+  /// get back a vector of string_views each viewing one character.  If `trim` is true then leading
+  /// and trailing empty values will be suppressed.
   ///
   ///     auto v = split("ab--c----de", "--"); // v is {"ab", "c", "", "de"}
   ///     auto v = split("abc", ""); // v is {"a", "b", "c"}
@@ -82,7 +92,8 @@ namespace llarp
   ///     auto v = split("-a--b--", "-"); // v is {"", "a", "", "b", "", ""}
   ///     auto v = split("-a--b--", "-", true); // v is {"a", "", "b"}
   ///
-  std::vector<std::string_view> split(std::string_view str, std::string_view delim, bool trim = false);
+  std::vector<std::string_view>
+  split(std::string_view str, std::string_view delim, bool trim = false);
 
   /// Splits a string on any 1 or more of the given delimiter characters and returns a vector of
   /// string_view's pointing into the pieces of the original string.  If delims is empty this works
@@ -90,33 +101,43 @@ namespace llarp
   /// pieces).
   ///
   ///     auto v = split_any("abcdedf", "dcx"); // v is {"ab", "e", "f"}
-  std::vector<std::string_view> split_any(std::string_view str, std::string_view delims, bool trim = false);
+  std::vector<std::string_view>
+  split_any(std::string_view str, std::string_view delims, bool trim = false);
 
-  /// Joins [begin, end) with a delimiter and returns the resulting string.  Elements can be anything
-  /// that can be sent to an ostream via `<<`.
+  /// Joins [begin, end) with a delimiter and returns the resulting string.  Elements can be
+  /// anything that can be sent to an ostream via `<<`.
   template <typename It>
-  std::string join(std::string_view delimiter, It begin, It end) {
-      std::ostringstream o;
-      if (begin != end)
-          o << *begin++;
-      while (begin != end)
-          o << delimiter << *begin++;
-      return o.str();
+  std::string
+  join(std::string_view delimiter, It begin, It end)
+  {
+    std::ostringstream o;
+    if (begin != end)
+      o << *begin++;
+    while (begin != end)
+      o << delimiter << *begin++;
+    return o.str();
   }
 
   /// Wrapper around the above that takes a container and passes c.begin(), c.end() to the above.
   template <typename Container>
-  std::string join(std::string_view delimiter, const Container& c) { return join(delimiter, c.begin(), c.end()); }
+  std::string
+  join(std::string_view delimiter, const Container& c)
+  {
+    return join(delimiter, c.begin(), c.end());
+  }
 
   /// Simple version of whitespace trimming: mutates the given string view to remove leading
   /// space, \t, \r, \n.  (More exotic and locale-dependent whitespace is not removed).
-  void trim(std::string_view& s);
+  void
+  trim(std::string_view& s);
 
   /// Parses an integer of some sort from a string, requiring that the entire string be consumed
   /// during parsing.  Return false if parsing failed, sets `value` and returns true if the entire
   /// string was consumed.
   template <typename T>
-  bool parse_int(const std::string_view str, T& value, int base = 10) {
+  bool
+  parse_int(const std::string_view str, T& value, int base = 10)
+  {
     T tmp;
     auto* strend = str.data() + str.size();
     auto [p, ec] = std::from_chars(str.data(), strend, tmp, base);
@@ -126,10 +147,12 @@ namespace llarp
     return true;
   }
 
-  std::string lowercase_ascii_string(std::string src);
+  std::string
+  lowercase_ascii_string(std::string src);
 
   /// Converts a duration into a human friendlier string.
-  std::string friendly_duration(std::chrono::nanoseconds dur);
+  std::string
+  friendly_duration(std::chrono::nanoseconds dur);
 
 }  // namespace llarp
 

--- a/llarp/util/str.hpp
+++ b/llarp/util/str.hpp
@@ -4,6 +4,9 @@
 #include <string_view>
 #include <sstream>
 #include <vector>
+#include <chrono>
+#include <iterator>
+#include <charconv>
 
 namespace llarp
 {
@@ -40,6 +43,93 @@ namespace llarp
   /// @return a vector of std::string_views with the split words, excluding the delimeter
   std::vector<std::string_view>
   split(const std::string_view str, char delimiter);
+
+  using namespace std::literals;
+
+  /// Returns true if the first string is equal to the second string, compared case-insensitively.
+  inline bool string_iequal(std::string_view s1, std::string_view s2) {
+    return std::equal(s1.begin(), s1.end(), s2.begin(), s2.end(), [](char a, char b) {
+        return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)); });
+  }
+
+  /// Returns true if the first string matches any of the given strings case-insensitively.  Arguments
+  /// must be string literals, std::string, or std::string_views
+  template <typename S1, typename... S>
+  bool string_iequal_any(const S1& s1, const S&... s) {
+    return (... || string_iequal(s1, s));
+  }
+
+  /// Returns true if the first argument begins with the second argument
+  inline bool starts_with(std::string_view str, std::string_view prefix) {
+    return str.substr(0, prefix.size()) == prefix;
+  }
+
+  /// Returns true if the first argument ends with the second argument
+  inline bool ends_with(std::string_view str, std::string_view suffix) {
+    return str.size() >= suffix.size() && str.substr(str.size() - suffix.size()) == suffix;
+  }
+
+  /// Splits a string on some delimiter string and returns a vector of string_view's pointing into the
+  /// pieces of the original string.  The pieces are valid only as long as the original string remains
+  /// valid.  Leading and trailing empty substrings are not removed.  If delim is empty you get back a
+  /// vector of string_views each viewing one character.  If `trim` is true then leading and trailing
+  /// empty values will be suppressed.
+  ///
+  ///     auto v = split("ab--c----de", "--"); // v is {"ab", "c", "", "de"}
+  ///     auto v = split("abc", ""); // v is {"a", "b", "c"}
+  ///     auto v = split("abc", "c"); // v is {"ab", ""}
+  ///     auto v = split("abc", "c", true); // v is {"ab"}
+  ///     auto v = split("-a--b--", "-"); // v is {"", "a", "", "b", "", ""}
+  ///     auto v = split("-a--b--", "-", true); // v is {"a", "", "b"}
+  ///
+  std::vector<std::string_view> split(std::string_view str, std::string_view delim, bool trim = false);
+
+  /// Splits a string on any 1 or more of the given delimiter characters and returns a vector of
+  /// string_view's pointing into the pieces of the original string.  If delims is empty this works
+  /// the same as split().  `trim` works like split (suppresses leading and trailing empty string
+  /// pieces).
+  ///
+  ///     auto v = split_any("abcdedf", "dcx"); // v is {"ab", "e", "f"}
+  std::vector<std::string_view> split_any(std::string_view str, std::string_view delims, bool trim = false);
+
+  /// Joins [begin, end) with a delimiter and returns the resulting string.  Elements can be anything
+  /// that can be sent to an ostream via `<<`.
+  template <typename It>
+  std::string join(std::string_view delimiter, It begin, It end) {
+      std::ostringstream o;
+      if (begin != end)
+          o << *begin++;
+      while (begin != end)
+          o << delimiter << *begin++;
+      return o.str();
+  }
+
+  /// Wrapper around the above that takes a container and passes c.begin(), c.end() to the above.
+  template <typename Container>
+  std::string join(std::string_view delimiter, const Container& c) { return join(delimiter, c.begin(), c.end()); }
+
+  /// Simple version of whitespace trimming: mutates the given string view to remove leading
+  /// space, \t, \r, \n.  (More exotic and locale-dependent whitespace is not removed).
+  void trim(std::string_view& s);
+
+  /// Parses an integer of some sort from a string, requiring that the entire string be consumed
+  /// during parsing.  Return false if parsing failed, sets `value` and returns true if the entire
+  /// string was consumed.
+  template <typename T>
+  bool parse_int(const std::string_view str, T& value, int base = 10) {
+    T tmp;
+    auto* strend = str.data() + str.size();
+    auto [p, ec] = std::from_chars(str.data(), strend, tmp, base);
+    if (ec != std::errc() || p != strend)
+      return false;
+    value = tmp;
+    return true;
+  }
+
+  std::string lowercase_ascii_string(std::string src);
+
+  /// Converts a duration into a human friendlier string.
+  std::string friendly_duration(std::chrono::nanoseconds dur);
 
 }  // namespace llarp
 


### PR DESCRIPTION
Service operators can now provide SRV records via the ini file.

To do so, in the [network] section add one or more lines with the following syntax:

`srv=_service._protocol priority weight port [target]`

Target must be omitted, a single dot `.`, or a valid name with .loki or .snode as the TLD.

.snode is allowed as this is meant to be used later for relays' router contact info.

Can squash upon request