### PR TITLE
move old stuff down a notch

### DIFF
--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -4,12 +4,14 @@ Currently supported targets:
 
 Tier 1:
 
+These builds are fully automated using [Drone CI](https://drone.io). Guaranteed to be fully reproducible.
 * Linux (arm/x86)
 * Windows 8+ (32 and 64 bit x86)
-* FreeBSD (amd64)
+
 
 Tier 2:
 
+These targets have no automation available, but do not require patches to build or run.
 * Mac OSX (> 10.10)
 * Android (arm/x86)
 * Apple IOS
@@ -17,14 +19,17 @@ Tier 2:
 
 Tier 3:
 
+These targets are somewhat obscure or possibly obsolete, and may require some patching to fix target specific issues.
 * Big Endian Linux
 * NetBSD
 * OpenBSD
 * Windows pre-8 (while this is technically possible, the requirement for [cryptographically reproducible builds](https://reproducible-builds.org/) precludes it.)
 * UNIX v5 (x86 AMD64)
 
-Unsupported (feel free to support this yourself)
+Unsupported 
+(feel free to support this yourself)
 
+we are completely unable to test these targets at all, proceed at your own risk
 * AIX
 * zOS
 

--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -20,7 +20,7 @@ Tier 3:
 * Big Endian Linux
 * NetBSD
 * OpenBSD
-* Windows pre-8 (while this is technically possible, the requirement for cryptographically reproducible builds precludes it.)
+* Windows pre-8 (while this is technically possible, the requirement for [cryptographically reproducible builds](https://reproducible-builds.org/) precludes it.)
 * UNIX v5 (x86 AMD64)
 
 Unsupported (feel free to support this yourself)

--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -11,11 +11,12 @@ These builds are fully automated using [Drone CI](https://drone.io). Guaranteed 
 
 Tier 2:
 
-These targets have no automation available, but do not require patches to build or run.
+These targets have no build automation available, but do not require patches to build or run.
 * Mac OSX (> 10.10)
 * Android (arm/x86)
 * Apple IOS
 * Linux PPC64 (little endian)
+* FreeBSD (amd64)
 
 Tier 3:
 

--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -20,7 +20,7 @@ Tier 3:
 * Big Endian Linux
 * NetBSD
 * OpenBSD
-* Windows pre-8
+* Windows pre-8 (while this is technically possible, the requirement for cryptographically reproducible builds precludes it.)
 * UNIX v5 (x86 AMD64)
 
 Unsupported (feel free to support this yourself)

--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -5,7 +5,7 @@ Currently supported targets:
 Tier 1:
 
 * Linux (arm/x86)
-* Windows (32 and 64 bit x86)
+* Windows 8+ (32 and 64 bit x86)
 * FreeBSD (amd64)
 
 Tier 2:
@@ -20,6 +20,8 @@ Tier 3:
 * Big Endian Linux
 * NetBSD
 * OpenBSD
+* Windows pre-8
+* UNIX v5 (x86 AMD64)
 
 Unsupported (feel free to support this yourself)
 


### PR DESCRIPTION
for 0.8 windows 8.1+ is practically enforced by ci
windows pre-8 can work but can't be automated