### PR TITLE
Allow -DWITH_SETCAP=OFF to disable setcap during make install

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -35,7 +35,10 @@ else()
     endif()
 
     if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-        install(CODE "execute_process(COMMAND setcap cap_net_admin,cap_net_bind_service=+eip ${CMAKE_INSTALL_PREFIX}/bin/lokinet)")
+        option(WITH_SETCAP "Enables setcap'ing the lokinet binary with the required capabilities during installation (requires root)" ON)
+        if(WITH_SETCAP)
+            install(CODE "execute_process(COMMAND setcap cap_net_admin,cap_net_bind_service=+eip ${CMAKE_INSTALL_PREFIX}/bin/lokinet)")
+        endif()
     endif()
     
 endif()


### PR DESCRIPTION
The debs don't want it (and so this will save needing to patch it out),
nor do you need it if running via a systemd service file that sets the
capabilities.