### PR TITLE
Make public-ip option work

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -81,12 +81,24 @@ namespace llarp
           m_dataDir = std::move(arg);
         });
 
-    conf.defineOption<std::string>("router", "public-address", false, "", [this](std::string arg) {
+    conf.defineOption<std::string>("router", "public-ip", false, "", [this](std::string arg) {
       if (not arg.empty())
       {
         llarp::LogInfo("public ip ", arg, " size ", arg.size());
 
-        if (arg.size() > 16)
+        if (arg.size() > 15)
+          throw std::invalid_argument(stringify("Not a valid IPv4 addr: ", arg));
+
+        m_publicAddress.setAddress(arg);
+      }
+    });
+
+    conf.defineOption<std::string>("router", "public-address", false, "", [this](std::string arg) {
+      if (not arg.empty())
+      {
+        llarp::LogWarn("*** WARNING: The config option [router]:public-address=", arg, " is deprecated, use public-ip=", arg, " instead.");
+
+        if (arg.size() > 15)
           throw std::invalid_argument(stringify("Not a valid IPv4 addr: ", arg));
 
         m_publicAddress.setAddress(arg);
@@ -767,6 +779,23 @@ namespace llarp
         "max-connections",
         {
             "Maximum number (hard limit) of routers lokinet will be connected to at any time.",
+        });
+
+    def.addOptionComments(
+        "router",
+        "public-ip",
+        {
+            "For complex network configurations where the detected IP is incorrect or non-public",
+            "this setting specifies the public IP at which this router is reachable. When",
+            "provided the public-port option must also be specified."
+        });
+
+    def.addOptionComments(
+        "router",
+        "public-port",
+        {
+            "When specifying public-ip=, this specifies the public UDP port at which this lokinet",
+            "router is reachable. Required when public-ip is used.",
         });
 
     // logging


### PR DESCRIPTION
0.7 supported both public-address and public-ip, but only the former was
being allowed in 0.8.

This makes `public-ip=...` work again, and makes it the canonical option
(because it makes a bit more sense than address when we also have the
public-port parameter), while making `public-address=` accepted with a
deprecation warning.

Also adds default descriptions for port and ip for the generated ini.