### PR TITLE
remove locks

### DIFF
--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -850,9 +850,7 @@ namespace llarp
            && (m_state->m_ExitEnabled || m_ExitMap.ContainsValue(msg->sender.Addr())))
           || msg->proto == eProtocolTrafficV4 || msg->proto == eProtocolTrafficV6)
       {
-        if (m_InboundTrafficQueue.full())
-          return false;
-        m_InboundTrafficQueue.pushBack(std::move(msg));
+        m_InboundTrafficQueue.tryPushBack(std::move(msg));
         return true;
       }
       if (msg->proto == eProtocolControl)
@@ -891,9 +889,7 @@ namespace llarp
 
       if (f.Sign(m_Identity))
       {
-        if (m_SendQueue.full())
-          return;
-        m_SendQueue.pushBack(
+        m_SendQueue.tryPushBack(
             SendEvent_t{std::make_shared<const routing::PathTransferMessage>(f, replyPath), path});
       }
     }
@@ -933,9 +929,7 @@ namespace llarp
         {
           LogWarn("invalidating convotag T=", frame.T);
           RemoveConvoTag(frame.T);
-          if (m_SendQueue.full())
-            return false;
-          m_SendQueue.pushBack(
+          m_SendQueue.tryPushBack(
               SendEvent_t{std::make_shared<const routing::PathTransferMessage>(f, frame.F), p});
         }
       }

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -19,6 +19,7 @@
 #include <hook/ihook.hpp>
 #include <util/compare_ptr.hpp>
 #include <util/thread/logic.hpp>
+#include <service/endpoint_types.hpp>
 
 #include <service/auth.hpp>
 
@@ -458,6 +459,9 @@ namespace llarp
       std::unique_ptr<EndpointState> m_state;
       std::shared_ptr<IAuthPolicy> m_AuthPolicy;
       std::unordered_map<Address, AuthInfo, Address::Hash> m_RemoteAuthInfos;
+
+      RecvPacketQueue_t m_InboundTrafficQueue;
+      SendMessageQueue_t m_SendQueue;
 
       void
       FlushRecvData();

--- a/llarp/service/endpoint_state.hpp
+++ b/llarp/service/endpoint_state.hpp
@@ -40,10 +40,6 @@ namespace llarp
       hooks::Backend_ptr m_OnDown;
       hooks::Backend_ptr m_OnReady;
 
-      util::Mutex m_InboundTrafficQueueMutex;  // protects m_InboundTrafficQueue
-      /// ordered queue for inbound hidden service traffic
-      RecvPacketQueue_t m_InboundTrafficQueue GUARDED_BY(m_InboundTrafficQueueMutex);
-
       std::set<RouterID> m_SnodeBlacklist;
 
       AbstractRouter* m_Router;
@@ -53,9 +49,6 @@ namespace llarp
       std::string m_Name;
       std::string m_NetNS;
       bool m_ExitEnabled = false;
-
-      util::Mutex m_SendQueueMutex;  // protects m_SendQueue
-      std::deque<SendEvent_t> m_SendQueue GUARDED_BY(m_SendQueueMutex);
 
       PendingTraffic m_PendingTraffic;
 

--- a/llarp/service/endpoint_types.hpp
+++ b/llarp/service/endpoint_types.hpp
@@ -5,6 +5,7 @@
 #include <service/router_lookup_job.hpp>
 #include <service/session.hpp>
 #include <util/compare_ptr.hpp>
+#include <util/thread/queue.hpp>
 
 #include <deque>
 #include <memory>
@@ -25,15 +26,15 @@ namespace llarp
     struct OutboundContext;
 
     using Msg_ptr = std::shared_ptr<const routing::PathTransferMessage>;
+
     using SendEvent_t = std::pair<Msg_ptr, path::Path_ptr>;
+    using SendMessageQueue_t = thread::Queue<SendEvent_t>;
+
     using PendingBufferQueue = std::deque<PendingBuffer>;
     using PendingTraffic = std::unordered_map<Address, PendingBufferQueue, Address::Hash>;
 
     using ProtocolMessagePtr = std::shared_ptr<ProtocolMessage>;
-    using RecvPacketQueue_t = std::priority_queue<
-        ProtocolMessagePtr,
-        std::vector<ProtocolMessagePtr>,
-        ComparePtr<ProtocolMessagePtr>>;
+    using RecvPacketQueue_t = thread::Queue<ProtocolMessagePtr>;
 
     using PendingRouters = std::unordered_map<RouterID, RouterLookupJob, RouterID::Hash>;
 


### PR DESCRIPTION
remove locks and use lockless queues to remove lock contention.
this yields a massive speedup in mainloop thread. before it was eating 100% cpu at 3200KBps, now it is at about 54% at same speeds.