### PR TITLE
dont serialize ephemeral members of service identity

### DIFF
--- a/contrib/py/keygen/.gitignore
+++ b/contrib/py/keygen/.gitignore
@@ -1,0 +1,1 @@
+*.private

--- a/contrib/py/keygen/keygen.py
+++ b/contrib/py/keygen/keygen.py
@@ -6,7 +6,7 @@ keygen tool for lokinet
 from argparse import ArgumentParser as AP
 from base64 import b32encode
 
-import pysodium
+from nacl.signing import SigningKey
 
 def base32z(data):
     """ base32 z encode """
@@ -23,12 +23,13 @@ def main():
     argparser = AP()
     argparser.add_argument('--keyfile', type=str, required=True, help='place to put generated keys')
     args = argparser.parse_args()
-    keys = pysodium.crypto_sign_keypair()
+    secret = SigningKey.generate()
     with open(args.keyfile, 'wb') as wfile:
-        wfile.write('d1:s{}:'.format(len(keys[1])).encode('ascii'))
-        wfile.write(keys[1])
+        wfile.write(b'd1:s64:')
+        wfile.write(secret.encode())
+        wfile.write(secret.verify_key.encode())
         wfile.write(b'e')
-    print("{}.loki".format(base32z(keys[0])))
+    print("{}.loki".format(base32z(secret.verify_key.encode())))
 
 if __name__ == '__main__':
     main()

--- a/contrib/py/keygen/keygen.py
+++ b/contrib/py/keygen/keygen.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+keygen tool for lokinet
+"""
+
+from argparse import ArgumentParser as AP
+from base64 import b32encode
+
+import pysodium
+
+def base32z(data):
+    """ base32 z encode """
+    return b32encode(data).translate(
+        bytes.maketrans(
+            b'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+            b'ybndrfg8ejkmcpqxot1uwisza345h769')).decode().rstrip('=')
+
+
+def main():
+    """
+    main function for keygen
+    """
+    argparser = AP()
+    argparser.add_argument('--keyfile', type=str, required=True, help='place to put generated keys')
+    args = argparser.parse_args()
+    keys = pysodium.crypto_sign_keypair()
+    with open(args.keyfile, 'wb') as wfile:
+        wfile.write('d1:s{}:'.format(len(keys[1])).encode('ascii'))
+        wfile.write(keys[1])
+        wfile.write(b'e')
+    print("{}.loki".format(base32z(keys[0])))
+
+if __name__ == '__main__':
+    main()

--- a/contrib/py/keygen/readme.md
+++ b/contrib/py/keygen/readme.md
@@ -3,7 +3,7 @@
 requires:
 
 * python3.7 or higher
-* pysodium
+* pynacl
 
 usage:
 

--- a/contrib/py/keygen/readme.md
+++ b/contrib/py/keygen/readme.md
@@ -1,0 +1,14 @@
+# lokinet key generator
+
+requires:
+
+* python3.7 or higher
+* pysodium
+
+usage:
+
+```bash
+./keygen.py --keyfile somekeyfile.private
+```
+
+this will overwrite the keyfile with new keys

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -90,7 +90,7 @@ namespace llarp
       return BEncodeSignedSection(buf);
     else if (version == 1)
     {
-      //TODO: heapless serialization for this in lokimq's bt serialization.
+      // TODO: heapless serialization for this in lokimq's bt serialization.
       if (not buf->writef("li1e%lu:", signature.size()))
         return false;
       if (not buf->write(signature.begin(), signature.end()))
@@ -224,15 +224,14 @@ namespace llarp
   {
     Clear();
 
-    if (*buf->cur == 'd') // old format
+    if (*buf->cur == 'd')  // old format
     {
       return DecodeVersion_0(buf);
     }
-    else if (*buf->cur != 'l') // if not dict, should be new format and start with list
+    else if (*buf->cur != 'l')  // if not dict, should be new format and start with list
     {
       return false;
     }
-
 
     try
     {
@@ -267,7 +266,7 @@ namespace llarp
   bool
   RouterContact::DecodeVersion_0(llarp_buffer_t* buf)
   {
-    signed_bt_dict = std::string(reinterpret_cast<char *>(buf->cur), buf->sz);
+    signed_bt_dict = std::string(reinterpret_cast<char*>(buf->cur), buf->sz);
     return bencode_decode_dict(*this, buf);
   }
 
@@ -424,7 +423,7 @@ namespace llarp
     buf.sz = buf.cur - buf.base;
     buf.cur = buf.base;
 
-    signed_bt_dict = std::string(reinterpret_cast<char *>(buf.base), buf.sz);
+    signed_bt_dict = std::string(reinterpret_cast<char*>(buf.base), buf.sz);
 
     if (version == 0 or version == 1)
     {

--- a/llarp/router_contact.hpp
+++ b/llarp/router_contact.hpp
@@ -20,7 +20,7 @@
 namespace lokimq
 {
   struct bt_list_consumer;
-} // namespace lokimq (forward declarations)
+}  // namespace lokimq
 
 namespace llarp
 {
@@ -222,9 +222,7 @@ namespace llarp
     bool
     VerifySignature() const;
 
-
-    private:
-
+   private:
     bool
     DecodeVersion_0(llarp_buffer_t* buf);
 

--- a/llarp/service/identity.hpp
+++ b/llarp/service/identity.hpp
@@ -55,6 +55,10 @@ namespace llarp
 
       bool
       Sign(Signature& sig, const llarp_buffer_t& buf) const;
+
+      /// zero out all secret key members
+      void
+      Clear();
     };
 
     inline bool


### PR DESCRIPTION
* don't serialize ephemeral members of service identity so that generating keyfiles is easier
* generate ephemeral members of service identity
* add a keygen python script that generates hidden service keyfiles