### PR TITLE
Support [dns] no-resolvconf option (ignored by lokinet) for deb compatibility

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -353,6 +353,9 @@ namespace llarp
     conf.defineOption<std::string>("dns", "bind", false, "127.3.2.1:53", [=](std::string arg) {
       m_bind = parseDNSAddr(std::move(arg));
     });
+
+    // Ignored option (used by the systemd service file to disable resolvconf configuration).
+    conf.defineOption<bool>("dns", "no-resolvconf", false, false);
   }
 
   LinksConfig::LinkInfo
@@ -839,6 +842,15 @@ namespace llarp
         {
             "Address to bind to for handling DNS requests.",
             "Multiple values accepted.",
+        });
+
+    def.addOptionComments(
+        "dns",
+        "no-resolvconf",
+        {
+            "Can be uncommented and set to 1 to disable resolvconf configuration of lokinet DNS.",
+            "(This is not used directly by lokinet itself, but by the lokinet init scripts",
+            "on systems which use resolveconf)",
         });
 
     // bootstrap

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -830,7 +830,7 @@ namespace llarp
 
     def.addOptionComments(
         "dns",
-        "upstream-dns",
+        "upstream",
         {
             "Upstream resolver(s) to use as fallback for non-loki addresses.",
             "Multiple values accepted.",

--- a/test/service/test_llarp_service_identity.cpp
+++ b/test/service/test_llarp_service_identity.cpp
@@ -1,7 +1,6 @@
 #include <crypto/crypto.hpp>
 #include <crypto/crypto_libsodium.hpp>
 #include <sodium/crypto_scalarmult_ed25519.h>
-#include <llarp_test.hpp>
 #include <path/path.hpp>
 #include <service/address.hpp>
 #include <service/identity.hpp>


### PR DESCRIPTION
The debs in 0.7 hack a `[dns] no-resolvconf=1` setting into the config file (commented out by default) that a user can use to disable the service file's invocation of resolvconf to update DNS settings.

lokinet 0.8 no longer allows unknown options, so this adds it into the config as a do-nothing option to let that setting still be used by init scripts.

Also contains a fix for the `upstream` comment not being written to generated files, and a test suite fix.